### PR TITLE
refactor: preference discovery and class extraction logic

### DIFF
--- a/packages/core/src/Application.php
+++ b/packages/core/src/Application.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Marko\Core;
 
 use Marko\Core\Attributes\Plugin;
-use Marko\Core\Attributes\Preference;
 use Marko\Core\Command\CommandDiscovery;
 use Marko\Core\Command\CommandRegistry;
 use Marko\Core\Command\CommandRunner;
@@ -235,34 +234,22 @@ class Application
     }
 
     /**
-     * @throws ReflectionException|PreferenceConflictException
+     * @throws PreferenceConflictException
      */
     private function discoverPreferences(): void
     {
-        $preferenceDiscovery = new PreferenceDiscovery();
+        $preferenceDiscovery = new PreferenceDiscovery($this->classFileParser);
 
         foreach ($this->modules as $module) {
-            $files = $preferenceDiscovery->discoverInModule($module);
+            $records = $preferenceDiscovery->discoverInModule($module);
 
-            foreach ($files as $file) {
-                $className = $this->classFileParser->extractClassName($file);
-                if ($className === null) {
-                    continue;
-                }
-
-                if (!$this->classFileParser->loadClass($file, $className)) {
-                    continue;
-                }
-
-                $reflection = new ReflectionClass($className);
-                $attributes = $reflection->getAttributes(Preference::class);
-
-                if (empty($attributes)) {
-                    continue;
-                }
-
-                $preference = $attributes[0]->newInstance();
-                $this->preferenceRegistry->register($preference->replaces, $className, $module->name, $module->source);
+            foreach ($records as $record) {
+                $this->preferenceRegistry->register(
+                    $record->replaces,
+                    $record->replacement,
+                    $module->name,
+                    $module->source,
+                );
             }
         }
     }

--- a/packages/core/src/Container/PreferenceDiscovery.php
+++ b/packages/core/src/Container/PreferenceDiscovery.php
@@ -4,23 +4,24 @@ declare(strict_types=1);
 
 namespace Marko\Core\Container;
 
+use Marko\Core\Attributes\Preference;
 use Marko\Core\Discovery\ClassFileParser;
 use Marko\Core\Module\ModuleManifest;
 use ReflectionClass;
 
 class PreferenceDiscovery
 {
-    private ClassFileParser $classFileParser;
-
-    public function __construct(ClassFileParser $classFileParser)
-    {
-        $this->classFileParser = $classFileParser;
-    }
+    public function __construct(
+        private readonly ClassFileParser $classFileParser,
+    ) {}
 
     /**
-     * Discover preference files in a module's src directory.
+     * Discover preferences in a module's src directory.
      *
-     * @return array<string> List of absolute paths to PHP files containing preferences
+     * Scans PHP files for classes with the #[Preference] attribute and returns
+     * structured records ready for registration in PreferenceRegistry.
+     *
+     * @return array<PreferenceRecord>
      */
     public function discoverInModule(ModuleManifest $manifest): array
     {
@@ -30,33 +31,40 @@ class PreferenceDiscovery
             return [];
         }
 
-        $preferenceFiles = [];
+        $records = [];
 
         foreach ($this->classFileParser->findPhpFiles($srcDir) as $file) {
             $filepath = $file->getPathname();
 
-            // Extract the fully qualified class name from the file
             $className = $this->classFileParser->extractClassName($filepath);
-            if (!$className) {
+            if ($className === null) {
                 continue;
             }
 
-            // Try to load the class
             if (!$this->classFileParser->loadClass($filepath, $className)) {
                 continue;
             }
 
-            // Check if class exists and has the #[Preference] attribute
-            if (class_exists($className) || interface_exists($className) || trait_exists($className)) {
-                $reflector = new ReflectionClass($className);
-                $attributes = $reflector->getAttributes('Preference');
-
-                if (!empty($attributes)) {
-                    $preferenceFiles[] = $filepath;
-                }
+            if (!class_exists($className)) {
+                continue;
             }
+
+            $reflector = new ReflectionClass($className);
+            $attributes = $reflector->getAttributes(Preference::class);
+
+            if (empty($attributes)) {
+                continue;
+            }
+
+            $preference = $attributes[0]->newInstance();
+
+            $records[] = new PreferenceRecord(
+                replacement: $className,
+                replaces: $preference->replaces,
+                filePath: $filepath,
+            );
         }
 
-        return array_unique($preferenceFiles);
+        return $records;
     }
 }

--- a/packages/core/src/Container/PreferenceDiscovery.php
+++ b/packages/core/src/Container/PreferenceDiscovery.php
@@ -16,28 +16,67 @@ class PreferenceDiscovery
      *
      * @return array<string> List of absolute paths to PHP files containing preferences
      */
-    public function discoverInModule(
-        ModuleManifest $manifest,
-    ): array {
+    public function discoverInModule(ModuleManifest $manifest): array
+    {
         $srcDir = $manifest->path . '/src';
-
+    
         if (!is_dir($srcDir)) {
             return [];
         }
-
+    
         $preferenceFiles = [];
         $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($srcDir),
+            new RecursiveDirectoryIterator($srcDir, RecursiveDirectoryIterator::SKIP_DOTS)
         );
-        $phpFiles = new RegexIterator($iterator, '/\.php$/');
-
+        $phpFiles = new RegexIterator($iterator, '/\.php$/i');
+    
         foreach ($phpFiles as $file) {
-            $content = file_get_contents($file->getPathname());
-            if ($content !== false && str_contains($content, '#[Preference')) {
-                $preferenceFiles[] = $file->getPathname();
+            $filepath = $file->getPathname();
+    
+            // Extract potential class name from filename
+            $className = $this->getClassNameFromFile($filepath);
+            if (!$className) {
+                continue;
+            }
+    
+            // Try to autoload or manually include the class
+            if (!class_exists($className, false)) {
+                require_once $filepath;
+            }
+    
+            // Check if class exists and has the #[Preference] attribute
+            if (class_exists($className) || interface_exists($className) || trait_exists($className)) {
+                $reflector = new ReflectionClass($className);
+                $attributes = $reflector->getAttributes('Preference');
+    
+                if (!empty($attributes)) {
+                    $preferenceFiles[] = $filepath;
+                }
             }
         }
+    
+        return array_unique($preferenceFiles);
+    }
 
-        return $preferenceFiles;
+    private function getClassNameFromFile(string $filepath): ?string
+    {
+        $contents = file_get_contents($filepath);
+        if ($contents === false) {
+            return null;
+        }
+    
+        // Basic heuristic to extract namespace + class name
+        $nsMatches = [];
+        $classMatches = [];
+    
+        preg_match('/namespace\s+([^;]+);/', $contents, $nsMatches);
+        preg_match('/\bclass\s+([a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)/', $contents, $classMatches);
+    
+        if (!isset($classMatches[1])) {
+            return null;
+        }
+    
+        $namespace = $nsMatches[1] ?? '';
+        return ltrim($namespace . '\\' . $classMatches[1], '\\');
     }
 }

--- a/packages/core/src/Container/PreferenceDiscovery.php
+++ b/packages/core/src/Container/PreferenceDiscovery.php
@@ -36,16 +36,19 @@ class PreferenceDiscovery
         foreach ($this->classFileParser->findPhpFiles($srcDir) as $file) {
             $filepath = $file->getPathname();
 
+            // Cheap pre-filter: skip files that obviously don't declare a preference
+            // before paying for class extraction, autoload, and reflection.
+            $contents = file_get_contents($filepath);
+            if ($contents === false || !str_contains($contents, '#[Preference')) {
+                continue;
+            }
+
             $className = $this->classFileParser->extractClassName($filepath);
             if ($className === null) {
                 continue;
             }
 
             if (!$this->classFileParser->loadClass($filepath, $className)) {
-                continue;
-            }
-
-            if (!class_exists($className)) {
                 continue;
             }
 
@@ -61,7 +64,6 @@ class PreferenceDiscovery
             $records[] = new PreferenceRecord(
                 replacement: $className,
                 replaces: $preference->replaces,
-                filePath: $filepath,
             );
         }
 

--- a/packages/core/src/Container/PreferenceDiscovery.php
+++ b/packages/core/src/Container/PreferenceDiscovery.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Marko\Core\Container;
 
+use Marko\Core\Discovery\ClassFileParser;
 use Marko\Core\Module\ModuleManifest;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use RegexIterator;
+use ReflectionClass;
 
 class PreferenceDiscovery
 {
+    private ClassFileParser $classFileParser;
+
+    public function __construct(ClassFileParser $classFileParser)
+    {
+        $this->classFileParser = $classFileParser;
+    }
+
     /**
      * Discover preference files in a module's src directory.
      *
@@ -19,64 +25,38 @@ class PreferenceDiscovery
     public function discoverInModule(ModuleManifest $manifest): array
     {
         $srcDir = $manifest->path . '/src';
-    
+
         if (!is_dir($srcDir)) {
             return [];
         }
-    
+
         $preferenceFiles = [];
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($srcDir, RecursiveDirectoryIterator::SKIP_DOTS)
-        );
-        $phpFiles = new RegexIterator($iterator, '/\.php$/i');
-    
-        foreach ($phpFiles as $file) {
+
+        foreach ($this->classFileParser->findPhpFiles($srcDir) as $file) {
             $filepath = $file->getPathname();
-    
-            // Extract potential class name from filename
-            $className = $this->getClassNameFromFile($filepath);
+
+            // Extract the fully qualified class name from the file
+            $className = $this->classFileParser->extractClassName($filepath);
             if (!$className) {
                 continue;
             }
-    
-            // Try to autoload or manually include the class
-            if (!class_exists($className, false)) {
-                require_once $filepath;
+
+            // Try to load the class
+            if (!$this->classFileParser->loadClass($filepath, $className)) {
+                continue;
             }
-    
+
             // Check if class exists and has the #[Preference] attribute
             if (class_exists($className) || interface_exists($className) || trait_exists($className)) {
                 $reflector = new ReflectionClass($className);
                 $attributes = $reflector->getAttributes('Preference');
-    
+
                 if (!empty($attributes)) {
                     $preferenceFiles[] = $filepath;
                 }
             }
         }
-    
-        return array_unique($preferenceFiles);
-    }
 
-    private function getClassNameFromFile(string $filepath): ?string
-    {
-        $contents = file_get_contents($filepath);
-        if ($contents === false) {
-            return null;
-        }
-    
-        // Basic heuristic to extract namespace + class name
-        $nsMatches = [];
-        $classMatches = [];
-    
-        preg_match('/namespace\s+([^;]+);/', $contents, $nsMatches);
-        preg_match('/\bclass\s+([a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)/', $contents, $classMatches);
-    
-        if (!isset($classMatches[1])) {
-            return null;
-        }
-    
-        $namespace = $nsMatches[1] ?? '';
-        return ltrim($namespace . '\\' . $classMatches[1], '\\');
+        return array_unique($preferenceFiles);
     }
 }

--- a/packages/core/src/Container/PreferenceRecord.php
+++ b/packages/core/src/Container/PreferenceRecord.php
@@ -13,11 +13,9 @@ readonly class PreferenceRecord
     /**
      * @param class-string $replacement The class carrying the #[Preference] attribute
      * @param class-string $replaces The class being replaced
-     * @param string $filePath Absolute path to the source file
      */
     public function __construct(
         public string $replacement,
         public string $replaces,
-        public string $filePath,
     ) {}
 }

--- a/packages/core/src/Container/PreferenceRecord.php
+++ b/packages/core/src/Container/PreferenceRecord.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Core\Container;
+
+/**
+ * Represents a discovered preference: a class annotated with #[Preference]
+ * that replaces another class.
+ */
+readonly class PreferenceRecord
+{
+    /**
+     * @param class-string $replacement The class carrying the #[Preference] attribute
+     * @param class-string $replaces The class being replaced
+     * @param string $filePath Absolute path to the source file
+     */
+    public function __construct(
+        public string $replacement,
+        public string $replaces,
+        public string $filePath,
+    ) {}
+}

--- a/packages/core/src/Container/PreferenceRegistry.php
+++ b/packages/core/src/Container/PreferenceRegistry.php
@@ -73,6 +73,7 @@ class PreferenceRegistry
      *
      * @param class-string $original
      * @return class-string|null
+     * @throws PreferenceConflictException When a circular preference chain is detected
      */
     public function getPreference(
         string $original,
@@ -82,8 +83,14 @@ class PreferenceRegistry
         }
 
         // Follow the preference chain to find the final replacement
+        $visited = [$original => true];
         $current = $this->preferences[$original];
+
         while (isset($this->preferences[$current])) {
+            if (isset($visited[$current])) {
+                throw PreferenceConflictException::circularPreference($original, $current);
+            }
+            $visited[$current] = true;
             $current = $this->preferences[$current];
         }
 

--- a/packages/core/src/Exceptions/PreferenceConflictException.php
+++ b/packages/core/src/Exceptions/PreferenceConflictException.php
@@ -21,4 +21,15 @@ class PreferenceConflictException extends MarkoException
             suggestion: 'Only one module at the same priority level can define a Preference for a class. Move one Preference to a higher-priority module (app/ overrides modules/ overrides vendor/) or remove the duplicate',
         );
     }
