### PR TITLE
docs: document integration-destructive group and run it in release script

### DIFF
--- a/.claude/testing.md
+++ b/.claude/testing.md
@@ -50,6 +50,31 @@ composer test:all
 ./vendor/bin/pest --profanity
 ```
 
+## The `integration-destructive` Test Group
+
+Tests tagged `->group('integration-destructive')` live in `tests/IntegrationVerificationTest.php`. They verify the clean-install workflow end-to-end by:
+
+1. Deleting `vendor/` and `composer.lock`
+2. Running `composer update` to re-resolve dependencies from scratch
+3. Running the full test suite in a subprocess against the freshly-resolved state
+
+Because they mutate the working directory, they're excluded from `composer test` by default. Use `composer test:all` to include them.
+
+### When to run them
+
+- **Before tagging a release** — verifies a fresh install still resolves and passes (`bin/release.sh` runs the full group automatically).
+- **After changing the root `composer.json`** — bumping PHP version, adding/removing dependencies, or changing version constraints.
+- **After changing any package `composer.json` that affects resolution** — new cross-package `require`, constraint bumps, replace/conflict declarations.
+- **When investigating dependency-resolution oddities** — to confirm the committed lock file actually installs cleanly from scratch.
+
+### When NOT to run them
+
+- Normal feature or bug-fix work on application logic — they don't exercise application code, they exercise the install pipeline, and they will leave your local `composer.lock` potentially updated to newer transitive versions.
+
+### Side effect to be aware of
+
+Running the destructive group updates your working directory's `composer.lock` (whatever `composer update` currently resolves). Commit any intended lock changes, or `git checkout composer.lock vendor/` to restore if you didn't mean to bump.
+
 ## TDD Workflow Commands
 
 Optimized commands for fast feedback during TDD cycles:

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -56,9 +56,9 @@ echo "  ✓ Branch: main (merged from develop)"
 echo "  ✓ Working directory clean"
 echo "  ✓ Tag ${TAG} available"
 echo ""
-echo "Running test suite..."
+echo "Running test suite (including integration-destructive group to verify clean install)..."
 
-"$PHP_BIN" vendor/bin/pest --parallel --exclude-group=integration-destructive || {
+"$PHP_BIN" vendor/bin/pest --parallel || {
     echo ""
     echo "Error: Tests failed. Fix failing tests before releasing."
     exit 1


### PR DESCRIPTION
## Summary

- Add a "When to use" section to `.claude/testing.md` explaining what the `integration-destructive` test group does, when to run it, when NOT to, and its side effects
- Update `bin/release.sh` to run the full suite (including the destructive group) so every release verifies a clean-install from scratch actually resolves and passes

## Why

`composer test` (the default dev command) excludes `integration-destructive` because those tests delete `vendor/` and `composer.lock` and re-resolve via `composer update`. That's the right default for iterative development, but release time is exactly when you want that verification. Previously `release.sh` mirrored the dev exclusion, defeating the purpose of having those tests in the first place.

## Test plan

- [x] `bash -n bin/release.sh` passes
- [x] `composer test:all` equivalent verified via `composer run-script --list`
- [x] Docs-only additions; no code behavior changed beyond the release script command

🤖 Generated with [Claude Code](https://claude.com/claude-code)