### PR TITLE
fix(split): notify Packagist after tag push to prevent missed updates

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -63,3 +63,13 @@ jobs:
             BRANCH="${GITHUB_REF#refs/heads/}"
             git push --force "$REPO" "${SHA}:refs/heads/${BRANCH}"
           fi
+
+      - name: Notify Packagist
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+        run: |
+          curl -sf -X POST https://packagist.org/api/update-package \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer markshust:${PACKAGIST_TOKEN}" \
+            -d "{\"repository\":\"https://github.com/${SPLIT_ORG}/marko-${{ matrix.package }}\"}"


### PR DESCRIPTION
## Summary

- Adds a "Notify Packagist" step to the split workflow that explicitly calls the Packagist update API after each tag push
- Acts as a reliable fallback when Packagist webhooks fail (which caused `marko/database` to miss the `0.1.0` tag)

## Root Cause

The Packagist webhook on `marko-php/marko-database` returned a **502** during the `0.1.0` release. GitHub does not auto-retry failed webhook deliveries, so Packagist never learned about the new tag.

## Requires

- `PACKAGIST_TOKEN` organization secret (already configured)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)