### PR TITLE
fix(database-mysql): Added missing QueryBuilderFactoryInterface implementation

### DIFF
--- a/packages/database-mysql/module.php
+++ b/packages/database-mysql/module.php
@@ -10,7 +10,9 @@ use Marko\Database\Introspection\IntrospectorInterface;
 use Marko\Database\MySql\Connection\MySqlConnection;
 use Marko\Database\MySql\Introspection\MySqlIntrospector;
 use Marko\Database\MySql\Query\MySqlQueryBuilder;
+use Marko\Database\MySql\Query\MySqlQueryBuilderFactory;
 use Marko\Database\MySql\Sql\MySqlGenerator;
+use Marko\Database\Query\QueryBuilderFactoryInterface;
 use Marko\Database\Query\QueryBuilderInterface;
 
 // Marko-specific configuration for this module.
@@ -29,5 +31,6 @@ return [
         },
         SqlGeneratorInterface::class => MySqlGenerator::class,
         QueryBuilderInterface::class => MySqlQueryBuilder::class,
+        QueryBuilderFactoryInterface::class => MySqlQueryBuilderFactory::class,
     ],
 ];

--- a/packages/database-mysql/src/Query/MySqlQueryBuilderFactory.php
+++ b/packages/database-mysql/src/Query/MySqlQueryBuilderFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Marko\Database\MySql\Query;
 
 use Marko\Database\Connection\ConnectionInterface;
-use Marko\Database\MySql\Query\MySqlQueryBuilder;
 use Marko\Database\Query\QueryBuilderFactoryInterface;
 use Marko\Database\Query\QueryBuilderInterface;
 

--- a/packages/database-mysql/src/Query/MySqlQueryBuilderFactory.php
+++ b/packages/database-mysql/src/Query/MySqlQueryBuilderFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\MySql\Query;
+
+use Marko\Database\Connection\ConnectionInterface;
+use Marko\Database\MySql\Query\MySqlQueryBuilder;
+use Marko\Database\Query\QueryBuilderFactoryInterface;
+use Marko\Database\Query\QueryBuilderInterface;
+
+class MySqlQueryBuilderFactory implements QueryBuilderFactoryInterface
+{
+    public function __construct(
+        private readonly ConnectionInterface $connection,
+    ) {}
+
+    public function create(): QueryBuilderInterface
+    {
+        return new MySqlQueryBuilder(
+            connection: $this->connection,
+        );
+    }
+}

--- a/packages/database-mysql/tests/Module/ModuleBindingsTest.php
+++ b/packages/database-mysql/tests/Module/ModuleBindingsTest.php
@@ -12,7 +12,9 @@ use Marko\Database\Diff\SqlGeneratorInterface;
 use Marko\Database\Exceptions\ConfigurationException;
 use Marko\Database\Introspection\IntrospectorInterface;
 use Marko\Database\MySql\Connection\MySqlConnection;
+use Marko\Database\MySql\Query\MySqlQueryBuilderFactory;
 use Marko\Database\MySql\Sql\MySqlGenerator;
+use Marko\Database\Query\QueryBuilderFactoryInterface;
 
 describe('MySQL module.php bindings', function (): void {
     it('binds ConnectionInterface to MySqlConnection class', function (): void {
@@ -40,6 +42,14 @@ describe('MySQL module.php bindings', function (): void {
         // IntrospectorInterface still uses a closure because it needs the database name
         expect($moduleConfig['bindings'])->toHaveKey(IntrospectorInterface::class)
             ->and($moduleConfig['bindings'][IntrospectorInterface::class])->toBeInstanceOf(Closure::class);
+    });
+
+    it('binds QueryBuilderFactoryInterface to MySqlQueryBuilderFactory class', function (): void {
+        $modulePath = dirname(__DIR__, 2);
+        $moduleConfig = require $modulePath . '/module.php';
+
+        expect($moduleConfig['bindings'])->toHaveKey(QueryBuilderFactoryInterface::class)
+            ->and($moduleConfig['bindings'][QueryBuilderFactoryInterface::class])->toBe(MySqlQueryBuilderFactory::class);
     });
 
     it('throws ConfigurationException when config file missing', function (): void {

--- a/packages/database-mysql/tests/Query/MySqlQueryBuilderFactoryTest.php
+++ b/packages/database-mysql/tests/Query/MySqlQueryBuilderFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\MySql\Tests\Query;
+
+use Marko\Database\Connection\ConnectionInterface;
+use Marko\Database\MySql\Query\MySqlQueryBuilder;
+use Marko\Database\MySql\Query\MySqlQueryBuilderFactory;
+use Marko\Database\Query\QueryBuilderFactoryInterface;
+use Marko\Database\Query\QueryBuilderInterface;
+use ReflectionClass;
+
+describe('MySqlQueryBuilderFactory', function (): void {
+    it('implements QueryBuilderFactoryInterface', function (): void {
+        $reflection = new ReflectionClass(MySqlQueryBuilderFactory::class);
+
+        expect($reflection->implementsInterface(QueryBuilderFactoryInterface::class))->toBeTrue();
+    });
+
+    it('accepts ConnectionInterface via constructor', function (): void {
+        $reflection = new ReflectionClass(MySqlQueryBuilderFactory::class);
+        $constructor = $reflection->getConstructor();
+        $params = $constructor->getParameters();
+
+        expect($params)->toHaveCount(1)
+            ->and($params[0]->getName())->toBe('connection')
+            ->and($params[0]->getType()->getName())->toBe(ConnectionInterface::class);
+    });
+
+    it('creates MySqlQueryBuilder instances', function (): void {
+        $connection = $this->createMock(ConnectionInterface::class);
+        $factory = new MySqlQueryBuilderFactory($connection);
+
+        $builder = $factory->create();
+
+        expect($builder)->toBeInstanceOf(QueryBuilderInterface::class)
+            ->and($builder)->toBeInstanceOf(MySqlQueryBuilder::class);
+    });
+
+    it('creates a new instance on each call', function (): void {
+        $connection = $this->createMock(ConnectionInterface::class);
+        $factory = new MySqlQueryBuilderFactory($connection);
+
+        $builder1 = $factory->create();
+        $builder2 = $factory->create();
+
+        expect($builder1)->not->toBe($builder2);
+    });
+});


### PR DESCRIPTION
## Summary
Adds the missing QueryBuilderFactoryInterface implementation to the marko/database-mysql package.

The Repository base class depends on QueryBuilderFactoryInterface, even though it says it's optional (vendor/marko/database/src/Repository/Repository.php:50). While this dependency is marked as optional in the constructor, it becomes required when calling query(). Without this implementation, repositories extending Repository and using custom queries throw NoDriverException::noDriverInstalled when the DI container attempts to bind the dependency.

This PR adds:
- MySqlQueryBuilderFactory class implementing QueryBuilderFactoryInterface
- Binding in module.php

Related commit where this was done for pgSQL, but not MySQL: [https://github.com/marko-php/marko/commit/2e530f02](https://github.com/marko-php/marko/commit/2e530f02)

### Additional changes (maintainer)
- Rebased onto current `develop`
- Added unit tests for `MySqlQueryBuilderFactory` (creation, instance independence, interface compliance)
- Added module binding test for the new `QueryBuilderFactoryInterface` entry in `ModuleBindingsTest.php`
- Removed unnecessary self-namespace import (`use Marko\Database\MySql\Query\MySqlQueryBuilder`) from the factory class

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor

## Checklist

- [X] Tests pass (`./vendor/bin/pest --parallel`)
- [X] Lint passes (`./vendor/bin/phpcs`)
- [X] Follows code standards