### PR TITLE
docs: fix code-standards violations across tutorials and guides

### DIFF
--- a/docs/src/content/docs/concepts/dependency-injection.md
+++ b/docs/src/content/docs/concepts/dependency-injection.md
@@ -19,11 +19,11 @@ namespace App\Blog\Service;
 use Marko\Cache\Contracts\CacheInterface;
 use Marko\Database\Connection\ConnectionInterface;
 
-class PostService
+readonly class PostService
 {
     public function __construct(
-        private readonly ConnectionInterface $connection,
-        private readonly CacheInterface $cache,
+        private ConnectionInterface $connection,
+        private CacheInterface $cache,
     ) {}
 
     public function getPost(int $id): ?array
@@ -106,10 +106,10 @@ If you request a concrete class with no special bindings, the container just bui
 
 ```php
 // No binding needed — container sees the constructor and resolves dependencies
-class PostController
+readonly class PostController
 {
     public function __construct(
-        private readonly PostService $postService,
+        private PostService $postService,
     ) {}
 }
 ```

--- a/docs/src/content/docs/concepts/events.md
+++ b/docs/src/content/docs/concepts/events.md
@@ -19,10 +19,10 @@ namespace App\Blog\Services;
 use Marko\Core\Event\EventDispatcherInterface;
 use App\Blog\Events\Post\PostCreated;
 
-class PostService
+readonly class PostService
 {
     public function __construct(
-        private readonly EventDispatcherInterface $eventDispatcher,
+        private EventDispatcherInterface $eventDispatcher,
     ) {}
 
     public function createPost(string $title, string $body): Post
@@ -51,10 +51,10 @@ namespace App\Blog\Events\Post;
 use App\Blog\Entity\PostInterface;
 use Marko\Core\Event\Event;
 
-class PostCreated extends Event
+readonly class PostCreated extends Event
 {
     public function __construct(
-        private readonly PostInterface $post,
+        private PostInterface $post,
     ) {}
 
     public function getPost(): PostInterface

--- a/docs/src/content/docs/concepts/modularity.md
+++ b/docs/src/content/docs/concepts/modularity.md
@@ -88,10 +88,10 @@ Your application code depends on the **interface package**:
 ```php
 use Marko\Cache\Contracts\CacheInterface;
 
-class ProductService
+readonly class ProductService
 {
     public function __construct(
-        private readonly CacheInterface $cache,
+        private CacheInterface $cache,
     ) {}
 }
 ```

--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -35,10 +35,10 @@ declare(strict_types=1);
 
 use Marko\Config\ConfigRepositoryInterface;
 
-class DatabaseService
+readonly class DatabaseService
 {
     public function __construct(
-        private readonly ConfigRepositoryInterface $configRepository,
+        private ConfigRepositoryInterface $configRepository,
     ) {}
 
     public function getHost(): string

--- a/docs/src/content/docs/guides/authentication.md
+++ b/docs/src/content/docs/guides/authentication.md
@@ -58,10 +58,10 @@ use Marko\Routing\Attributes\Middleware;
 use Marko\Authentication\Middleware\AuthMiddleware;
 use Marko\Routing\Http\Response;
 
-class DashboardController
+readonly class DashboardController
 {
     public function __construct(
-        private readonly AuthManager $authManager,
+        private AuthManager $authManager,
     ) {}
 
     #[Get('/dashboard')]

--- a/docs/src/content/docs/guides/caching.md
+++ b/docs/src/content/docs/guides/caching.md
@@ -26,10 +26,10 @@ namespace App\Blog\Service;
 
 use Marko\Cache\Contracts\CacheInterface;
 
-class PostService
+readonly class PostService
 {
     public function __construct(
-        private readonly CacheInterface $cache,
+        private CacheInterface $cache,
     ) {}
 
     public function getPopularPosts(): array

--- a/docs/src/content/docs/guides/database.md
+++ b/docs/src/content/docs/guides/database.md
@@ -110,10 +110,10 @@ namespace App\Blog\Repository;
 use Marko\Database\Query\QueryBuilderInterface;
 use DateTimeImmutable;
 
-class PostRepository
+readonly class PostRepository
 {
     public function __construct(
-        private readonly QueryBuilderInterface $queryBuilder,
+        private QueryBuilderInterface $queryBuilder,
     ) {}
 
     public function findById(int $id): ?array
@@ -213,10 +213,10 @@ use Marko\Database\Query\QueryBuilderInterface;
 use Marko\Database\Seed\SeederInterface;
 use DateTimeImmutable;
 
-class PostSeeder implements SeederInterface
+readonly class PostSeeder implements SeederInterface
 {
     public function __construct(
-        private readonly QueryBuilderInterface $queryBuilder,
+        private QueryBuilderInterface $queryBuilder,
     ) {}
 
     public function run(): void

--- a/docs/src/content/docs/guides/database.md
+++ b/docs/src/content/docs/guides/database.md
@@ -177,6 +177,8 @@ class PostRepository extends Repository
 }
 ```
 
+`query()` returns a `RepositoryQueryBuilder` pre-scoped to the repository's table. It exposes the full query builder (`where`, `whereIn`, `whereNotNull`, joins, `orderBy`, `limit`, etc.) and terminates with `getEntities()` for an `EntityCollection` or `firstEntity()` for a single hydrated entity. Fall back to `get()` / `first()` only when you want raw arrays (reports, aggregates).
+
 Use `with()` to eager-load relationships and avoid N+1 queries. Nested relationships use dot notation:
 
 ```php

--- a/docs/src/content/docs/guides/file-storage.md
+++ b/docs/src/content/docs/guides/file-storage.md
@@ -58,10 +58,10 @@ namespace App\Blog\Service;
 
 use Marko\Filesystem\Contracts\FilesystemInterface;
 
-class DocumentService
+readonly class DocumentService
 {
     public function __construct(
-        private readonly FilesystemInterface $filesystem,
+        private FilesystemInterface $filesystem,
     ) {}
 
     public function save(string $name, string $contents): void
@@ -226,10 +226,10 @@ namespace App\Blog\Service;
 
 use Marko\Filesystem\Manager\FilesystemManager;
 
-class MediaService
+readonly class MediaService
 {
     public function __construct(
-        private readonly FilesystemManager $filesystemManager,
+        private FilesystemManager $filesystemManager,
     ) {}
 
     public function upload(string $path, string $contents): void

--- a/docs/src/content/docs/guides/mail.md
+++ b/docs/src/content/docs/guides/mail.md
@@ -23,10 +23,10 @@ namespace App\Blog\Service;
 use Marko\Mail\Contracts\MailerInterface;
 use Marko\Mail\Message;
 
-class NotificationService
+readonly class NotificationService
 {
     public function __construct(
-        private readonly MailerInterface $mailer,
+        private MailerInterface $mailer,
     ) {}
 
     public function notifyAuthor(string $email, string $postTitle): void

--- a/docs/src/content/docs/guides/queues.md
+++ b/docs/src/content/docs/guides/queues.md
@@ -26,11 +26,11 @@ namespace App\Blog\Job;
 
 use Marko\Queue\Job;
 
-class SendWelcomeEmail extends Job
+readonly class SendWelcomeEmail extends Job
 {
     public function __construct(
-        private readonly string $email,
-        private readonly string $name,
+        private string $email,
+        private string $name,
     ) {}
 
     public function handle(): void
@@ -50,10 +50,10 @@ declare(strict_types=1);
 use Marko\Queue\QueueInterface;
 use App\Blog\Job\SendWelcomeEmail;
 
-class RegistrationService
+readonly class RegistrationService
 {
     public function __construct(
-        private readonly QueueInterface $queue,
+        private QueueInterface $queue,
     ) {}
 
     public function register(string $email, string $name): void

--- a/docs/src/content/docs/guides/scheduling.md
+++ b/docs/src/content/docs/guides/scheduling.md
@@ -79,10 +79,10 @@ You can programmatically check which tasks are due at a given time using `dueTas
 use Marko\Scheduler\Schedule;
 use DateTimeImmutable;
 
-class MaintenanceService
+readonly class MaintenanceService
 {
     public function __construct(
-        private readonly Schedule $schedule,
+        private Schedule $schedule,
     ) {}
 
     public function pendingTasks(): array

--- a/docs/src/content/docs/guides/validation.md
+++ b/docs/src/content/docs/guides/validation.md
@@ -21,10 +21,10 @@ declare(strict_types=1);
 use Marko\Validation\Contracts\ValidatorInterface;
 use Marko\Validation\Validation\ValidationErrors;
 
-class PostController
+readonly class PostController
 {
     public function __construct(
-        private readonly ValidatorInterface $validator,
+        private ValidatorInterface $validator,
     ) {}
 
     public function store(array $data): void

--- a/docs/src/content/docs/packages/admin-auth.md
+++ b/docs/src/content/docs/packages/admin-auth.md
@@ -64,10 +64,10 @@ Modules register their permissions via `PermissionRegistryInterface`:
 ```php title="CatalogPermissions.php"
 use Marko\AdminAuth\Contracts\PermissionRegistryInterface;
 
-class CatalogPermissions
+readonly class CatalogPermissions
 {
     public function __construct(
-        private readonly PermissionRegistryInterface $permissionRegistry,
+        private PermissionRegistryInterface $permissionRegistry,
     ) {}
 
     public function register(): void
@@ -131,10 +131,10 @@ class OrderService
 use Marko\AdminAuth\Entity\AdminUserInterface;
 use Marko\Authentication\Contracts\GuardInterface;
 
-class DashboardController
+readonly class DashboardController
 {
     public function __construct(
-        private readonly GuardInterface $guard,
+        private GuardInterface $guard,
     ) {}
 
     public function index(): Response

--- a/docs/src/content/docs/packages/admin-panel.md
+++ b/docs/src/content/docs/packages/admin-panel.md
@@ -34,10 +34,10 @@ The panel registers these routes automatically:
 use Marko\AdminPanel\Menu\AdminMenuBuilderInterface;
 use Marko\AdminAuth\Entity\AdminUserInterface;
 
-class LayoutHelper
+readonly class LayoutHelper
 {
     public function __construct(
-        private readonly AdminMenuBuilderInterface $adminMenuBuilder,
+        private AdminMenuBuilderInterface $adminMenuBuilder,
     ) {}
 
     public function getSidebar(

--- a/docs/src/content/docs/packages/admin.md
+++ b/docs/src/content/docs/packages/admin.md
@@ -104,10 +104,10 @@ Inject `AdminSectionRegistryInterface` to access all registered sections:
 use Marko\Admin\Contracts\AdminSectionInterface;
 use Marko\Admin\Contracts\AdminSectionRegistryInterface;
 
-class NavigationBuilder
+readonly class NavigationBuilder
 {
     public function __construct(
-        private readonly AdminSectionRegistryInterface $adminSectionRegistry,
+        private AdminSectionRegistryInterface $adminSectionRegistry,
     ) {}
 
     public function buildMenu(): array
@@ -170,10 +170,10 @@ return [
 ```php
 use Marko\Admin\Config\AdminConfigInterface;
 
-class AdminRouter
+readonly class AdminRouter
 {
     public function __construct(
-        private readonly AdminConfigInterface $adminConfig,
+        private AdminConfigInterface $adminConfig,
     ) {}
 
     public function getBaseUrl(): string

--- a/docs/src/content/docs/packages/authorization.md
+++ b/docs/src/content/docs/packages/authorization.md
@@ -21,10 +21,10 @@ Register abilities as closures on the Gate:
 use Marko\Authorization\AuthorizableInterface;
 use Marko\Authorization\Contracts\GateInterface;
 
-class AuthorizationBootstrap
+readonly class AuthorizationBootstrap
 {
     public function __construct(
-        private readonly GateInterface $gate,
+        private GateInterface $gate,
     ) {}
 
     public function boot(): void
@@ -42,10 +42,10 @@ class AuthorizationBootstrap
 ```php
 use Marko\Authorization\Contracts\GateInterface;
 
-class SettingsController
+readonly class SettingsController
 {
     public function __construct(
-        private readonly GateInterface $gate,
+        private GateInterface $gate,
     ) {}
 
     public function update(): void

--- a/docs/src/content/docs/packages/database.md
+++ b/docs/src/content/docs/packages/database.md
@@ -334,10 +334,10 @@ namespace App\Blog\Query;
 use Marko\Database\Query\QueryBuilderInterface;
 use Marko\Database\Query\QuerySpecification;
 
-class RecentSpec implements QuerySpecification
+readonly class RecentSpec implements QuerySpecification
 {
     public function __construct(
-        private readonly int $limit = 10,
+        private int $limit = 10,
     ) {}
 
     public function apply(QueryBuilderInterface $queryBuilder): void

--- a/docs/src/content/docs/packages/database.md
+++ b/docs/src/content/docs/packages/database.md
@@ -134,6 +134,63 @@ class PostRepository extends Repository
 - **Flexibility**: Switch databases without changing entity code
 - **Clarity**: No hidden magic, explicit saves via repository
 
+### Custom Queries with `query()`
+
+The base `Repository` provides three ways to query, each suited to a different use case:
+
+| Method                              | When to use                                                                 |
+|-------------------------------------|-----------------------------------------------------------------------------|
+| `findBy(array $criteria)`           | Simple equality matches on columns                                          |
+| `matching(QuerySpecification ...)`  | Reusable, composable query fragments shared across repositories             |
+| `query()`                           | One-off custom queries --- joins, raw conditions, ordering, limits, offsets |
+
+`query()` returns a `RepositoryQueryBuilder` pre-configured with the repository's table name. It implements the full `QueryBuilderInterface` and adds entity hydration.
+
+```php
+public function findPublished(int $limit = 10): EntityCollection
+{
+    return $this->query()
+        ->where('status', '=', 'published')
+        ->whereNotNull('published_at')
+        ->orderBy('published_at', 'desc')
+        ->limit($limit)
+        ->getEntities();
+}
+```
+
+#### Returning entities vs arrays
+
+| Method            | Returns                                 |
+|-------------------|-----------------------------------------|
+| `getEntities()`   | `EntityCollection<TEntity>` --- hydrated, supports eager loading |
+| `firstEntity()`   | `?TEntity` --- hydrated, or `null` if no match |
+| `get()`           | `array<array<string, mixed>>` --- raw rows |
+| `first()`         | `?array<string, mixed>` --- raw row, or `null` |
+| `count()`         | `int`                                   |
+
+Use `getEntities()` / `firstEntity()` for typed domain objects. Drop to `get()` / `first()` only for reports or aggregates where building entities adds no value.
+
+#### Available filters
+
+`where`, `whereIn`, `whereNull`, `whereNotNull`, `orWhere`, `join`, `leftJoin`, `rightJoin`, `orderBy`, `limit`, `offset`, `select`. All return `static` for chaining. The escape hatch is `raw(string $sql, array $bindings = [])` for queries the builder can't express.
+
+#### Eager loading
+
+Chain `->with('comments', 'author')` before `getEntities()` to load relationships in a single round trip:
+
+```php
+return $this->query()
+    ->where('status', '=', 'published')
+    ->with('author', 'comments.author')
+    ->getEntities();
+```
+
+Dot-notation loads nested relationships.
+
+#### Query builder requirement
+
+`query()` depends on `QueryBuilderFactoryInterface` being injected into the repository. When a driver package (`marko/database-mysql`, `marko/database-pgsql`) is installed, the container wires this automatically. If you construct a repository manually without providing a factory, `query()` throws `RepositoryException::queryBuilderNotConfigured`.
+
 ## Relationships
 
 Define relationships between entities using property attributes. Marko loads related entities explicitly — there is no lazy loading.

--- a/docs/src/content/docs/packages/encryption.md
+++ b/docs/src/content/docs/packages/encryption.md
@@ -24,14 +24,18 @@ Note: You typically install a driver package (like `marko/encryption-openssl`) w
 Inject `EncryptorInterface` wherever you need encryption:
 
 ```php
+use JsonException;
 use Marko\Encryption\Contracts\EncryptorInterface;
 
-class TokenService
+readonly class TokenService
 {
     public function __construct(
         private EncryptorInterface $encryptor,
     ) {}
 
+    /**
+     * @throws JsonException
+     */
     public function issueToken(
         array $payload,
     ): string {
@@ -40,6 +44,9 @@ class TokenService
         return $this->encryptor->encrypt($json);
     }
 
+    /**
+     * @throws JsonException
+     */
     public function verifyToken(
         string $token,
     ): array {

--- a/docs/src/content/docs/packages/health.md
+++ b/docs/src/content/docs/packages/health.md
@@ -73,10 +73,10 @@ use Marko\Health\Contracts\HealthCheckInterface;
 use Marko\Health\Value\HealthResult;
 use Marko\Health\Value\HealthStatus;
 
-class RedisHealthCheck implements HealthCheckInterface
+readonly class RedisHealthCheck implements HealthCheckInterface
 {
     public function __construct(
-        private readonly RedisClient $redisClient,
+        private RedisClient $redisClient,
     ) {}
 
     public function getName(): string

--- a/docs/src/content/docs/packages/queue-rabbitmq.md
+++ b/docs/src/content/docs/packages/queue-rabbitmq.md
@@ -93,10 +93,10 @@ Use `QueueInterface` as usual --- the RabbitMQ driver handles persistent message
 ```php
 use Marko\Queue\QueueInterface;
 
-class OrderProcessor
+readonly class OrderProcessor
 {
     public function __construct(
-        private readonly QueueInterface $queue,
+        private QueueInterface $queue,
     ) {}
 
     public function dispatch(): void

--- a/docs/src/content/docs/packages/queue.md
+++ b/docs/src/content/docs/packages/queue.md
@@ -28,10 +28,10 @@ Extend the `Job` base class and implement `handle()`:
 ```php
 use Marko\Queue\Job;
 
-class SendWelcomeEmail extends Job
+readonly class SendWelcomeEmail extends Job
 {
     public function __construct(
-        private readonly string $email,
+        private string $email,
     ) {}
 
     public function handle(): void
@@ -66,10 +66,10 @@ Inject `QueueInterface` and push jobs:
 ```php
 use Marko\Queue\QueueInterface;
 
-class RegistrationService
+readonly class RegistrationService
 {
     public function __construct(
-        private readonly QueueInterface $queue,
+        private QueueInterface $queue,
     ) {}
 
     public function register(): void

--- a/docs/src/content/docs/packages/security.md
+++ b/docs/src/content/docs/packages/security.md
@@ -69,10 +69,10 @@ Include the token in forms:
 ```php
 use Marko\Security\Contracts\CsrfTokenManagerInterface;
 
-class ContactController
+readonly class ContactController
 {
     public function __construct(
-        private readonly CsrfTokenManagerInterface $csrfTokenManager,
+        private CsrfTokenManagerInterface $csrfTokenManager,
     ) {}
 
     public function form(): Response

--- a/docs/src/content/docs/packages/translation-file.md
+++ b/docs/src/content/docs/packages/translation-file.md
@@ -73,10 +73,10 @@ You do not need to interact with the loader directly. Place your translation fil
 ```php
 use Marko\Translation\Contracts\TranslatorInterface;
 
-class PostController
+readonly class PostController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
+        private TranslatorInterface $translator,
     ) {}
 
     public function index(): string
@@ -96,10 +96,10 @@ class PostController
 use Marko\Translation\File\Loader\FileTranslationLoader;
 use Marko\Translation\Contracts\TranslationLoaderInterface;
 
-class FileTranslationLoader implements TranslationLoaderInterface
+readonly class FileTranslationLoader implements TranslationLoaderInterface
 {
     public function __construct(
-        private readonly string $basePath,
+        private string $basePath,
     ) {}
 
     public function load(string $locale, string $group, ?string $namespace = null): array;

--- a/docs/src/content/docs/packages/translation.md
+++ b/docs/src/content/docs/packages/translation.md
@@ -24,10 +24,10 @@ Inject `TranslatorInterface` and call `get()` with a dot-notation key:
 ```php
 use Marko\Translation\Contracts\TranslatorInterface;
 
-class WelcomeController
+readonly class WelcomeController
 {
     public function __construct(
-        private readonly TranslatorInterface $translator,
+        private TranslatorInterface $translator,
     ) {}
 
     public function greet(): string

--- a/docs/src/content/docs/packages/validation.md
+++ b/docs/src/content/docs/packages/validation.md
@@ -20,10 +20,10 @@ Inject `ValidatorInterface` and pass data with rules:
 ```php
 use Marko\Validation\Contracts\ValidatorInterface;
 
-class UserController
+readonly class UserController
 {
     public function __construct(
-        private readonly ValidatorInterface $validator,
+        private ValidatorInterface $validator,
     ) {}
 
     public function store(

--- a/docs/src/content/docs/packages/view.md
+++ b/docs/src/content/docs/packages/view.md
@@ -24,10 +24,10 @@ use Marko\Routing\Attributes\Get;
 use Marko\Routing\Http\Response;
 use Marko\View\ViewInterface;
 
-class PostController
+readonly class PostController
 {
     public function __construct(
-        private readonly ViewInterface $view,
+        private ViewInterface $view,
     ) {}
 
     #[Get('/posts/{id}')]
@@ -79,10 +79,10 @@ mymodule/
 ```php
 use Marko\View\TemplateResolverInterface;
 
-class TemplateFinder
+readonly class TemplateFinder
 {
     public function __construct(
-        private readonly TemplateResolverInterface $templateResolver,
+        private TemplateResolverInterface $templateResolver,
     ) {}
 
     public function locate(

--- a/docs/src/content/docs/tutorials/build-a-chat.md
+++ b/docs/src/content/docs/tutorials/build-a-chat.md
@@ -101,39 +101,47 @@ declare(strict_types=1);
 
 namespace App\Chat\Repository;
 
-use Marko\Database\Query\QueryBuilderInterface;
+use App\Chat\Entity\Message;
+use Marko\Database\Repository\Repository;
 
-class MessageRepository
+class MessageRepository extends Repository
 {
-    public function __construct(
-        private readonly QueryBuilderInterface $queryBuilder,
-    ) {}
+    protected const string ENTITY_CLASS = Message::class;
 
-    public function create(string $room, string $username, string $body): int
+    public function create(string $room, string $username, string $body): Message
     {
-        return $this->queryBuilder->table('messages')->insert([
-            'room' => $room,
-            'username' => $username,
-            'body' => $body,
-        ]);
+        $message = new Message();
+        $message->room = $room;
+        $message->username = $username;
+        $message->body = $body;
+
+        $this->save($message);
+
+        return $message;
     }
 
+    /**
+     * @return array<Message>
+     */
     public function forRoom(string $room, int $limit = 50): array
     {
-        return $this->queryBuilder->table('messages')
+        return $this->query()
             ->where('room', '=', $room)
             ->orderBy('id', 'DESC')
             ->limit($limit)
-            ->get();
+            ->getEntities();
     }
 
+    /**
+     * @return array<Message>
+     */
     public function sinceId(string $room, int $lastId): array
     {
-        return $this->queryBuilder->table('messages')
+        return $this->query()
             ->where('room', '=', $room)
             ->where('id', '>', $lastId)
             ->orderBy('id', 'ASC')
-            ->get();
+            ->getEntities();
     }
 }
 ```
@@ -165,13 +173,13 @@ use Marko\Routing\Http\Response;
 use Marko\View\ViewInterface;
 
 #[Middleware(AuthMiddleware::class)]
-class ChatController
+readonly class ChatController
 {
     public function __construct(
-        private readonly MessageRepository $messageRepository,
-        private readonly PublisherInterface $publisher,
-        private readonly AuthManager $authManager,
-        private readonly ViewInterface $view,
+        private MessageRepository $messageRepository,
+        private PublisherInterface $publisher,
+        private AuthManager $authManager,
+        private ViewInterface $view,
     ) {}
 
     #[Get('/chat/{room}')]
@@ -194,13 +202,13 @@ class ChatController
         $data = json_decode($request->body(), true, flags: JSON_THROW_ON_ERROR);
         $username = (string) $this->authManager->id();
 
-        $id = $this->messageRepository->create($room, $username, $data['body']);
+        $message = $this->messageRepository->create($room, $username, $data['body']);
 
         $payload = json_encode([
-            'id' => $id,
+            'id' => $message->id,
             'room' => $room,
             'username' => $username,
-            'body' => $data['body'],
+            'body' => $message->body,
         ], JSON_THROW_ON_ERROR);
 
         $this->publisher->publish(
@@ -208,7 +216,7 @@ class ChatController
             message: new Message(channel: "room.$room", payload: $payload),
         );
 
-        return Response::json(data: ['id' => $id], statusCode: 201);
+        return Response::json(data: ['id' => $message->id], statusCode: 201);
     }
 }
 ```
@@ -237,11 +245,11 @@ use Marko\Sse\SseStream;
 use Marko\Sse\StreamingResponse;
 
 #[Middleware(AuthMiddleware::class)]
-class StreamController
+readonly class StreamController
 {
     public function __construct(
-        private readonly SubscriberInterface $subscriber,
-        private readonly MessageRepository $messageRepository,
+        private SubscriberInterface $subscriber,
+        private MessageRepository $messageRepository,
     ) {}
 
     #[Get('/chat/{room}/stream')]
@@ -271,7 +279,7 @@ class StreamController
             $event = new SseEvent(
                 data: $message,
                 event: "room.$room",
-                id: $message['id'],
+                id: (string) $message->id,
             );
             echo $event->format();
             flush();
@@ -309,7 +317,7 @@ Marko uses Latte templates stored in `resources/views/` within each module. The 
     <div id="messages">
         {foreach $messages as $message}
             <div class="message">
-                <span class="username">{$message['username']}:</span> {$message['body']}
+                <span class="username">{$message->username}:</span> {$message->body}
             </div>
         {/foreach}
     </div>
@@ -397,11 +405,11 @@ use Marko\Sse\SseStream;
 use Marko\Sse\StreamingResponse;
 
 #[Middleware(AuthMiddleware::class)]
-class StreamController
+readonly class StreamController
 {
     public function __construct(
-        private readonly SubscriberInterface $subscriber,
-        private readonly MessageRepository $messageRepository,
+        private SubscriberInterface $subscriber,
+        private MessageRepository $messageRepository,
     ) {}
 
     #[Get('/chat/{room}/stream')]
@@ -423,6 +431,9 @@ class StreamController
         return new StreamingResponse(stream: $stream);
     }
 
+    /**
+     * @throws JsonException
+     */
     private function replayMissed(string $room, int $lastId): void
     {
         $missed = $this->messageRepository->sinceId($room, $lastId);
@@ -431,7 +442,7 @@ class StreamController
             $event = new SseEvent(
                 data: json_encode($message, JSON_THROW_ON_ERROR),
                 event: "room.$room",
-                id: $message['id'],
+                id: (string) $message->id,
             );
             echo $event->format();
             flush();

--- a/docs/src/content/docs/tutorials/build-a-rest-api.md
+++ b/docs/src/content/docs/tutorials/build-a-rest-api.md
@@ -10,7 +10,7 @@ Build a RESTful API for managing articles, complete with authentication, validat
 - A full CRUD JSON API for articles
 - Token-based authentication for protected endpoints
 - Request validation with meaningful error responses
-- Proper HTTP status codes (200, 201, 204, 404)
+- Proper HTTP status codes (200, 201, 204, 400, 403, 404, 422)
 
 ## Prerequisites
 
@@ -30,7 +30,7 @@ composer require marko/core marko/routing marko/config marko/env \
 
 ## Step 2: Define the Entity
 
-Marko uses attribute-driven entities --- define your schema with `#[Table]` and `#[Column]` attributes, then `marko db:migrate` auto-generates migrations.
+Marko reads `#[Table]`, `#[Column]`, and `#[Index]` to auto-generate migrations. `DateTimeImmutable` properties are hydrated from and persisted to the database automatically.
 
 ```php title="app/api/src/Entity/Article.php"
 <?php
@@ -39,6 +39,7 @@ declare(strict_types=1);
 
 namespace App\Api\Entity;
 
+use DateTimeImmutable;
 use Marko\Database\Attributes\Column;
 use Marko\Database\Attributes\Index;
 use Marko\Database\Attributes\Table;
@@ -52,19 +53,19 @@ class Article extends Entity
     public ?int $id = null;
 
     #[Column(length: 200)]
-    public string $title;
+    public string $title = '';
 
     #[Column(type: 'TEXT')]
-    public string $body;
+    public string $body = '';
 
     #[Column]
-    public string $authorEmail;
+    public string $authorEmail = '';
 
     #[Column]
-    public ?string $createdAt = null;
+    public ?DateTimeImmutable $createdAt = null;
 
     #[Column]
-    public ?string $updatedAt = null;
+    public ?DateTimeImmutable $updatedAt = null;
 }
 ```
 
@@ -76,6 +77,8 @@ marko db:migrate
 
 ## Step 3: Create the Repository
 
+Extend the base `Repository` class. It provides `find()`, `findAll()`, `findBy()`, `findOneBy()`, `save()`, and `delete()` with automatic entity hydration, dirty-field tracking on updates, and lifecycle events.
+
 ```php title="app/api/src/Repository/ArticleRepository.php"
 <?php
 
@@ -83,50 +86,43 @@ declare(strict_types=1);
 
 namespace App\Api\Repository;
 
-use Marko\Database\Query\QueryBuilderInterface;
+use App\Api\Entity\Article;
+use Marko\Database\Repository\Repository;
 
-class ArticleRepository
+class ArticleRepository extends Repository
 {
-    public function __construct(
-        private readonly QueryBuilderInterface $queryBuilder,
-    ) {}
+    protected const string ENTITY_CLASS = Article::class;
 
-    public function all(): array
+    /**
+     * @return array<Article>
+     */
+    public function findLatest(): array
     {
-        return $this->queryBuilder->table('articles')
+        return $this->query()
             ->orderBy('created_at', 'DESC')
-            ->get();
-    }
-
-    public function find(int $id): ?array
-    {
-        return $this->queryBuilder->table('articles')
-            ->where('id', '=', $id)
-            ->first();
-    }
-
-    public function create(array $data): int
-    {
-        return $this->queryBuilder->table('articles')->insert($data);
-    }
-
-    public function update(int $id, array $data): void
-    {
-        $this->queryBuilder->table('articles')
-            ->where('id', '=', $id)
-            ->update($data);
-    }
-
-    public function delete(int $id): void
-    {
-        $this->queryBuilder->table('articles')
-            ->where('id', '=', $id)
-            ->delete();
+            ->getEntities();
     }
 }
 ```
 
-## Step 4: Build the Controller
+## Step 4: Register the Module
+
+```php title="app/api/composer.json"
+{
+    "name": "app/api",
+    "autoload": {
+        "psr-4": {
+            "App\\Api\\": "src/"
+        }
+    }
+}
+```
+
+No `module.php` is needed --- the controller and repository are autowired from their constructor signatures.
+
+## Step 5: Build the Controller
+
+The controller is a stateless service, so it's a `readonly class`. Every mutation validates input, enforces ownership, and returns proper HTTP status codes.
 
 ```php title="app/api/src/Controller/ArticleController.php"
 <?php
@@ -135,7 +131,10 @@ declare(strict_types=1);
 
 namespace App\Api\Controller;
 
+use App\Api\Entity\Article;
 use App\Api\Repository\ArticleRepository;
+use DateTimeImmutable;
+use JsonException;
 use Marko\Authentication\AuthManager;
 use Marko\Authentication\Middleware\AuthMiddleware;
 use Marko\Routing\Attributes\Delete;
@@ -146,22 +145,27 @@ use Marko\Routing\Attributes\Put;
 use Marko\Routing\Http\Request;
 use Marko\Routing\Http\Response;
 use Marko\Validation\Contracts\ValidatorInterface;
-use DateTimeImmutable;
 
-class ArticleController
+readonly class ArticleController
 {
     public function __construct(
-        private readonly ArticleRepository $articleRepository,
-        private readonly ValidatorInterface $validator,
-        private readonly AuthManager $authManager,
+        private ArticleRepository $articleRepository,
+        private ValidatorInterface $validator,
+        private AuthManager $authManager,
     ) {}
 
+    /**
+     * @throws JsonException
+     */
     #[Get('/api/articles')]
     public function index(): Response
     {
-        return Response::json(data: $this->articleRepository->all());
+        return Response::json(data: $this->articleRepository->findLatest());
     }
 
+    /**
+     * @throws JsonException
+     */
     #[Get('/api/articles/{id}')]
     public function show(int $id): Response
     {
@@ -177,11 +181,21 @@ class ArticleController
         return Response::json(data: $article);
     }
 
+    /**
+     * @throws JsonException
+     */
     #[Post('/api/articles')]
     #[Middleware(AuthMiddleware::class)]
     public function store(Request $request): Response
     {
-        $data = json_decode($request->body(), true, flags: JSON_THROW_ON_ERROR);
+        $data = $this->decodeBody($request);
+
+        if ($data === null) {
+            return Response::json(
+                data: ['error' => 'Invalid JSON body'],
+                statusCode: 400,
+            );
+        }
 
         $errors = $this->validator->validate($data, [
             'title' => ['required', 'string', 'min:3', 'max:200'],
@@ -195,27 +209,50 @@ class ArticleController
             );
         }
 
-        $user = $this->authManager->user();
+        $now = new DateTimeImmutable();
+        $article = new Article();
+        $article->title = $data['title'];
+        $article->body = $data['body'];
+        $article->authorEmail = (string) $this->authManager->user()?->getAuthIdentifier();
+        $article->createdAt = $now;
+        $article->updatedAt = $now;
 
-        $id = $this->articleRepository->create([
-            'title' => $data['title'],
-            'body' => $data['body'],
-            'author_email' => $user?->getAuthIdentifier(),
-            'created_at' => new DateTimeImmutable(),
-            'updated_at' => new DateTimeImmutable(),
-        ]);
+        $this->articleRepository->save($article);
 
-        return Response::json(
-            data: $this->articleRepository->find($id),
-            statusCode: 201,
-        );
+        return Response::json(data: $article, statusCode: 201);
     }
 
+    /**
+     * @throws JsonException
+     */
     #[Put('/api/articles/{id}')]
     #[Middleware(AuthMiddleware::class)]
     public function update(int $id, Request $request): Response
     {
-        $data = json_decode($request->body(), true, flags: JSON_THROW_ON_ERROR);
+        $article = $this->articleRepository->find($id);
+
+        if ($article === null) {
+            return Response::json(
+                data: ['error' => 'Article not found'],
+                statusCode: 404,
+            );
+        }
+
+        if ($article->authorEmail !== $this->authManager->user()?->getAuthIdentifier()) {
+            return Response::json(
+                data: ['error' => 'Forbidden'],
+                statusCode: 403,
+            );
+        }
+
+        $data = $this->decodeBody($request);
+
+        if ($data === null) {
+            return Response::json(
+                data: ['error' => 'Invalid JSON body'],
+                statusCode: 400,
+            );
+        }
 
         $errors = $this->validator->validate($data, [
             'title' => ['string', 'min:3', 'max:200'],
@@ -229,32 +266,72 @@ class ArticleController
             );
         }
 
-        $this->articleRepository->update($id, [
-            ...$data,
-            'updated_at' => new DateTimeImmutable(),
-        ]);
+        if (isset($data['title'])) {
+            $article->title = $data['title'];
+        }
 
-        return Response::json(data: $this->articleRepository->find($id));
+        if (isset($data['body'])) {
+            $article->body = $data['body'];
+        }
+
+        $article->updatedAt = new DateTimeImmutable();
+
+        $this->articleRepository->save($article);
+
+        return Response::json(data: $article);
     }
 
+    /**
+     * @throws JsonException
+     */
     #[Delete('/api/articles/{id}')]
     #[Middleware(AuthMiddleware::class)]
     public function destroy(int $id): Response
     {
-        $this->articleRepository->delete($id);
+        $article = $this->articleRepository->find($id);
+
+        if ($article === null) {
+            return Response::json(
+                data: ['error' => 'Article not found'],
+                statusCode: 404,
+            );
+        }
+
+        if ($article->authorEmail !== $this->authManager->user()?->getAuthIdentifier()) {
+            return Response::json(
+                data: ['error' => 'Forbidden'],
+                statusCode: 403,
+            );
+        }
+
+        $this->articleRepository->delete($article);
 
         return Response::json(data: null, statusCode: 204);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decodeBody(Request $request): ?array
+    {
+        try {
+            $decoded = json_decode($request->body(), true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        return is_array($decoded) ? $decoded : null;
     }
 }
 ```
 
-## Step 5: Start the Server
+## Step 6: Start the Server
 
 ```bash
 marko up
 ```
 
-## Step 6: Test with cURL
+## Step 7: Test with cURL
 
 ```bash
 # List articles
@@ -269,7 +346,13 @@ curl -X POST http://localhost:8000/api/articles \
     -H "Content-Type: application/json" \
     -d '{"title": "My First Article", "body": "Hello from Marko!"}'
 
-# Delete
+# Update (owner only)
+curl -X PUT http://localhost:8000/api/articles/1 \
+    -H "Authorization: Bearer YOUR_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"title": "Updated"}'
+
+# Delete (owner only)
 curl -X DELETE http://localhost:8000/api/articles/1 \
     -H "Authorization: Bearer YOUR_TOKEN"
 ```
@@ -278,10 +361,13 @@ curl -X DELETE http://localhost:8000/api/articles/1 \
 
 - Minimal Marko installation for APIs (no views, no sessions)
 - Entity-driven database schemas with `#[Table]` and `#[Column]` attributes
-- RESTful controller with full CRUD
+- Base `Repository` class with automatic entity hydration and lifecycle events
+- RESTful controller as a `readonly class` (stateless service)
 - Request validation with [`ValidatorInterface`](/docs/packages/validation/)
 - Token-based authentication with [`AuthMiddleware`](/docs/packages/authentication/)
+- Ownership enforcement on mutations
 - Proper HTTP status codes using [`Response::json()`](/docs/packages/routing/)
+- Declared `@throws` on every method that propagates a checked exception
 
 ## Next Steps
 

--- a/docs/src/content/docs/tutorials/build-an-admin-panel.md
+++ b/docs/src/content/docs/tutorials/build-an-admin-panel.md
@@ -255,10 +255,10 @@ namespace App\Admin\Setup;
 
 use Marko\AdminAuth\Contracts\PermissionRegistryInterface;
 
-class RegisterPermissions
+readonly class RegisterPermissions
 {
     public function __construct(
-        private readonly PermissionRegistryInterface $permissionRegistry,
+        private PermissionRegistryInterface $permissionRegistry,
     ) {}
 
     public function register(): void
@@ -403,10 +403,10 @@ use Marko\Routing\Http\Response;
 use Marko\View\ViewInterface;
 
 #[Middleware(AdminAuthMiddleware::class)]
-class PostController
+readonly class PostController
 {
     public function __construct(
-        private readonly ViewInterface $view,
+        private ViewInterface $view,
     ) {}
 
     #[Get(path: '/admin/posts')]
@@ -610,6 +610,7 @@ declare(strict_types=1);
 
 namespace App\Admin\Controller;
 
+use JsonException;
 use Marko\AdminApi\ApiResponse;
 use Marko\AdminAuth\Attributes\RequiresPermission;
 use Marko\AdminAuth\Middleware\AdminAuthMiddleware;
@@ -632,6 +633,9 @@ class PostApiController
         return ApiResponse::success(data: $posts);
     }
 
+    /**
+     * @throws JsonException
+     */
     #[Post(path: '/admin/api/v1/posts')]
     #[RequiresPermission(permission: 'posts.create')]
     public function store(Request $request): Response
@@ -743,10 +747,10 @@ namespace App\Admin\Widget;
 use Marko\Admin\Contracts\DashboardWidgetInterface;
 use Marko\View\ViewInterface;
 
-class RecentPostsWidget implements DashboardWidgetInterface
+readonly class RecentPostsWidget implements DashboardWidgetInterface
 {
     public function __construct(
-        private readonly ViewInterface $view,
+        private ViewInterface $view,
     ) {}
 
     public function getId(): string

--- a/docs/src/content/docs/tutorials/custom-module.md
+++ b/docs/src/content/docs/tutorials/custom-module.md
@@ -121,10 +121,10 @@ namespace Marko\Analytics;
 
 use Marko\Database\Query\QueryBuilderInterface;
 
-class DatabaseAnalytics implements AnalyticsInterface
+readonly class DatabaseAnalytics implements AnalyticsInterface
 {
     public function __construct(
-        private readonly QueryBuilderInterface $queryBuilder,
+        private QueryBuilderInterface $queryBuilder,
     ) {}
 
     public function trackPageView(string $path, ?string $userId = null): void
@@ -205,11 +205,11 @@ use Marko\Routing\Http\Request;
 use Marko\Routing\Http\Response;
 use Marko\Routing\Middleware\MiddlewareInterface;
 
-class TrackPageViewMiddleware implements MiddlewareInterface
+readonly class TrackPageViewMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private readonly AnalyticsInterface $analytics,
-        private readonly AuthManager $authManager,
+        private AnalyticsInterface $analytics,
+        private AuthManager $authManager,
     ) {}
 
     public function handle(


### PR DESCRIPTION
## Summary

- Rewrites `build-a-rest-api.md` to follow Marko conventions: `readonly class` controller, `ArticleRepository extends Repository` with entity hydration, `@throws JsonException` on methods propagating JSON errors, 404/403 guards + ownership enforcement on mutations, and `JsonException` → 400 handling.
- Applies code-standards Rule 4 ("if ALL promoted properties are readonly, use `readonly class`") across 27 other docs files — 38 classes converted.
- Refactors `build-a-chat.md` `MessageRepository` to extend the base `Repository` (eliminating pseudo-functionality against the already-defined `Message` entity); updates template + `StreamController` to read entity properties.
- Adds missing `@throws JsonException` tags in `build-an-admin-panel.md` and `encryption.md`.

## Rationale

The previous REST API tutorial demonstrated several anti-patterns that the framework's own standards explicitly call out:
- `private readonly` instead of `readonly class` (Rule 4, "the most commonly missed rule")
- `Article` entity defined but ignored by the repository (violates "No pseudo-functionality")
- Silent 500 on malformed JSON (violates Loud Errors)
- No 404 / ownership check on PUT/DELETE
- Missing `@throws` tags on methods calling `json_decode(..., JSON_THROW_ON_ERROR)`

Auditing neighbouring docs surfaced the same Rule 4 violation in 38 classes across tutorials, guides, concepts, and package pages.

## Intentionally unchanged

- Bare constructor snippets with no surrounding class (queue-sync, session-*, scheduler, rate-limiting, webhook, search) — conversion would require fabricating a class.
- `MarkoException extends \Exception` — parent has mutable properties, so a `readonly class` child would be invalid PHP.

## Test plan

- [ ] Run the docs site locally (`cd docs && npm run dev`) and spot-check the REST API tutorial, chat tutorial, and a few converted package pages render correctly.
- [ ] Verify code blocks are syntactically valid PHP in the rewritten tutorial by copying into a scratch file.
- [ ] Confirm `build-a-chat.md` template + StreamController still read the same shape (`$message->username`, `$message->body`, `$message->id`).
- [ ] Verify `grep -rn "private readonly" docs/src/content/docs` only matches the intentionally-unchanged snippets listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)