### PR TITLE
docs: use composer test for faster local test runs

### DIFF
--- a/.claude/testing.md
+++ b/.claude/testing.md
@@ -15,8 +15,11 @@ composer require pestphp/pest --dev
 ## Commands
 
 ```bash
-# Run all tests
-./vendor/bin/pest
+# Run tests (fast — excludes slow destructive integration tests). Prefer this during development.
+composer test
+
+# Run all tests including destructive integration tests
+composer test:all
 
 # Run specific test file
 ./vendor/bin/pest tests/Unit/Container/ContainerTest.php
@@ -28,12 +31,12 @@ composer require pestphp/pest --dev
 ./vendor/bin/pest --filter="resolves dependencies"
 
 # Run with coverage
-./vendor/bin/pest --coverage
+./vendor/bin/pest -c phpunit.xml --parallel --exclude-group=integration-destructive --coverage
 
 # Run with coverage and minimum threshold
-./vendor/bin/pest --coverage --min=80
+./vendor/bin/pest -c phpunit.xml --parallel --exclude-group=integration-destructive --coverage --min=80
 
-# Run in parallel (faster)
+# Run in parallel (faster) — equivalent to composer test:all
 ./vendor/bin/pest --parallel
 
 # Run with test sharding (for CI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,14 @@ Marko is a modular PHP 8.5+ framework combining Magento's extensibility with Lar
 ## Commands
 
 ```bash
-# Run tests
-./vendor/bin/pest --parallel
+# Run tests (fast — excludes slow destructive integration tests)
+composer test
+
+# Run all tests including destructive integration tests
+composer test:all
 
 # Run with coverage
-./vendor/bin/pest --parallel --coverage --min=80
+./vendor/bin/pest -c phpunit.xml --parallel --exclude-group=integration-destructive --coverage --min=80
 
 # Lint (check)
 ./vendor/bin/phpcs


### PR DESCRIPTION
## Summary

- Update CLAUDE.md and testing.md to recommend `composer test` (excludes `integration-destructive` group) as the default test command
- `composer test` runs in ~5s vs ~20s for the full suite during local/iterative development
- `composer test:all` documented for when the full suite (including destructive integration tests) is needed

## Test plan

- [x] Docs-only change; no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)