### PR TITLE
fix(release): derive repo from git remote for gh release create

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -48,6 +48,9 @@ else
     echo "  ⚠ gh CLI not found — GitHub Release will need to be created manually"
 fi
 
+# Derive repo from git remote so gh doesn't require set-default
+GH_REPO=$(git remote get-url origin | sed -E 's#.*github\.com[:/](.+)\.git$#\1#; s#.*github\.com[:/](.+)$#\1#')
+
 echo "  ✓ PHP ${PHP_VERSION}"
 echo "  ✓ Branch: main (merged from develop)"
 echo "  ✓ Working directory clean"
@@ -82,6 +85,7 @@ if [[ "$GH_AVAILABLE" == "true" ]]; then
 
     if [[ -n "$PREV_TAG" ]]; then
         if gh release create "$TAG" \
+            --repo "$GH_REPO" \
             --generate-notes \
             --latest \
             --notes-start-tag "$PREV_TAG"; then
@@ -91,6 +95,7 @@ if [[ "$GH_AVAILABLE" == "true" ]]; then
         fi
     else
         if gh release create "$TAG" \
+            --repo "$GH_REPO" \
             --generate-notes \
             --latest; then
             echo "  ✓ GitHub Release created"

--- a/tests/ReleaseScriptTest.php
+++ b/tests/ReleaseScriptTest.php
@@ -74,6 +74,13 @@ it('validates PHP version is 8.5+ (uses PHP_BIN env var or defaults to system ph
         ->and($contents)->toContain('8.5');
 });
 
+it('derives repo from git remote for gh release create', function () use ($script): void {
+    $contents = file_get_contents($script);
+
+    expect($contents)->toContain('GH_REPO=$(git remote get-url origin')
+        ->and($contents)->toContain('--repo "$GH_REPO"');
+});
+
 it('creates bin/release.sh with version argument validation', function () use ($root, $script): void {
     expect(file_exists($script))->toBeTrue('bin/release.sh does not exist')
         ->and(is_executable($script))->toBeTrue('bin/release.sh is not executable');


### PR DESCRIPTION
## Summary
- The release script's `gh release create` failed during the 0.1.2 release with "No default remote repository has been set" because `gh repo set-default` hadn't been run
- Fix: derive the repo owner/name from the `origin` remote URL and pass `--repo` explicitly to all `gh release create` calls
- Added test coverage for the new `GH_REPO` derivation and `--repo` flag

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor

## Checklist

- [x] Tests pass (`./vendor/bin/pest --parallel`)
- [x] Follows code standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)