### PR TITLE
Add issue type to bug report and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Report a bug in the Marko framework
+type: bug
 labels: [bug]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: Feature Request
 description: Suggest a new feature or improvement for the Marko framework
+type: feature
 labels: [enhancement]
 body:
   - type: textarea


### PR DESCRIPTION
## Summary
- Add `type: bug` and `type: feature` to issue templates so the org-level issue type is auto-assigned alongside the existing label
- Uses lowercase to match GitHub's documented convention

## Test plan
- [ ] Create a test bug report issue — verify both "bug" label and "Bug" issue type are assigned
- [ ] Create a test feature request issue — verify both "enhancement" label and "Feature" issue type are assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)