### PR TITLE
fix(cli): preload project autoloader in bin

### DIFF
--- a/.claude/release-process.md
+++ b/.claude/release-process.md
@@ -222,7 +222,7 @@ Runtime env vars for bin scripts (not stored as secrets — passed at the comman
 
 **Tests fail before release**
 - Fix the failing tests. They must pass before tagging.
-- Run locally: `/opt/homebrew/Cellar/php/8.5.1_2/bin/php vendor/bin/pest --parallel`
+- Run locally: `php vendor/bin/pest --parallel` (ensure PHP 8.5+ is on your PATH, or set `PHP_BIN` env var)
 
 **`composer update` fails locally**
 - Always run from the repo root (not inside a package directory)

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -32,10 +32,7 @@ if git rev-parse "$TAG" >/dev/null 2>&1; then
 fi
 
 # Find PHP 8.5+ binary
-PHP_BIN="/opt/homebrew/Cellar/php/8.5.1_2/bin/php"
-if [[ ! -x "$PHP_BIN" ]]; then
-    PHP_BIN="php"
-fi
+PHP_BIN="${PHP_BIN:-php}"
 
 PHP_VERSION=$("$PHP_BIN" -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;')
 if [[ "$PHP_VERSION" != "8.5" ]]; then

--- a/packages/cli/bin/marko
+++ b/packages/cli/bin/marko
@@ -21,11 +21,15 @@ use Marko\Cli\CliKernel;
 use Marko\Cli\ProjectFinder;
 
 try {
-    $kernel = new CliKernel(
-        projectFinder: new ProjectFinder(),
-    );
-    $exitCode = $kernel->run($argv);
-    exit($exitCode);
+    $projectFinder = new ProjectFinder();
+
+    if (($projectRoot = $projectFinder->find()) !== null) {
+        require_once "{$projectRoot}/vendor/autoload.php";
+    }
+
+    exit((new CliKernel(
+        projectFinder: $projectFinder,
+    ))->run($argv));
 } catch (Throwable $e) {
     fwrite(STDERR, "Error: " . $e->getMessage() . PHP_EOL);
     exit(1);

--- a/packages/cli/tests/BinMarkoTest.php
+++ b/packages/cli/tests/BinMarkoTest.php
@@ -24,21 +24,30 @@ it('instantiates CliKernel', function () use ($binMarkoPath) {
     $content = file_get_contents($binMarkoPath);
 
     expect($content)->toContain('use Marko\Cli\CliKernel')
-        ->and($content)->toContain('new CliKernel');
+        ->and($content)->toContain('new CliKernel')
+        ->and($content)->toContain('projectFinder: $projectFinder');
 });
 
 it('passes argv to kernel run method', function () use ($binMarkoPath) {
     $content = file_get_contents($binMarkoPath);
 
-    expect($content)->toContain('$kernel->run($argv)');
+    expect($content)->toContain('->run($argv)');
 });
 
 it('exits with code returned from kernel', function () use ($binMarkoPath) {
     $content = file_get_contents($binMarkoPath);
 
-    // Should capture exit code and use it
-    expect($content)->toContain('$exitCode')
-        ->and($content)->toContain('exit($exitCode)');
+    expect($content)->toContain('exit((new CliKernel(')
+        ->and($content)->toContain('))->run($argv));');
+});
+
+it('loads the project autoloader when a project root is found', function () use ($binMarkoPath) {
+    $content = file_get_contents($binMarkoPath);
+
+    expect($content)->toContain('use Marko\Cli\ProjectFinder')
+        ->and($content)->toContain('$projectFinder = new ProjectFinder()')
+        ->and($content)->toContain('$projectFinder->find()')
+        ->and($content)->toContain('require_once "{$projectRoot}/vendor/autoload.php"');
 });
 
 it('handles uncaught exceptions gracefully', function () use ($binMarkoPath) {

--- a/packages/dev-server/tests/Command/DevDownCommandTest.php
+++ b/packages/dev-server/tests/Command/DevDownCommandTest.php
@@ -304,10 +304,22 @@ it('kills entire process group when stopping a process', function (): void {
 
     usleep(100000); // let signals propagate
 
-    // Both parent and child should be dead — process group killed
-    expect($pidFile->isProcessGroupRunning($parentPid))->toBeFalse();
-
     proc_close($proc);
+
+    $groupRunning = true;
+    for ($i = 0; $i < 10; $i++) {
+        $groupRunning = $pidFile->isProcessGroupRunning($parentPid);
+        if ($groupRunning === false) {
+            break;
+        }
+
+        usleep(50000);
+    }
+
+    // Reap the parent process before asserting so zombie cleanup does not
+    // make the process group appear alive briefly on Linux.
+    expect($groupRunning)->toBeFalse();
+
     devDownRemoveDir($tmpDir);
 });
 

--- a/tests/IntegrationVerificationTest.php
+++ b/tests/IntegrationVerificationTest.php
@@ -43,14 +43,45 @@ it('validates the root composer.json passes composer validate', function () use 
 it(
     'removes composer.lock and vendor/ before running composer update to ensure clean resolution',
     function () use ($root): void {
-        $php = '/opt/homebrew/Cellar/php/8.5.1_2/bin/php';
+        $php = PHP_BINARY;
         $resultFile = tempnam(sys_get_temp_dir(), 'marko_result_');
+        $isolatedRoot = sys_get_temp_dir() . '/marko-clean-install-' . uniqid();
     
         $script = <<<'SCRIPT'
 <?php
-[$root, $resultFile] = [$argv[1], $argv[2]];
+[$root, $resultFile, $php, $isolatedRoot] = [$argv[1], $argv[2], $argv[3], $argv[4]];
 
 $results = [];
+
+function copyTree(string $source, string $destination): void
+{
+    if (is_link($source)) {
+        symlink(readlink($source), $destination);
+
+        return;
+    }
+
+    if (is_file($source)) {
+        copy($source, $destination);
+
+        return;
+    }
+
+    if (!is_dir($destination)) {
+        mkdir($destination, 0777, true);
+    }
+
+    foreach (scandir($source) as $entry) {
+        if ($entry === '.' || $entry === '..' || $entry === '.git' || $entry === 'vendor') {
+            continue;
+        }
+
+        copyTree($source . '/' . $entry, $destination . '/' . $entry);
+    }
+}
+
+copyTree($root, $isolatedRoot);
+$root = $isolatedRoot;
 
 // Step 1: Remove lock and vendor
 if (file_exists($root . '/composer.lock')) {
@@ -74,7 +105,6 @@ $results['lock_restored']          = file_exists($root . '/composer.lock');
 $results['composer_update_output'] = implode("\n", array_slice($updateOutput, -5));
 
 // Step 3: Run test suite (exclude destructive group to avoid recursion)
-$php = '/opt/homebrew/Cellar/php/8.5.1_2/bin/php';
 exec(
     'cd ' . escapeshellarg($root) . ' && ' . $php . ' vendor/bin/pest --parallel --exclude-group=integration-destructive 2>&1',
     $testOutput,
@@ -96,6 +126,8 @@ SCRIPT;
             $php . ' ' . escapeshellarg($scriptFile)
             . ' ' . escapeshellarg($root)
             . ' ' . escapeshellarg($resultFile)
+            . ' ' . escapeshellarg($php)
+            . ' ' . escapeshellarg($isolatedRoot)
             . ' 2>/dev/null',
         );
     
@@ -121,7 +153,7 @@ it('runs composer update from root successfully', function () use ($root): void 
 })->group('integration-destructive');
 
 it('runs the full test suite and all tests pass', function () use ($root): void {
-    $php = '/opt/homebrew/Cellar/php/8.5.1_2/bin/php';
+    $php = PHP_BINARY;
     $output = [];
     $exitCode = 0;
     exec(

--- a/tests/ReleaseScriptTest.php
+++ b/tests/ReleaseScriptTest.php
@@ -67,12 +67,10 @@ it('validates semver format (rejects invalid versions like 1.0 or v1.0.0)', func
         ->and($contents)->toContain('Expected X.Y.Z');
 });
 
-it('validates PHP version is 8.5+ (checks /opt/homebrew/Cellar/php/8.5.1_2/bin/php or system php)', function () use ($script): void {
-    // Script should check the Homebrew PHP path first, then fall back to system php
+it('validates PHP version is 8.5+ (uses PHP_BIN env var or defaults to system php)', function () use ($script): void {
     $contents = file_get_contents($script);
 
-    expect($contents)->toContain('/opt/homebrew/Cellar/php/8.5.1_2/bin/php')
-        ->and($contents)->toContain('PHP_BIN="php"')
+    expect($contents)->toContain('PHP_BIN="${PHP_BIN:-php}"')
         ->and($contents)->toContain('8.5');
 });
 


### PR DESCRIPTION
## Summary

This PR fixes a CLI bootstrap issue where running marko could fail with "`Error: Class "Marko\Core\Command\Output`" not found.

The root cause was that the bin script could construct and run CliKernel before the project's own autoloader was loaded. Since CliKernel depends on project classes from marko/core, those classes were not always available at startup. The fix updates packages/cli/bin/marko to resolve the project root first and preload the project vendor/autoload.php before booting the kernel.

The PR also updates `packages/cli/tests/BinMarkoTest.php` so the test suite reflects the new bootstrap flow, including coverage for ProjectFinder usage, conditional project autoloader loading, and the direct inline kernel execution path. The CLI package tests pass with this change.

### tests/IntegrationVerificationTest.php
The `tests/IntegrationVerificationTest.php` changes were made to make the integration test portable and truly isolated.

The test previously assumed a macOS-specific PHP path and also deleted the live project vendor/ directory while Pest was still running from it. That caused failures on non-macOS systems and runtime fatals like Class "Pest\\Panic" not found. The fix switches to PHP_BINARY so the current interpreter is used on any OS, and runs the destructive Composer workflow in a temporary copy of the repo so the active test process is never corrupted.

### packages/dev-server/tests/Command/DevDownCommandTest.php
The `packages/dev-server/tests/Command/DevDownCommandTest.php` changes make the dev:down process-group test resilient to normal Unix process cleanup timing. The original test asserted that the process group disappeared immediately after sending the stop signal, but on Linux the terminated parent can briefly remain as a zombie until it is reaped, causing the group to still appear alive.

The test was updated to proc_close() the spawned parent before the final assertion and to add a short retry loop when checking isProcessGroupRunning(). This keeps the intent of the test the same while avoiding a false failure caused by process reaping timing rather than shutdown behavior.

### bin/release.sh, tests/ReleaseScriptTest.php, .claude/release-process.md
Removed the hardcoded macOS Homebrew PHP path (`/opt/homebrew/Cellar/php/8.5.1_2/bin/php`) from the release script, its test, and release process docs. The release script now uses `${PHP_BIN:-php}`, allowing contributors to either set a `PHP_BIN` env var or rely on `php` being on their PATH. The PHP 8.5+ version check still runs and will abort with a helpful message if the wrong version is found.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor

## Related Issues

Closes #8

## Checklist

- [x] Tests pass (`./vendor/bin/pest --parallel`)
- [x] Lint passes (`./vendor/bin/phpcs`)
- [x] Follows code standards