### PR TITLE
feat: Add marko/vite package

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -115,6 +115,7 @@ body:
         - validation
         - view
         - view-latte
+        - vite
         - webhook
         - other
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -103,6 +103,7 @@ body:
         - validation
         - view
         - view-latte
+        - vite
         - webhook
         - other
     validations:

--- a/composer.json
+++ b/composer.json
@@ -286,6 +286,10 @@
         },
         {
             "type": "path",
+            "url": "packages/vite"
+        },
+        {
+            "type": "path",
             "url": "packages/webhook"
         }
     ],
@@ -364,6 +368,7 @@
         "marko/validation": "self.version",
         "marko/view": "self.version",
         "marko/view-latte": "self.version",
+        "marko/vite": "self.version",
         "marko/webhook": "self.version"
     },
     "require-dev": {
@@ -454,6 +459,7 @@
             "Marko\\Translation\\Tests\\": "packages/translation/tests/",
             "Marko\\Translation\\File\\Tests\\": "packages/translation-file/tests/",
             "Marko\\View\\Latte\\Tests\\": "packages/view-latte/tests/",
+            "Marko\\Vite\\Tests\\": "packages/vite/tests/",
             "Marko\\Notification\\Tests\\": "packages/notification/tests/",
             "Marko\\Notification\\Database\\Tests\\": "packages/notification-database/tests/",
             "Marko\\Pagination\\Tests\\": "packages/pagination/tests/",

--- a/docs/src/content/docs/packages/vite.md
+++ b/docs/src/content/docs/packages/vite.md
@@ -1,0 +1,116 @@
+---
+title: marko/vite
+description: Vite integration for the Marko Framework — asset manifest resolution and dev-server detection for production builds and HMR.
+---
+
+Vite integration for the Marko Framework. Resolves the [Vite](https://vitejs.dev/) build manifest in production and emits dev-server tags during development, with React Fast Refresh support detected from entry filenames.
+
+## Installation
+
+```bash
+composer require marko/vite
+```
+
+## Configuration
+
+Configure via `config/vite.php`:
+
+```php title="config/vite.php"
+return [
+    'entry' => env('VITE_ENTRY', ''),
+    'buildDirectory' => 'build',
+    'manifestFilename' => '.vite/manifest.json',
+    'devServerUrl' => env('VITE_DEV_SERVER_URL', ''),
+    'devServerStylesheets' => [],
+    'useDevServer' => env('VITE_USE_DEV_SERVER', env('APP_ENV', 'local') === 'local'),
+];
+```
+
+| Key | Purpose |
+| --- | --- |
+| `entry` | Default entry point relative to your project root (e.g. `app/web/resources/js/app.js`). Required when calling `headTags()` without an argument. |
+| `buildDirectory` | Subdirectory under `public/` where Vite writes built assets. Defaults to `build`. |
+| `manifestFilename` | Manifest path relative to `public/{buildDirectory}/`. Defaults to `.vite/manifest.json`. |
+| `devServerUrl` | URL of the running Vite dev server. Required when `useDevServer` is true. |
+| `devServerStylesheets` | Stylesheets served directly by Vite during dev (e.g. Tailwind entrypoints). |
+| `useDevServer` | When true, emit dev-server tags. When false, read the production manifest. |
+
+## Usage
+
+Inject `Vite` and call `headTags()` to render the `<script>` and `<link>` tags for the document head:
+
+```php
+use Marko\Vite\Vite;
+
+class LayoutController
+{
+    public function __construct(
+        private readonly Vite $vite,
+    ) {}
+
+    public function head(): string
+    {
+        return $this->vite->headTags('app/web/resources/js/app.js');
+    }
+}
+```
+
+Pass an entry path to override the configured default. With no argument, the value of `vite.entry` is used.
+
+### Development mode
+
+When `vite.useDevServer` is `true`, `headTags()` emits dev-server tags:
+
+```html
+<link rel="stylesheet" href="http://localhost:5173/app/web/resources/css/app.css">
+<script type="module" src="http://localhost:5173/@vite/client"></script>
+<script type="module" src="http://localhost:5173/app/web/resources/js/app.js"></script>
+```
+
+If the entry filename ends in `.jsx` or `.tsx`, a [React Fast Refresh](https://github.com/facebook/react/tree/main/packages/react-refresh) preamble is automatically injected before the entry script.
+
+### Production mode
+
+When `useDevServer` is `false`, `headTags()` reads `public/{buildDirectory}/{manifestFilename}` and emits hashed asset tags:
+
+```html
+<link rel="stylesheet" href="/build/assets/app.456.css">
+<script type="module" src="/build/assets/app.123.js"></script>
+<link rel="modulepreload" href="/build/assets/shared.789.js">
+```
+
+Imported chunks are walked recursively — their CSS files and JS modules are emitted as `<link rel="stylesheet">` and `<link rel="modulepreload">` respectively, so HTTP/2 push and module preloading work correctly.
+
+## Errors
+
+Following Marko's loud-errors principle, configuration and manifest issues throw rather than silently degrade.
+
+`Marko\Vite\Exceptions\ViteConfigurationException` is thrown when:
+
+- `vite.entry` is empty and no entry argument is passed to `headTags()`.
+- `vite.devServerUrl` is empty and `useDevServer` is true.
+- A required config key is missing or has the wrong type.
+
+`Marko\Vite\Exceptions\ViteManifestException` is thrown in production mode when:
+
+- The manifest file does not exist (run `npm run build`).
+- The manifest cannot be read or is not valid JSON.
+- The configured entry is not present in the manifest.
+- The entry's `file` field is missing or empty.
+
+## API Reference
+
+```php
+namespace Marko\Vite;
+
+class Vite
+{
+    public function headTags(?string $entry = null): string;
+    public function useDevServer(): bool;
+}
+```
+
+## Related Packages
+
+- [`marko/config`](/docs/packages/config/) — provides the configuration repository
+- [`marko/env`](/docs/packages/env/) — provides the `env()` helper used in `config/vite.php`

--- a/packages/vite/.gitattributes
+++ b/packages/vite/.gitattributes
@@ -1,0 +1,5 @@
+/tests              export-ignore
+/.github             export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/phpunit.xml.dist   export-ignore

--- a/packages/vite/.gitattributes
+++ b/packages/vite/.gitattributes
@@ -1,5 +1,5 @@
 /tests              export-ignore
-/.github             export-ignore
+/.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /phpunit.xml.dist   export-ignore

--- a/packages/vite/LICENSE
+++ b/packages/vite/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Devtomic LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -1,0 +1,11 @@
+# Marko Vite
+
+Standalone `marko/vite` package for the Marko Framework.
+
+## Package
+
+- `marko/vite`
+
+## Configuration
+
+Publish or merge `config/vite.php` into your application config and set the Vite entry points for your frontend.

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -1,11 +1,33 @@
-# Marko Vite
+# marko/vite
 
-Standalone `marko/vite` package for the Marko Framework.
+Vite integration for the Marko Framework — asset manifest resolution and dev-server detection for production builds and HMR.
 
-## Package
+## Installation
 
-- `marko/vite`
+```bash
+composer require marko/vite
+```
 
-## Configuration
+## Quick Example
 
-Publish or merge `config/vite.php` into your application config and set the Vite entry points for your frontend.
+```php
+use Marko\Vite\Vite;
+
+class LayoutController
+{
+    public function __construct(
+        private readonly Vite $vite,
+    ) {}
+
+    public function head(): string
+    {
+        return $this->vite->headTags('app/web/resources/js/app.js');
+    }
+}
+```
+
+In dev (`vite.useDevServer = true`), this emits `<script type="module">` tags pointing at the Vite dev server. In production, it reads `public/build/.vite/manifest.json` and emits hashed `<script>`, `<link rel="stylesheet">`, and `<link rel="modulepreload">` tags.
+
+## Documentation
+
+Full usage, API reference, and examples: [marko/vite](https://marko.build/docs/packages/vite/)

--- a/packages/vite/composer.json
+++ b/packages/vite/composer.json
@@ -1,27 +1,27 @@
 {
-  "name": "marko/vite",
-  "description": "Vite integration for the Marko Framework - asset manifest resolution and dev-server detection",
-  "license": "MIT",
-  "type": "marko-module",
-  "require": {
-    "php": "^8.5",
-    "marko/config": "self.version",
-    "marko/core": "self.version",
-    "marko/env": "self.version"
-  },
-  "autoload": {
-    "psr-4": {
-      "Marko\\Vite\\": "src/"
+    "name": "marko/vite",
+    "description": "Vite integration for the Marko Framework - asset manifest resolution and dev-server detection",
+    "license": "MIT",
+    "type": "marko-module",
+    "require": {
+        "php": "^8.5",
+        "marko/config": "self.version",
+        "marko/core": "self.version",
+        "marko/env": "self.version"
+    },
+    "autoload": {
+        "psr-4": {
+            "Marko\\Vite\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Marko\\Vite\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "marko": {
+            "module": true
+        }
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Marko\\Vite\\Tests\\": "tests/"
-    }
-  },
-  "extra": {
-    "marko": {
-      "module": true
-    }
-  }
 }

--- a/packages/vite/composer.json
+++ b/packages/vite/composer.json
@@ -1,0 +1,27 @@
+{
+  "name": "marko/vite",
+  "description": "Vite integration for the Marko Framework - asset manifest resolution and dev-server detection",
+  "license": "MIT",
+  "type": "marko-module",
+  "require": {
+    "php": "^8.5",
+    "marko/config": "self.version",
+    "marko/core": "self.version",
+    "marko/env": "self.version"
+  },
+  "autoload": {
+    "psr-4": {
+      "Marko\\Vite\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Marko\\Vite\\Tests\\": "tests/"
+    }
+  },
+  "extra": {
+    "marko": {
+      "module": true
+    }
+  }
+}

--- a/packages/vite/config/vite.php
+++ b/packages/vite/config/vite.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'entry' => env('VITE_ENTRY', ''),
+    'buildDirectory' => 'build',
+    'manifestFilename' => '.vite/manifest.json',
+    'devServerUrl' => env('VITE_DEV_SERVER_URL', ''),
+    'devServerStylesheets' => [],
+    'useDevServer' => env('VITE_USE_DEV_SERVER', env('APP_ENV', 'local') === 'local'),
+];

--- a/packages/vite/module.php
+++ b/packages/vite/module.php
@@ -2,35 +2,9 @@
 
 declare(strict_types=1);
 
-use Marko\Config\ConfigRepositoryInterface;
-use Marko\Core\Container\ContainerInterface;
-use Marko\Core\Path\ProjectPaths;
 use Marko\Vite\Vite;
 
 return [
-    'enabled' => true,
-    'sequence' => [
-        'after' => ['marko/config'],
-    ],
-    'bindings' => [
-        Vite::class => function (ContainerInterface $container): Vite {
-            $config = $container->get(ConfigRepositoryInterface::class);
-            $paths = $container->get(ProjectPaths::class);
-
-            if (! $config instanceof ConfigRepositoryInterface) {
-                throw new RuntimeException('Config repository binding must implement '.ConfigRepositoryInterface::class);
-            }
-
-            if (! $paths instanceof ProjectPaths) {
-                throw new RuntimeException('Project paths binding must resolve to '.ProjectPaths::class);
-            }
-
-            return new Vite(
-                $config,
-                $paths,
-            );
-        },
-    ],
     'singletons' => [
         Vite::class,
     ],

--- a/packages/vite/module.php
+++ b/packages/vite/module.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Config\ConfigRepositoryInterface;
+use Marko\Core\Container\ContainerInterface;
+use Marko\Core\Path\ProjectPaths;
+use Marko\Vite\Vite;
+
+return [
+    'enabled' => true,
+    'sequence' => [
+        'after' => ['marko/config'],
+    ],
+    'bindings' => [
+        Vite::class => function (ContainerInterface $container): Vite {
+            $config = $container->get(ConfigRepositoryInterface::class);
+            $paths = $container->get(ProjectPaths::class);
+
+            if (! $config instanceof ConfigRepositoryInterface) {
+                throw new RuntimeException('Config repository binding must implement '.ConfigRepositoryInterface::class);
+            }
+
+            if (! $paths instanceof ProjectPaths) {
+                throw new RuntimeException('Project paths binding must resolve to '.ProjectPaths::class);
+            }
+
+            return new Vite(
+                $config,
+                $paths,
+            );
+        },
+    ],
+    'singletons' => [
+        Vite::class,
+    ],
+];

--- a/packages/vite/src/Exceptions/ViteConfigurationException.php
+++ b/packages/vite/src/Exceptions/ViteConfigurationException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Vite\Exceptions;
+
+use Marko\Core\Exceptions\MarkoException;
+use Throwable;
+
+final class ViteConfigurationException extends MarkoException
+{
+    public static function missingOrInvalid(string $key, Throwable $previous): self
+    {
+        return new self(
+            sprintf('Vite configuration key "%s" is missing or invalid.', $key),
+            $previous->getMessage(),
+            'Publish or update config/vite.php with the expected Vite configuration keys.',
+            previous: $previous,
+        );
+    }
+
+    public static function empty(string $key, string $suggestion): self
+    {
+        return new self(
+            sprintf('Vite configuration key "%s" must not be empty.', $key),
+            sprintf('The "%s" value resolved to an empty string.', $key),
+            $suggestion,
+        );
+    }
+}

--- a/packages/vite/src/Exceptions/ViteConfigurationException.php
+++ b/packages/vite/src/Exceptions/ViteConfigurationException.php
@@ -7,10 +7,12 @@ namespace Marko\Vite\Exceptions;
 use Marko\Core\Exceptions\MarkoException;
 use Throwable;
 
-final class ViteConfigurationException extends MarkoException
+class ViteConfigurationException extends MarkoException
 {
-    public static function missingOrInvalid(string $key, Throwable $previous): self
-    {
+    public static function missingOrInvalid(
+        string $key,
+        Throwable $previous,
+    ): self {
         return new self(
             sprintf('Vite configuration key "%s" is missing or invalid.', $key),
             $previous->getMessage(),
@@ -19,8 +21,10 @@ final class ViteConfigurationException extends MarkoException
         );
     }
 
-    public static function empty(string $key, string $suggestion): self
-    {
+    public static function empty(
+        string $key,
+        string $suggestion,
+    ): self {
         return new self(
             sprintf('Vite configuration key "%s" must not be empty.', $key),
             sprintf('The "%s" value resolved to an empty string.', $key),

--- a/packages/vite/src/Exceptions/ViteManifestException.php
+++ b/packages/vite/src/Exceptions/ViteManifestException.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Vite\Exceptions;
+
+use Marko\Core\Exceptions\MarkoException;
+
+class ViteManifestException extends MarkoException
+{
+    public static function notFound(string $manifestPath): self
+    {
+        return new self(
+            sprintf('Vite manifest not found at "%s".', $manifestPath),
+            'The production manifest is required when vite.useDevServer is false.',
+            'Run "npm run build" to generate the manifest, or set vite.useDevServer=true for development.',
+        );
+    }
+
+    public static function unreadable(string $manifestPath): self
+    {
+        return new self(
+            sprintf('Vite manifest at "%s" could not be read.', $manifestPath),
+            'file_get_contents() returned false for the manifest path.',
+            'Check filesystem permissions on the manifest file.',
+        );
+    }
+
+    public static function invalid(string $manifestPath): self
+    {
+        return new self(
+            sprintf('Vite manifest at "%s" is not valid JSON.', $manifestPath),
+            'json_decode() failed or returned a non-object structure.',
+            'Re-run "npm run build" to regenerate the manifest.',
+        );
+    }
+
+    public static function entryNotFound(
+        string $entry,
+        string $manifestPath,
+    ): self {
+        return new self(
+            sprintf('Vite entry "%s" was not found in manifest "%s".', $entry, $manifestPath),
+            'The configured vite.entry does not match any key in the manifest.',
+            sprintf('Add "%s" to your vite.config build inputs, or update vite.entry to a known key.', $entry),
+        );
+    }
+
+    public static function entryFileInvalid(
+        string $entry,
+        string $manifestPath,
+    ): self {
+        return new self(
+            sprintf('Vite entry "%s" in manifest "%s" has no valid "file" field.', $entry, $manifestPath),
+            'The manifest entry is missing or has an empty "file" attribute.',
+            'Re-run "npm run build" to regenerate the manifest.',
+        );
+    }
+}

--- a/packages/vite/src/Vite.php
+++ b/packages/vite/src/Vite.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Marko\Vite;
 
-use Marko\Config\Exceptions\ConfigException;
 use Marko\Config\ConfigRepositoryInterface;
+use Marko\Config\Exceptions\ConfigException;
 use Marko\Core\Path\ProjectPaths;
 use Marko\Vite\Exceptions\ViteConfigurationException;
+use Marko\Vite\Exceptions\ViteManifestException;
 
 readonly class Vite
 {
@@ -49,7 +50,7 @@ readonly class Vite
 
         foreach ($this->devServerStylesheets() as $stylesheet) {
             $stylesheet = ltrim($stylesheet, '/');
-            $tags .= "<link rel=\"stylesheet\" href=\"{$url}/{$stylesheet}\">\n";
+            $tags .= "<link rel=\"stylesheet\" href=\"$url/$stylesheet\">\n";
         }
 
         if ($this->isReactEntry($entry)) {
@@ -57,8 +58,8 @@ readonly class Vite
         }
 
         $tags .= <<<HTML
-<script type="module" src="{$url}/@vite/client"></script>
-<script type="module" src="{$url}/{$entry}"></script>
+<script type="module" src="$url/@vite/client"></script>
+<script type="module" src="$url/$entry"></script>
 HTML;
 
         return $tags;
@@ -72,7 +73,7 @@ HTML;
     {
         return <<<HTML
 <script type="module">
-import { injectIntoGlobalHook } from "{$url}/@react-refresh";
+import { injectIntoGlobalHook } from "$url/@react-refresh";
 injectIntoGlobalHook(window);
 window.\$RefreshReg\$ = () => {};
 window.\$RefreshSig\$ = () => (type) => type;
@@ -108,17 +109,17 @@ HTML;
         $manifestPath = $this->manifestPath();
 
         if (! is_file($manifestPath)) {
-            return '<!-- Vite manifest not found. Run: npm run build -->';
+            throw ViteManifestException::notFound($manifestPath);
         }
 
         $manifestContents = file_get_contents($manifestPath);
         if ($manifestContents === false) {
-            return '<!-- Vite manifest is invalid -->';
+            throw ViteManifestException::unreadable($manifestPath);
         }
 
         $manifest = $this->decodeManifest($manifestContents);
         if ($manifest === null) {
-            return '<!-- Vite manifest is invalid -->';
+            throw ViteManifestException::invalid($manifestPath);
         }
 
         $buildDir = $this->configString('vite.buildDirectory');
@@ -126,12 +127,12 @@ HTML;
 
         $entryData = $manifest[$entry] ?? null;
         if (! is_array($entryData)) {
-            return "<!-- Vite entry '{$entry}' not found in manifest -->";
+            throw ViteManifestException::entryNotFound($entry, $manifestPath);
         }
 
         $entryFile = $entryData['file'] ?? null;
         if (! is_string($entryFile) || $entryFile === '') {
-            return "<!-- Vite entry '{$entry}' is invalid -->";
+            throw ViteManifestException::entryFileInvalid($entry, $manifestPath);
         }
 
         $importedChunks = $this->importedChunks($manifest, $entryData);
@@ -147,7 +148,7 @@ HTML;
                     continue;
                 }
 
-                $stylesheets[$css] = "<link rel=\"stylesheet\" href=\"{$basePath}{$css}\">";
+                $stylesheets[$css] = "<link rel=\"stylesheet\" href=\"$basePath$css\">";
             }
         }
 
@@ -161,7 +162,7 @@ HTML;
                 continue;
             }
 
-            $tags[] = "<link rel=\"modulepreload\" href=\"{$basePath}{$chunkFile}\">";
+            $tags[] = "<link rel=\"modulepreload\" href=\"$basePath$chunkFile\">";
         }
 
         return implode("\n", $tags);
@@ -276,8 +277,10 @@ HTML;
      * @param array<string, mixed> $entryData
      * @return list<array<string, mixed>>
      */
-    private function importedChunks(array $manifest, array $entryData): array
-    {
+    private function importedChunks(
+        array $manifest,
+        array $entryData,
+    ): array {
         $seen = [];
 
         return array_values($this->collectImportedChunks($manifest, $entryData, $seen));
@@ -289,8 +292,11 @@ HTML;
      * @param array<string, true> $seen
      * @return array<string, array<string, mixed>>
      */
-    private function collectImportedChunks(array $manifest, array $chunk, array &$seen): array
-    {
+    private function collectImportedChunks(
+        array $manifest,
+        array $chunk,
+        array &$seen,
+    ): array {
         $imports = $chunk['imports'] ?? null;
         $chunks = [];
 
@@ -342,12 +348,14 @@ HTML;
         return $normalizedChunk;
     }
 
-    private function entryTag(string $basePath, string $entryFile): string
-    {
+    private function entryTag(
+        string $basePath,
+        string $entryFile,
+    ): string {
         if (str_ends_with($entryFile, '.css')) {
-            return "<link rel=\"stylesheet\" href=\"{$basePath}{$entryFile}\">";
+            return "<link rel=\"stylesheet\" href=\"$basePath$entryFile\">";
         }
 
-        return "<script type=\"module\" src=\"{$basePath}{$entryFile}\"></script>";
+        return "<script type=\"module\" src=\"$basePath$entryFile\"></script>";
     }
 }

--- a/packages/vite/src/Vite.php
+++ b/packages/vite/src/Vite.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Vite;
+
+use Marko\Config\Exceptions\ConfigException;
+use Marko\Config\ConfigRepositoryInterface;
+use Marko\Core\Path\ProjectPaths;
+use Marko\Vite\Exceptions\ViteConfigurationException;
+
+readonly class Vite
+{
+    public function __construct(
+        private ConfigRepositoryInterface $config,
+        private ProjectPaths $paths,
+    ) {}
+
+    /**
+     * Generate Vite script/link tags for the HTML head.
+     */
+    public function headTags(?string $entry = null): string
+    {
+        $entry = $this->normalizeEntry($entry ?? $this->configuredEntry());
+
+        if ($this->useDevServer()) {
+            return $this->devServerTags($entry);
+        }
+
+        return $this->manifestTags($entry);
+    }
+
+    /**
+     * Check if Vite dev server should be used.
+     */
+    public function useDevServer(): bool
+    {
+        return $this->configBool('vite.useDevServer');
+    }
+
+    /**
+     * Tags for Vite dev server (hot module replacement).
+     */
+    private function devServerTags(string $entry): string
+    {
+        $url = $this->devServerUrl();
+
+        $tags = '';
+
+        foreach ($this->devServerStylesheets() as $stylesheet) {
+            $stylesheet = ltrim($stylesheet, '/');
+            $tags .= "<link rel=\"stylesheet\" href=\"{$url}/{$stylesheet}\">\n";
+        }
+
+        if ($this->isReactEntry($entry)) {
+            $tags .= $this->reactRefreshPreamble($url)."\n";
+        }
+
+        $tags .= <<<HTML
+<script type="module" src="{$url}/@vite/client"></script>
+<script type="module" src="{$url}/{$entry}"></script>
+HTML;
+
+        return $tags;
+    }
+
+    /**
+     * React Fast Refresh expects this preamble when Vite is not serving the
+     * application HTML itself.
+     */
+    private function reactRefreshPreamble(string $url): string
+    {
+        return <<<HTML
+<script type="module">
+import { injectIntoGlobalHook } from "{$url}/@react-refresh";
+injectIntoGlobalHook(window);
+window.\$RefreshReg\$ = () => {};
+window.\$RefreshSig\$ = () => (type) => type;
+</script>
+HTML;
+    }
+
+    private function isReactEntry(string $entry): bool
+    {
+        return str_ends_with($entry, '.jsx') || str_ends_with($entry, '.tsx');
+    }
+
+    /**
+     * Stylesheets served directly by Vite in dev mode.
+     *
+     * @return list<string>
+     */
+    private function devServerStylesheets(): array
+    {
+        $stylesheets = $this->configArray('vite.devServerStylesheets');
+
+        return array_values(array_filter(
+            $stylesheets,
+            static fn (mixed $stylesheet): bool => is_string($stylesheet) && $stylesheet !== '',
+        ));
+    }
+
+    /**
+     * Tags from production build manifest.
+     */
+    private function manifestTags(string $entry): string
+    {
+        $manifestPath = $this->manifestPath();
+
+        if (! is_file($manifestPath)) {
+            return '<!-- Vite manifest not found. Run: npm run build -->';
+        }
+
+        $manifestContents = file_get_contents($manifestPath);
+        if ($manifestContents === false) {
+            return '<!-- Vite manifest is invalid -->';
+        }
+
+        $manifest = $this->decodeManifest($manifestContents);
+        if ($manifest === null) {
+            return '<!-- Vite manifest is invalid -->';
+        }
+
+        $buildDir = $this->configString('vite.buildDirectory');
+        $basePath = '/'.trim($buildDir, '/').'/';
+
+        $entryData = $manifest[$entry] ?? null;
+        if (! is_array($entryData)) {
+            return "<!-- Vite entry '{$entry}' not found in manifest -->";
+        }
+
+        $entryFile = $entryData['file'] ?? null;
+        if (! is_string($entryFile) || $entryFile === '') {
+            return "<!-- Vite entry '{$entry}' is invalid -->";
+        }
+
+        $importedChunks = $this->importedChunks($manifest, $entryData);
+        $stylesheets = [];
+
+        foreach (array_merge([$entryData], $importedChunks) as $chunk) {
+            if (! isset($chunk['css']) || ! is_array($chunk['css'])) {
+                continue;
+            }
+
+            foreach ($chunk['css'] as $css) {
+                if (! is_string($css) || $css === '') {
+                    continue;
+                }
+
+                $stylesheets[$css] = "<link rel=\"stylesheet\" href=\"{$basePath}{$css}\">";
+            }
+        }
+
+        $tags = array_values($stylesheets);
+        $tags[] = $this->entryTag($basePath, $entryFile);
+
+        foreach ($importedChunks as $chunk) {
+            $chunkFile = $chunk['file'] ?? null;
+
+            if (! is_string($chunkFile) || $chunkFile === '' || str_ends_with($chunkFile, '.css')) {
+                continue;
+            }
+
+            $tags[] = "<link rel=\"modulepreload\" href=\"{$basePath}{$chunkFile}\">";
+        }
+
+        return implode("\n", $tags);
+    }
+
+    /**
+     * Resolve the absolute path to the Vite manifest file.
+     */
+    private function manifestPath(): string
+    {
+        $buildDir = $this->configString('vite.buildDirectory');
+        $manifestFilename = $this->configString('vite.manifestFilename');
+
+        return $this->paths->base.'/public/'.trim($buildDir, '/').'/'.$manifestFilename;
+    }
+
+    private function configuredEntry(): string
+    {
+        return $this->configString('vite.entry');
+    }
+
+    private function normalizeEntry(string $entry): string
+    {
+        $entry = trim($entry);
+
+        if ($entry === '') {
+            throw ViteConfigurationException::empty(
+                'vite.entry',
+                'Set vite.entry in config/vite.php or pass a non-empty entry to Vite::headTags().',
+            );
+        }
+
+        return ltrim($entry, '/');
+    }
+
+    private function devServerUrl(): string
+    {
+        $url = trim($this->configString('vite.devServerUrl'));
+
+        if ($url === '') {
+            throw ViteConfigurationException::empty(
+                'vite.devServerUrl',
+                'Set vite.devServerUrl in config/vite.php when vite.useDevServer is true.',
+            );
+        }
+
+        return rtrim($url, '/');
+    }
+
+    private function configString(string $key): string
+    {
+        try {
+            return $this->config->getString($key);
+        } catch (ConfigException $exception) {
+            throw ViteConfigurationException::missingOrInvalid($key, $exception);
+        }
+    }
+
+    private function configBool(string $key): bool
+    {
+        try {
+            return $this->config->getBool($key);
+        } catch (ConfigException $exception) {
+            throw ViteConfigurationException::missingOrInvalid($key, $exception);
+        }
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    private function configArray(string $key): array
+    {
+        try {
+            return $this->config->getArray($key);
+        } catch (ConfigException $exception) {
+            throw ViteConfigurationException::missingOrInvalid($key, $exception);
+        }
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>|null
+     */
+    private function decodeManifest(string $manifestContents): ?array
+    {
+        $manifest = json_decode($manifestContents, true);
+
+        if (! is_array($manifest)) {
+            return null;
+        }
+
+        $normalizedManifest = [];
+
+        foreach ($manifest as $key => $chunk) {
+            if (! is_string($key)) {
+                return null;
+            }
+
+            $normalizedChunk = $this->normalizeChunk($chunk);
+
+            if ($normalizedChunk === null) {
+                return null;
+            }
+
+            $normalizedManifest[$key] = $normalizedChunk;
+        }
+
+        return $normalizedManifest;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $manifest
+     * @param array<string, mixed> $entryData
+     * @return list<array<string, mixed>>
+     */
+    private function importedChunks(array $manifest, array $entryData): array
+    {
+        $seen = [];
+
+        return array_values($this->collectImportedChunks($manifest, $entryData, $seen));
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $manifest
+     * @param array<string, mixed> $chunk
+     * @param array<string, true> $seen
+     * @return array<string, array<string, mixed>>
+     */
+    private function collectImportedChunks(array $manifest, array $chunk, array &$seen): array
+    {
+        $imports = $chunk['imports'] ?? null;
+        $chunks = [];
+
+        if (! is_array($imports)) {
+            return $chunks;
+        }
+
+        foreach ($imports as $import) {
+            if (! is_string($import) || isset($seen[$import])) {
+                continue;
+            }
+
+            $importedChunk = $manifest[$import] ?? null;
+
+            if (! is_array($importedChunk)) {
+                continue;
+            }
+
+            $seen[$import] = true;
+            $chunks[$import] = $importedChunk;
+
+            foreach ($this->collectImportedChunks($manifest, $importedChunk, $seen) as $nestedImport => $nestedChunk) {
+                $chunks[$nestedImport] = $nestedChunk;
+            }
+        }
+
+        return $chunks;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function normalizeChunk(mixed $chunk): ?array
+    {
+        if (! is_array($chunk)) {
+            return null;
+        }
+
+        $normalizedChunk = [];
+
+        foreach ($chunk as $key => $value) {
+            if (! is_string($key)) {
+                return null;
+            }
+
+            $normalizedChunk[$key] = $value;
+        }
+
+        return $normalizedChunk;
+    }
+
+    private function entryTag(string $basePath, string $entryFile): string
+    {
+        if (str_ends_with($entryFile, '.css')) {
+            return "<link rel=\"stylesheet\" href=\"{$basePath}{$entryFile}\">";
+        }
+
+        return "<script type=\"module\" src=\"{$basePath}{$entryFile}\"></script>";
+    }
+}

--- a/packages/vite/tests/ViteTest.php
+++ b/packages/vite/tests/ViteTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Config\ConfigRepository;
+use Marko\Core\Path\ProjectPaths;
+use Marko\Vite\Exceptions\ViteConfigurationException;
+use Marko\Vite\Vite;
+
+beforeEach(function () {
+    $this->basePath = dirname(__DIR__);
+    $this->paths = new ProjectPaths($this->basePath);
+});
+
+function makeProjectPathsWithManifest(array|string $manifest): ProjectPaths
+{
+    $basePath = sys_get_temp_dir().'/marko-vite-test-'.bin2hex(random_bytes(6));
+    $manifestDirectory = $basePath.'/public/build/.vite';
+
+    mkdir($manifestDirectory, 0777, true);
+    file_put_contents(
+        $manifestDirectory.'/manifest.json',
+        is_array($manifest) ? json_encode($manifest, JSON_THROW_ON_ERROR) : $manifest,
+    );
+
+    return new ProjectPaths($basePath);
+}
+
+test('vite returns manifest not found when manifest is missing', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'entry' => 'app/web/resources/js/app.js',
+            'buildDirectory' => 'build',
+            'manifestFilename' => '.vite/nonexistent.json',
+            'useDevServer' => false,
+        ],
+    ]);
+
+    $vite = new Vite($config, $this->paths);
+    $tags = $vite->headTags();
+
+    expect($tags)->toContain('Vite manifest not found');
+});
+
+test('vite detects dev server from config', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'useDevServer' => true,
+        ],
+    ]);
+
+    $vite = new Vite($config, $this->paths);
+
+    expect($vite->useDevServer())->toBeTrue();
+});
+
+test('vite uses the configured default entry when no entry is provided', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'entry' => 'app/web/resources/js/app.js',
+            'buildDirectory' => 'build',
+            'manifestFilename' => '.vite/nonexistent.json',
+            'useDevServer' => false,
+        ],
+    ]);
+
+    $vite = new Vite($config, $this->paths);
+    $tags = $vite->headTags();
+
+    expect($tags)->toContain('Vite manifest not found');
+});
+
+test('vite throws when no default entry is configured', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'entry' => '',
+            'useDevServer' => false,
+        ],
+    ]);
+
+    $vite = new Vite($config, $this->paths);
+
+    expect(fn () => $vite->headTags())
+        ->toThrow(ViteConfigurationException::class, 'vite.entry');
+});
+
+test('vite throws when dev server config is missing', function () {
+    $config = new ConfigRepository([
+        'vite' => [],
+    ]);
+
+    $vite = new Vite($config, $this->paths);
+
+    expect(fn () => $vite->useDevServer())
+        ->toThrow(ViteConfigurationException::class, 'vite.useDevServer');
+});
+
+test('vite dev server tags include vite client and entry', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'devServerUrl' => 'http://localhost:5173',
+            'devServerStylesheets' => [
+                'app/web/resources/css/app.css',
+            ],
+            'useDevServer' => true,
+        ],
+    ]);
+
+    $vite = new Vite($config, $this->paths);
+    $tags = $vite->headTags('app/web/resources/js/app.js');
+
+    expect($tags)->toContain('@vite/client');
+    expect($tags)->toContain('app/web/resources/js/app.js');
+    expect($tags)->toContain('rel="stylesheet"');
+    expect($tags)->toContain('app/web/resources/css/app.css');
+    expect($tags)->not->toContain('@react-refresh');
+});
+
+test('vite throws when the dev server url is missing in dev mode', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'devServerUrl' => '',
+            'useDevServer' => true,
+            'devServerStylesheets' => [],
+        ],
+    ]);
+
+    $vite = new Vite($config, $this->paths);
+
+    expect(fn () => $vite->headTags('app/web/resources/js/app.js'))
+        ->toThrow(ViteConfigurationException::class, 'vite.devServerUrl');
+});
+
+test('vite dev server tags use the configured dev server url', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'devServerUrl' => 'http://localhost:5174',
+            'devServerStylesheets' => [],
+            'useDevServer' => true,
+        ],
+    ]);
+
+    $vite = new Vite($config, $this->paths);
+    $tags = $vite->headTags('app/react-web/resources/js/app.jsx');
+
+    expect($tags)->toContain('http://localhost:5174/@vite/client');
+    expect($tags)->toContain('http://localhost:5174/app/react-web/resources/js/app.jsx');
+    expect($tags)->toContain('http://localhost:5174/@react-refresh');
+    expect($tags)->toContain('window.$RefreshReg$');
+    expect($tags)->not->toContain('localhost:5173');
+});
+
+test('vite dev server tags skip react refresh preamble for svelte entries', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'devServerUrl' => 'http://localhost:5173',
+            'devServerStylesheets' => [],
+            'useDevServer' => true,
+        ],
+    ]);
+
+    $vite = new Vite($config, $this->paths);
+    $tags = $vite->headTags('app/svelte-web/resources/js/app.js');
+
+    expect($tags)->toContain('app/svelte-web/resources/js/app.js');
+    expect($tags)->not->toContain('@react-refresh');
+    expect($tags)->not->toContain('window.$RefreshReg$');
+});
+
+test('vite returns css and js tags from a production manifest', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'entry' => 'app/web/resources/js/app.js',
+            'buildDirectory' => 'build',
+            'manifestFilename' => '.vite/manifest.json',
+            'useDevServer' => false,
+        ],
+    ]);
+
+    $paths = makeProjectPathsWithManifest([
+        'app/web/resources/js/app.js' => [
+            'file' => 'assets/app.123.js',
+            'css' => ['assets/app.456.css'],
+        ],
+    ]);
+
+    $tags = (new Vite($config, $paths))->headTags();
+
+    expect($tags)->toContain('<link rel="stylesheet" href="/build/assets/app.456.css">');
+    expect($tags)->toContain('<script type="module" src="/build/assets/app.123.js"></script>');
+});
+
+test('vite includes imported chunk css and modulepreload tags from a production manifest', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'entry' => 'app/web/resources/js/app.js',
+            'buildDirectory' => 'build',
+            'manifestFilename' => '.vite/manifest.json',
+            'useDevServer' => false,
+        ],
+    ]);
+
+    $paths = makeProjectPathsWithManifest([
+        'app/web/resources/js/app.js' => [
+            'file' => 'assets/app.123.js',
+            'css' => ['assets/app.456.css'],
+            'imports' => ['_shared.js', '_nested.js'],
+        ],
+        '_shared.js' => [
+            'file' => 'assets/shared.789.js',
+            'css' => ['assets/shared.789.css'],
+            'imports' => ['_nested.js'],
+        ],
+        '_nested.js' => [
+            'file' => 'assets/nested.999.js',
+            'css' => ['assets/nested.999.css'],
+        ],
+    ]);
+
+    $tags = (new Vite($config, $paths))->headTags();
+
+    expect($tags)->toContain('<link rel="stylesheet" href="/build/assets/app.456.css">');
+    expect($tags)->toContain('<link rel="stylesheet" href="/build/assets/shared.789.css">');
+    expect($tags)->toContain('<link rel="stylesheet" href="/build/assets/nested.999.css">');
+    expect($tags)->toContain('<script type="module" src="/build/assets/app.123.js"></script>');
+    expect($tags)->toContain('<link rel="modulepreload" href="/build/assets/shared.789.js">');
+    expect($tags)->toContain('<link rel="modulepreload" href="/build/assets/nested.999.js">');
+    expect(substr_count($tags, 'assets/nested.999.css'))->toBe(1);
+});
+
+test('vite reports invalid manifests and missing entries', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'entry' => 'app/web/resources/js/app.js',
+            'buildDirectory' => 'build',
+            'manifestFilename' => '.vite/manifest.json',
+            'useDevServer' => false,
+        ],
+    ]);
+
+    $invalidManifestTags = (new Vite($config, makeProjectPathsWithManifest('not-json')))
+        ->headTags();
+
+    $missingEntryTags = (new Vite($config, makeProjectPathsWithManifest([])))
+        ->headTags();
+
+    expect($invalidManifestTags)->toContain('Vite manifest is invalid');
+    expect($missingEntryTags)->toContain("Vite entry 'app/web/resources/js/app.js' not found");
+});