+
+    public static function circularPreference(
+        string $original,
+        string $cycleTarget,
+    ): self {
+        return new self(
+            message: "Circular preference detected: '$cycleTarget' is part of a cycle starting from '$original'",
+            context: "While resolving preference chain for '$original'",
+            suggestion: 'Check your #[Preference] attributes for circular references (e.g., A replaces B and B replaces A) and remove the cycle',
+        );
+    }
 }

--- a/packages/core/tests/Unit/Container/PreferenceTest.php
+++ b/packages/core/tests/Unit/Container/PreferenceTest.php
@@ -6,6 +6,7 @@ use Marko\Core\Attributes\Preference;
 use Marko\Core\Container\Container;
 use Marko\Core\Container\PreferenceDiscovery;
 use Marko\Core\Container\PreferenceRegistry;
+use Marko\Core\Discovery\ClassFileParser;
 use Marko\Core\Exceptions\PreferenceConflictException;
 use Marko\Core\Module\ModuleManifest;
 
@@ -66,7 +67,7 @@ PHP;
         path: $tempDir,
     );
 
-    $discovery = new PreferenceDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PreferenceDiscovery(new ClassFileParser());
     $records = $discovery->discoverInModule($manifest);
 
     expect($records)
@@ -74,8 +75,7 @@ PHP;
         ->toHaveCount(1);
 
     expect($records[0]->replacement)->toEndWith('CustomStdClass');
