### PR TITLE
fix: use DI container to instantiate layout components

### DIFF
--- a/packages/layout/src/LayoutProcessor.php
+++ b/packages/layout/src/LayoutProcessor.php
@@ -8,6 +8,8 @@ use Marko\Layout\Exceptions\AmbiguousSortOrderException;
 use Marko\Layout\Exceptions\CircularSlotException;
 use Marko\Layout\Exceptions\LayoutNotFoundException;
 use Marko\Layout\Exceptions\SlotNotFoundException;
+use Marko\Core\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface;
 use Marko\Routing\Http\Request;
 use Marko\Routing\Http\Response;
 use Marko\View\ViewInterface;
@@ -15,6 +17,7 @@ use Marko\View\ViewInterface;
 readonly class LayoutProcessor implements LayoutProcessorInterface
 {
     public function __construct(
+        private ContainerInterface $container,
         private LayoutResolver $layoutResolver,
         private HandleResolver $handleResolver,
         private ComponentCollectorInterface $componentCollector,
@@ -30,7 +33,7 @@ readonly class LayoutProcessor implements LayoutProcessorInterface
      * @throws SlotNotFoundException
      * @throws CircularSlotException
      * @throws LayoutNotFoundException
-     * @throws AmbiguousSortOrderException
+     * @throws AmbiguousSortOrderException|ContainerExceptionInterface
      */
     public function process(
         string $controllerClass,
@@ -87,7 +90,7 @@ readonly class LayoutProcessor implements LayoutProcessorInterface
      * Render all components in a slot and fill any sub-slots they define.
      *
      * @param array<string, mixed> $routeParameters
-     * @throws AmbiguousSortOrderException
+     * @throws AmbiguousSortOrderException|ContainerExceptionInterface
      */
     private function renderSlot(
         string $slotName,
@@ -99,7 +102,7 @@ readonly class LayoutProcessor implements LayoutProcessorInterface
         $html = '';
 
         foreach ($slotComponents as $definition) {
-            $componentInstance = new $definition->className();
+            $componentInstance = $this->container->get($definition->className);
             $data = $this->componentDataResolver->resolve($componentInstance, $routeParameters, $request);
             $componentHtml = $this->view->renderToString($definition->template, $data);
 

--- a/packages/layout/tests/Unit/Helpers.php
+++ b/packages/layout/tests/Unit/Helpers.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Layout\Tests\Unit;
+
+use Closure;
+use Marko\Core\Container\ContainerInterface;
+
+final class Helpers
+{
+    public static function stubContainer(): ContainerInterface
+    {
+        return new class () implements ContainerInterface
+        {
+            public function get(string $id): object
+            {
+                return new $id();
+            }
+
+            public function has(string $id): bool
+            {
+                return class_exists($id);
+            }
+
+            public function singleton(string $id): void {}
+
+            public function instance(string $id, object $instance): void {}
+
+            public function call(Closure $callable): mixed
+            {
+                return $callable();
+            }
+        };
+    }
+}

--- a/packages/layout/tests/Unit/LayoutProcessorNestedTest.php
+++ b/packages/layout/tests/Unit/LayoutProcessorNestedTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Marko\Layout\Attributes\Component;
+use Marko\Layout\Tests\Unit\Helpers;
 use Marko\Layout\Attributes\Layout;
 use Marko\Layout\ComponentCollection;
 use Marko\Layout\ComponentCollectorInterface;
@@ -129,6 +130,7 @@ function lpnStubView(callable $renderFn): ViewInterface
 function lpnBuildProcessor(ComponentCollection $collection, ViewInterface $view, string $controllerClass = LpnFixtureController::class): LayoutProcessor
 {
     return new LayoutProcessor(
+        container: Helpers::stubContainer(),
         layoutResolver: new LayoutResolver(),
         handleResolver: new HandleResolver(),
         componentCollector: lpnStubCollector($collection),

--- a/packages/layout/tests/Unit/LayoutProcessorTest.php
+++ b/packages/layout/tests/Unit/LayoutProcessorTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Marko\Layout\Attributes\Component;
+use Marko\Layout\Tests\Unit\Helpers;
 use Marko\Layout\Attributes\Layout;
 use Marko\Layout\ComponentCollection;
 use Marko\Layout\ComponentCollectorInterface;
@@ -143,6 +144,7 @@ function defaultCollection(): ComponentCollection
 function buildProcessor(ComponentCollection $collection, ViewInterface $view): LayoutProcessor
 {
     return new LayoutProcessor(
+        container: Helpers::stubContainer(),
         layoutResolver: new LayoutResolver(),
         handleResolver: new HandleResolver(),
         componentCollector: stubCollector($collection),


### PR DESCRIPTION
## Summary

- LayoutProcessor was using `new $className()` to create component instances, bypassing the DI container
- Any component with constructor dependencies (like a repository) would fail with "Too few arguments"
- Now injects `ContainerInterface` and uses `$container->get()` so dependencies are auto-resolved
- Extracted shared test stub container to `Helpers.php` to keep tests DRY

## Test plan

- [x] All 124 layout package tests passing
- [x] Existing component rendering behavior unchanged (zero-arg components still work)
- [x] Stub container extracted to shared helper, used by both processor test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)