--- a/packages/vite/tests/ViteTest.php
+++ b/packages/vite/tests/ViteTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Marko\Config\ConfigRepository;
 use Marko\Core\Path\ProjectPaths;
 use Marko\Vite\Exceptions\ViteConfigurationException;
+use Marko\Vite\Exceptions\ViteManifestException;
 use Marko\Vite\Vite;
 
 beforeEach(function () {
@@ -26,7 +27,7 @@ function makeProjectPathsWithManifest(array|string $manifest): ProjectPaths
     return new ProjectPaths($basePath);
 }
 
-test('vite returns manifest not found when manifest is missing', function () {
+test('vite throws when the production manifest is missing', function () {
     $config = new ConfigRepository([
         'vite' => [
             'entry' => 'app/web/resources/js/app.js',
@@ -37,9 +38,9 @@ test('vite returns manifest not found when manifest is missing', function () {
     ]);
 
     $vite = new Vite($config, $this->paths);
-    $tags = $vite->headTags();
 
-    expect($tags)->toContain('Vite manifest not found');
+    expect(fn () => $vite->headTags())
+        ->toThrow(ViteManifestException::class, 'Vite manifest not found');
 });
 
 test('vite detects dev server from config', function () {
@@ -65,9 +66,9 @@ test('vite uses the configured default entry when no entry is provided', functio
     ]);
 
     $vite = new Vite($config, $this->paths);
-    $tags = $vite->headTags();
 
-    expect($tags)->toContain('Vite manifest not found');
+    expect(fn () => $vite->headTags())
+        ->toThrow(ViteManifestException::class, 'Vite manifest not found');
 });
 
 test('vite throws when no default entry is configured', function () {
@@ -228,7 +229,7 @@ test('vite includes imported chunk css and modulepreload tags from a production 
     expect(substr_count($tags, 'assets/nested.999.css'))->toBe(1);
 });
 
-test('vite reports invalid manifests and missing entries', function () {
+test('vite throws when the production manifest is invalid json', function () {
     $config = new ConfigRepository([
         'vite' => [
             'entry' => 'app/web/resources/js/app.js',
@@ -238,12 +239,24 @@ test('vite reports invalid manifests and missing entries', function () {
         ],
     ]);
 
-    $invalidManifestTags = (new Vite($config, makeProjectPathsWithManifest('not-json')))
-        ->headTags();
+    $vite = new Vite($config, makeProjectPathsWithManifest('not-json'));
 
-    $missingEntryTags = (new Vite($config, makeProjectPathsWithManifest([])))
-        ->headTags();
+    expect(fn () => $vite->headTags())
+        ->toThrow(ViteManifestException::class, 'is not valid JSON');
+});
 
-    expect($invalidManifestTags)->toContain('Vite manifest is invalid');
-    expect($missingEntryTags)->toContain("Vite entry 'app/web/resources/js/app.js' not found");
+test('vite throws when the configured entry is not in the manifest', function () {
+    $config = new ConfigRepository([
+        'vite' => [
+            'entry' => 'app/web/resources/js/app.js',
+            'buildDirectory' => 'build',
+            'manifestFilename' => '.vite/manifest.json',
+            'useDevServer' => false,
+        ],
+    ]);
+
+    $vite = new Vite($config, makeProjectPathsWithManifest([]));
+
+    expect(fn () => $vite->headTags())
+        ->toThrow(ViteManifestException::class, 'app/web/resources/js/app.js');
 });

--- a/tests/IntegrationVerificationTest.php
+++ b/tests/IntegrationVerificationTest.php
@@ -11,9 +11,9 @@ $packages = array_values(array_filter(
 ));
 
 it(
-    'validates all 71 package composer.json files are valid JSON with required keys (name, require) via structural check',
+    'validates all 72 package composer.json files are valid JSON with required keys (name, require) via structural check',
     function () use ($packagesRoot, $packages): void {
-        expect($packages)->toHaveCount(71);
+        expect($packages)->toHaveCount(72);
     
         foreach ($packages as $package) {
             $file = $packagesRoot . '/' . $package . '/composer.json';
@@ -223,7 +223,7 @@ it('verifies all marko/* dependencies use self.version constraint', function () 
 });
 
 it('verifies every package directory has a .gitattributes file', function () use ($packagesRoot, $packages): void {
-    expect($packages)->toHaveCount(71);
+    expect($packages)->toHaveCount(72);
 
     foreach ($packages as $package) {
         $path = $packagesRoot . '/' . $package . '/.gitattributes';
@@ -232,7 +232,7 @@ it('verifies every package directory has a .gitattributes file', function () use
 });
 
 it('verifies every package directory has a LICENSE file', function () use ($packagesRoot, $packages): void {
-    expect($packages)->toHaveCount(71);
+    expect($packages)->toHaveCount(72);
 
     foreach ($packages as $package) {
         $path = $packagesRoot . '/' . $package . '/LICENSE';

--- a/tests/PackagingTest.php
+++ b/tests/PackagingTest.php
@@ -9,8 +9,8 @@ $packages = array_values(array_filter(
     fn(string $entry): bool => $entry !== '.' && $entry !== '..' && is_dir($packagesRoot . '/' . $entry),
 ));
 
-it('creates .gitattributes in all 71 package directories', function () use ($packagesRoot, $packages): void {
-    expect($packages)->toHaveCount(71);
+it('creates .gitattributes in all 72 package directories', function () use ($packagesRoot, $packages): void {
+    expect($packages)->toHaveCount(72);
 
     foreach ($packages as $package) {
         $path = $packagesRoot . '/' . $package . '/.gitattributes';
@@ -64,8 +64,8 @@ it('creates or updates root .gitattributes for the monorepo', function (): void 
         ->toContain('eol=lf');
 });
 
-it('creates LICENSE (MIT) in all 71 package directories with copyright Devtomic LLC', function () use ($packagesRoot, $packages): void {
-    expect($packages)->toHaveCount(71);
+it('creates LICENSE (MIT) in all 72 package directories with copyright Devtomic LLC', function () use ($packagesRoot, $packages): void {
+    expect($packages)->toHaveCount(72);
 
     foreach ($packages as $package) {
         $path = $packagesRoot . '/' . $package . '/LICENSE';


### PR DESCRIPTION
## Summary

This is PR 1/5 in the stacked package-import sequence for Marko Vite + Inertia packages.

Preceding dependency PR: none. This PR starts the stack from `upstream/develop`.

Adds `marko/vite` as a monorepo package under `packages/vite`, registers it in root Composer metadata, and imports the package tests without standalone package tooling files.

## Maintainer Feedback Addressed

- Config-loading failures are loud through package exceptions instead of falling back silently.
- Standalone tooling files are not imported.
- Package-local Composer scripts and redundant tooling dev dependencies are removed.
- `marko/env` remains a runtime dependency because `config/vite.php` uses `env()`.

## Test Plan

- `composer validate --strict --no-check-lock`
- `vendor/bin/pest tests/IntegrationVerificationTest.php tests/PackagingTest.php packages/vite/tests --colors=never`
- `composer test -- --colors=never`

Note: `composer cs:check` is currently blocked by an existing monorepo PHPCS path issue: `The file "demo/app" does not exist.`