-    expect($records[0]->replaces)->toBe(\stdClass::class);
-    expect($records[0]->filePath)->toEndWith('CustomStdClass.php');
+    expect($records[0]->replaces)->toBe(stdClass::class);
 
     cleanupPreferenceTestDirectory($tempDir);
 });

--- a/packages/core/tests/Unit/Container/PreferenceTest.php
+++ b/packages/core/tests/Unit/Container/PreferenceTest.php
@@ -66,13 +66,16 @@ PHP;
         path: $tempDir,
     );
 
-    $discovery = new PreferenceDiscovery();
-    $preferenceFiles = $discovery->discoverInModule($manifest);
+    $discovery = new PreferenceDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $records = $discovery->discoverInModule($manifest);
 
-    expect($preferenceFiles)
+    expect($records)
         ->toBeArray()
-        ->toHaveCount(1)
-        ->and($preferenceFiles[0])->toEndWith('CustomStdClass.php');
+        ->toHaveCount(1);
+
+    expect($records[0]->replacement)->toEndWith('CustomStdClass');
+    expect($records[0]->replaces)->toBe(\stdClass::class);
+    expect($records[0]->filePath)->toEndWith('CustomStdClass.php');
 
     cleanupPreferenceTestDirectory($tempDir);
 });
@@ -186,3 +189,20 @@ it('ignores lower-priority preference when higher-priority already registered', 
     expect($registry->getPreference(OriginalService::class))
         ->toBe(FinalPreferredService::class);
 });
+
+it('throws PreferenceConflictException for circular preference chains', function (): void {
+    $registry = new PreferenceRegistry();
+
+    // PreferredService replaces OriginalService
+    $registry->register(
+        original: OriginalService::class,
+        replacement: PreferredService::class,
+    );
+    // OriginalService replaces PreferredService — creates a cycle
+    $registry->register(
+        original: PreferredService::class,
+        replacement: OriginalService::class,
+    );
+
+    $registry->getPreference(OriginalService::class);
+})->throws(PreferenceConflictException::class, 'Circular preference detected');


### PR DESCRIPTION
### What

Refactors preference discovery so `Application` no longer duplicates class extraction and reflection that `PreferenceDiscovery` is better positioned to own.

### Changes

- `PreferenceDiscovery::discoverInModule()` now returns `PreferenceRecord[]` (structured data) instead of raw file paths — extraction, autoload, and reflection live alongside the directory walk.
- `Application::discoverPreferences()` simplified to iterate records and register.
- `PreferenceDiscovery` keeps the cheap `str_contains('#[Preference')` pre-filter so non-preference files don't pay for `extractClassName` + `loadClass` + `ReflectionClass`.
- Add circular preference chain detection in `PreferenceRegistry::getPreference()` — the chain-following loop was previously unbounded.
- New `PreferenceRecord` value object (`replacement`, `replaces`).

### Follow-up

`PluginDiscovery` has the same shape (returns file paths, `Application` re-does extraction/reflection). Worth refactoring to return structured data in a separate PR for consistency.