### PR TITLE
refactor: offload plugin discovery to PluginDiscovery class

### DIFF
--- a/packages/core/src/Application.php
+++ b/packages/core/src/Application.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Marko\Core;
 
-use Marko\Core\Attributes\Plugin;
 use Marko\Core\Command\CommandDiscovery;
 use Marko\Core\Command\CommandRegistry;
 use Marko\Core\Command\CommandRunner;
@@ -45,7 +44,6 @@ use Marko\Routing\Middleware\MiddlewareInterface;
 use Marko\Routing\Router;
 use Marko\Routing\RoutingBootstrapper;
 use Psr\Container\ContainerExceptionInterface;
-use ReflectionClass;
 use ReflectionException;
 use RuntimeException;
 
@@ -238,7 +236,7 @@ class Application
      */
     private function discoverPreferences(): void
     {
-        $preferenceDiscovery = new PreferenceDiscovery($this->classFileParser);
+        $preferenceDiscovery = new PreferenceDiscovery();
 
         foreach ($this->modules as $module) {
             $records = $preferenceDiscovery->discoverInModule($module);
@@ -259,7 +257,7 @@ class Application
      */
     private function discoverPlugins(): void
     {
-        $pluginDiscovery = new PluginDiscovery($this->classFileParser);
+        $pluginDiscovery = new PluginDiscovery();
 
         foreach ($this->modules as $module) {
             $definitions = $pluginDiscovery->discoverInModule($module);

--- a/packages/core/src/Application.php
+++ b/packages/core/src/Application.php
@@ -239,7 +239,7 @@ class Application
      */
     private function discoverPreferences(): void
     {
-        $preferenceDiscovery = new PreferenceDiscovery();
+        $preferenceDiscovery = new PreferenceDiscovery($this->classFileParser);
 
         foreach ($this->modules as $module) {
             $files = $preferenceDiscovery->discoverInModule($module);
@@ -272,30 +272,12 @@ class Application
      */
     private function discoverPlugins(): void
     {
-        $pluginDiscovery = new PluginDiscovery();
+        $pluginDiscovery = new PluginDiscovery($this->classFileParser);
 
         foreach ($this->modules as $module) {
-            $files = $pluginDiscovery->discoverInModule($module);
+            $definitions = $pluginDiscovery->discoverInModule($module);
 
-            foreach ($files as $file) {
-                $className = $this->classFileParser->extractClassName($file);
-                if ($className === null) {
-                    continue;
-                }
-
-                if (!$this->classFileParser->loadClass($file, $className)) {
-                    continue;
-                }
-
-                // Verify the class actually has the #[Plugin] attribute
-                $reflection = new ReflectionClass($className);
-                $pluginAttributes = $reflection->getAttributes(Plugin::class);
-
-                if (empty($pluginAttributes)) {
-                    continue;
-                }
-
-                $definition = $pluginDiscovery->parsePluginClass($className);
+            foreach ($definitions as $definition) {
                 $this->pluginRegistry->register($definition);
             }
         }

--- a/packages/core/src/Container/PreferenceDiscovery.php
+++ b/packages/core/src/Container/PreferenceDiscovery.php
@@ -11,10 +11,6 @@ use ReflectionClass;
 
 class PreferenceDiscovery
 {
-    public function __construct(
-        private readonly ClassFileParser $classFileParser,
-    ) {}
-
     /**
      * Discover preferences in a module's src directory.
      *
@@ -32,8 +28,9 @@ class PreferenceDiscovery
         }
 
         $records = [];
+        $parser = new ClassFileParser();
 
-        foreach ($this->classFileParser->findPhpFiles($srcDir) as $file) {
+        foreach ($parser->findPhpFiles($srcDir) as $file) {
             $filepath = $file->getPathname();
 
             // Cheap pre-filter: skip files that obviously don't declare a preference
@@ -43,12 +40,12 @@ class PreferenceDiscovery
                 continue;
             }
 
-            $className = $this->classFileParser->extractClassName($filepath);
+            $className = $parser->extractClassName($filepath);
             if ($className === null) {
                 continue;
             }
 
-            if (!$this->classFileParser->loadClass($filepath, $className)) {
+            if (!$parser->loadClass($filepath, $className)) {
                 continue;
             }
 

--- a/packages/core/src/Plugin/PluginDiscovery.php
+++ b/packages/core/src/Plugin/PluginDiscovery.php
@@ -7,44 +7,64 @@ namespace Marko\Core\Plugin;
 use Marko\Core\Attributes\After;
 use Marko\Core\Attributes\Before;
 use Marko\Core\Attributes\Plugin;
+use Marko\Core\Discovery\ClassFileParser;
 use Marko\Core\Exceptions\PluginException;
 use Marko\Core\Module\ModuleManifest;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use ReflectionClass;
 use ReflectionException;
-use RegexIterator;
 
 class PluginDiscovery
 {
+    public function __construct(
+        private readonly ClassFileParser $classFileParser,
+    ) {}
+
     /**
-     * Discover plugin files in a module's src directory.
+     * Discover plugin definitions in a module's src directory.
      *
-     * @return array<string> List of absolute paths to PHP files containing plugins
+     * Scans PHP files for classes with the #[Plugin] attribute and returns
+     * fully parsed PluginDefinition instances ready for registration.
+     *
+     * @return array<PluginDefinition>
+     * @throws PluginException|ReflectionException
      */
-    public function discoverInModule(
-        ModuleManifest $manifest,
-    ): array {
+    public function discoverInModule(ModuleManifest $manifest): array
+    {
         $srcDir = $manifest->path . '/src';
 
         if (!is_dir($srcDir)) {
             return [];
         }
 
-        $pluginFiles = [];
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($srcDir),
-        );
-        $phpFiles = new RegexIterator($iterator, '/\.php$/');
+        $definitions = [];
 
-        foreach ($phpFiles as $file) {
-            $content = file_get_contents($file->getPathname());
-            if ($content !== false && str_contains($content, '#[Plugin')) {
-                $pluginFiles[] = $file->getPathname();
+        foreach ($this->classFileParser->findPhpFiles($srcDir) as $file) {
+            $filepath = $file->getPathname();
+
+            $className = $this->classFileParser->extractClassName($filepath);
+            if ($className === null) {
+                continue;
             }
+
+            if (!$this->classFileParser->loadClass($filepath, $className)) {
+                continue;
+            }
+
+            if (!class_exists($className)) {
+                continue;
+            }
+
+            $reflector = new ReflectionClass($className);
+            $pluginAttributes = $reflector->getAttributes(Plugin::class);
+
+            if (empty($pluginAttributes)) {
+                continue;
+            }
+
+            $definitions[] = $this->parsePluginClass($className);
         }
 
-        return $pluginFiles;
+        return $definitions;
     }
 
     /**

--- a/packages/core/src/Plugin/PluginDiscovery.php
+++ b/packages/core/src/Plugin/PluginDiscovery.php
@@ -15,10 +15,6 @@ use ReflectionException;
 
 class PluginDiscovery
 {
-    public function __construct(
-        private readonly ClassFileParser $classFileParser,
-    ) {}
-
     /**
      * Discover plugin definitions in a module's src directory.
      *
@@ -37,20 +33,24 @@ class PluginDiscovery
         }
 
         $definitions = [];
+        $parser = new ClassFileParser();
 
-        foreach ($this->classFileParser->findPhpFiles($srcDir) as $file) {
+        foreach ($parser->findPhpFiles($srcDir) as $file) {
             $filepath = $file->getPathname();
 
-            $className = $this->classFileParser->extractClassName($filepath);
+            // Cheap pre-filter: skip files that obviously don't declare a plugin
+            // before paying for class extraction, autoload, and reflection.
+            $contents = file_get_contents($filepath);
+            if ($contents === false || !str_contains($contents, '#[Plugin')) {
+                continue;
+            }
+
+            $className = $parser->extractClassName($filepath);
             if ($className === null) {
                 continue;
             }
 
-            if (!$this->classFileParser->loadClass($filepath, $className)) {
-                continue;
-            }
-
-            if (!class_exists($className)) {
+            if (!$parser->loadClass($filepath, $className)) {
                 continue;
             }
 

--- a/packages/core/tests/Unit/Container/PreferenceTest.php
+++ b/packages/core/tests/Unit/Container/PreferenceTest.php
@@ -6,7 +6,6 @@ use Marko\Core\Attributes\Preference;
 use Marko\Core\Container\Container;
 use Marko\Core\Container\PreferenceDiscovery;
 use Marko\Core\Container\PreferenceRegistry;
-use Marko\Core\Discovery\ClassFileParser;
 use Marko\Core\Exceptions\PreferenceConflictException;
 use Marko\Core\Module\ModuleManifest;
 
@@ -67,7 +66,7 @@ PHP;
         path: $tempDir,
     );
 
-    $discovery = new PreferenceDiscovery(new ClassFileParser());
+    $discovery = new PreferenceDiscovery();
     $records = $discovery->discoverInModule($manifest);
 
     expect($records)

--- a/packages/core/tests/Unit/Plugin/PluginDiscoveryTest.php
+++ b/packages/core/tests/Unit/Plugin/PluginDiscoveryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Marko\Core\Attributes\After;
 use Marko\Core\Attributes\Before;
 use Marko\Core\Attributes\Plugin;
+use Marko\Core\Discovery\ClassFileParser;
 use Marko\Core\Exceptions\PluginException;
 use Marko\Core\Module\ModuleManifest;
 use Marko\Core\Plugin\PluginDefinition;
@@ -113,13 +114,16 @@ it('discovers plugin classes in module src directories', function (): void {
         path: $tempDir,
     );
 
-    $discovery = new PluginDiscovery();
-    $pluginFiles = $discovery->discoverInModule($manifest);
+    $discovery = new PluginDiscovery(new ClassFileParser());
+    $definitions = $discovery->discoverInModule($manifest);
 
-    expect($pluginFiles)
+    expect($definitions)
         ->toBeArray()
-        ->toHaveCount(1)
-        ->and($pluginFiles[0])->toEndWith('UserServicePlugin.php');
+        ->toHaveCount(1);
+
+    expect($definitions[0])
+        ->toBeInstanceOf(PluginDefinition::class)
+        ->and($definitions[0]->pluginClass)->toEndWith('UserServicePlugin');
 
     cleanupPluginTestDirectory($tempDir);
 });
@@ -153,13 +157,16 @@ it('discovers plugin classes in module src directories with new naming', functio
         path: $tempDir,
     );
 
-    $discovery = new PluginDiscovery();
-    $pluginFiles = $discovery->discoverInModule($manifest);
+    $discovery = new PluginDiscovery(new ClassFileParser());
+    $definitions = $discovery->discoverInModule($manifest);
 
-    expect($pluginFiles)
+    expect($definitions)
         ->toBeArray()
-        ->toHaveCount(1)
-        ->and($pluginFiles[0])->toEndWith('ProductServicePlugin.php');
+        ->toHaveCount(1);
+
+    expect($definitions[0])
+        ->toBeInstanceOf(PluginDefinition::class)
+        ->and($definitions[0]->pluginClass)->toEndWith('ProductServicePlugin');
 
     cleanupPluginTestDirectory($tempDir);
 });
@@ -186,7 +193,7 @@ class TargetServicePlugin
 }
 
 it('extracts target class from Plugin attribute', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition)
@@ -195,7 +202,7 @@ it('extracts target class from Plugin attribute', function (): void {
 });
 
 it('extracts target-method-keyed before methods from plugin class', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition->beforeMethods)
@@ -208,7 +215,7 @@ it('extracts target-method-keyed before methods from plugin class', function ():
 });
 
 it('extracts before methods with their sort orders', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition->beforeMethods)
@@ -218,7 +225,7 @@ it('extracts before methods with their sort orders', function (): void {
 });
 
 it('extracts target-method-keyed after methods from plugin class', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition->afterMethods)
@@ -231,7 +238,7 @@ it('extracts target-method-keyed after methods from plugin class', function (): 
 });
 
 it('extracts after methods with their sort orders', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition->afterMethods)
@@ -247,7 +254,7 @@ class NotAPlugin
 }
 
 it('throws PluginException when Plugin attribute missing target', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
 
     expect(fn () => $discovery->parsePluginClass(NotAPlugin::class))
         ->toThrow(PluginException::class);
@@ -266,14 +273,14 @@ class InvalidPluginWithBeforeAfter
 }
 
 it('throws PluginException when before/after method on non-plugin class', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
 
     expect(fn () => $discovery->validatePluginMethods(InvalidPluginWithBeforeAfter::class))
         ->toThrow(PluginException::class);
 });
 
 it('validates orphaned plugin methods still throws exception', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
 
     expect(fn () => $discovery->validatePluginMethods(InvalidPluginWithBeforeAfter::class))
         ->toThrow(PluginException::class);
@@ -299,7 +306,7 @@ class SimpleTargetPlugin
 }
 
 it('resolves target method from plugin method name when no method param', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(SimpleTargetPlugin::class);
 
     expect($definition->beforeMethods)
@@ -332,7 +339,7 @@ class ExplicitAfterPlugin
 }
 
 it('resolves target method from Before attribute method param', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(ExplicitBeforePlugin::class);
 
     expect($definition->beforeMethods)
@@ -342,7 +349,7 @@ it('resolves target method from Before attribute method param', function (): voi
 });
 
 it('resolves target method from After attribute method param', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(ExplicitAfterPlugin::class);
 
     expect($definition->afterMethods)
@@ -365,7 +372,7 @@ class MappingPlugin
 }
 
 it('builds PluginDefinition with correct target-to-plugin method mapping', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(MappingPlugin::class);
 
     expect($definition->pluginClass)->toBe(MappingPlugin::class)
@@ -395,7 +402,7 @@ class MixedPlugin
 }
 
 it('handles mixed standard and explicit method params in same plugin', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(MixedPlugin::class);
 
     expect($definition->beforeMethods)
@@ -427,7 +434,7 @@ class DuplicateBeforePlugin
 }
 
 it('throws PluginException when two before methods in same class target the same method', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
 
     expect(fn () => $discovery->parsePluginClass(DuplicateBeforePlugin::class))
         ->toThrow(PluginException::class);
@@ -451,7 +458,7 @@ class DuplicateAfterPlugin
 }
 
 it('throws PluginException when two after methods in same class target the same method', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
 
     expect(fn () => $discovery->parsePluginClass(DuplicateAfterPlugin::class))
         ->toThrow(PluginException::class);
@@ -475,7 +482,7 @@ class SameMethodBeforeAfterPlugin
 }
 
 it('allows before and after targeting the same method via method param in same class', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
     $definition = $discovery->parsePluginClass(SameMethodBeforeAfterPlugin::class);
 
     expect($definition->beforeMethods)->toHaveKey('save')
@@ -483,7 +490,7 @@ it('allows before and after targeting the same method via method param in same c
 });
 
 it('provides helpful error message with class and method names for intra-class conflict', function (): void {
-    $discovery = new PluginDiscovery();
+    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
 
     try {
         $discovery->parsePluginClass(DuplicateBeforePlugin::class);

--- a/packages/core/tests/Unit/Plugin/PluginDiscoveryTest.php
+++ b/packages/core/tests/Unit/Plugin/PluginDiscoveryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use Marko\Core\Attributes\After;
 use Marko\Core\Attributes\Before;
 use Marko\Core\Attributes\Plugin;
-use Marko\Core\Discovery\ClassFileParser;
 use Marko\Core\Exceptions\PluginException;
 use Marko\Core\Module\ModuleManifest;
 use Marko\Core\Plugin\PluginDefinition;
@@ -114,7 +113,7 @@ it('discovers plugin classes in module src directories', function (): void {
         path: $tempDir,
     );
 
-    $discovery = new PluginDiscovery(new ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definitions = $discovery->discoverInModule($manifest);
 
     expect($definitions)
@@ -157,7 +156,7 @@ it('discovers plugin classes in module src directories with new naming', functio
         path: $tempDir,
     );
 
-    $discovery = new PluginDiscovery(new ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definitions = $discovery->discoverInModule($manifest);
 
     expect($definitions)
@@ -193,7 +192,7 @@ class TargetServicePlugin
 }
 
 it('extracts target class from Plugin attribute', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition)
@@ -202,7 +201,7 @@ it('extracts target class from Plugin attribute', function (): void {
 });
 
 it('extracts target-method-keyed before methods from plugin class', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition->beforeMethods)
@@ -215,7 +214,7 @@ it('extracts target-method-keyed before methods from plugin class', function ():
 });
 
 it('extracts before methods with their sort orders', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition->beforeMethods)
@@ -225,7 +224,7 @@ it('extracts before methods with their sort orders', function (): void {
 });
 
 it('extracts target-method-keyed after methods from plugin class', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition->afterMethods)
@@ -238,7 +237,7 @@ it('extracts target-method-keyed after methods from plugin class', function (): 
 });
 
 it('extracts after methods with their sort orders', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(TargetServicePlugin::class);
 
     expect($definition->afterMethods)
@@ -254,7 +253,7 @@ class NotAPlugin
 }
 
 it('throws PluginException when Plugin attribute missing target', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
 
     expect(fn () => $discovery->parsePluginClass(NotAPlugin::class))
         ->toThrow(PluginException::class);
@@ -273,14 +272,14 @@ class InvalidPluginWithBeforeAfter
 }
 
 it('throws PluginException when before/after method on non-plugin class', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
 
     expect(fn () => $discovery->validatePluginMethods(InvalidPluginWithBeforeAfter::class))
         ->toThrow(PluginException::class);
 });
 
 it('validates orphaned plugin methods still throws exception', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
 
     expect(fn () => $discovery->validatePluginMethods(InvalidPluginWithBeforeAfter::class))
         ->toThrow(PluginException::class);
@@ -306,7 +305,7 @@ class SimpleTargetPlugin
 }
 
 it('resolves target method from plugin method name when no method param', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(SimpleTargetPlugin::class);
 
     expect($definition->beforeMethods)
@@ -339,7 +338,7 @@ class ExplicitAfterPlugin
 }
 
 it('resolves target method from Before attribute method param', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(ExplicitBeforePlugin::class);
 
     expect($definition->beforeMethods)
@@ -349,7 +348,7 @@ it('resolves target method from Before attribute method param', function (): voi
 });
 
 it('resolves target method from After attribute method param', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(ExplicitAfterPlugin::class);
 
     expect($definition->afterMethods)
@@ -372,7 +371,7 @@ class MappingPlugin
 }
 
 it('builds PluginDefinition with correct target-to-plugin method mapping', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(MappingPlugin::class);
 
     expect($definition->pluginClass)->toBe(MappingPlugin::class)
@@ -402,7 +401,7 @@ class MixedPlugin
 }
 
 it('handles mixed standard and explicit method params in same plugin', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(MixedPlugin::class);
 
     expect($definition->beforeMethods)
@@ -434,7 +433,7 @@ class DuplicateBeforePlugin
 }
 
 it('throws PluginException when two before methods in same class target the same method', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
 
     expect(fn () => $discovery->parsePluginClass(DuplicateBeforePlugin::class))
         ->toThrow(PluginException::class);
@@ -458,7 +457,7 @@ class DuplicateAfterPlugin
 }
 
 it('throws PluginException when two after methods in same class target the same method', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
 
     expect(fn () => $discovery->parsePluginClass(DuplicateAfterPlugin::class))
         ->toThrow(PluginException::class);
@@ -482,7 +481,7 @@ class SameMethodBeforeAfterPlugin
 }
 
 it('allows before and after targeting the same method via method param in same class', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
     $definition = $discovery->parsePluginClass(SameMethodBeforeAfterPlugin::class);
 
     expect($definition->beforeMethods)->toHaveKey('save')
@@ -490,7 +489,7 @@ it('allows before and after targeting the same method via method param in same c
 });
 
 it('provides helpful error message with class and method names for intra-class conflict', function (): void {
-    $discovery = new PluginDiscovery(new \Marko\Core\Discovery\ClassFileParser());
+    $discovery = new PluginDiscovery();
 
     try {
         $discovery->parsePluginClass(DuplicateBeforePlugin::class);


### PR DESCRIPTION
### What

Offloads plugin discovery logic into `PluginDiscovery` so `Application` doesn't duplicate the work. Follow-up to #44.

Also drops the `ClassFileParser` constructor injection that #44 introduced on `PreferenceDiscovery` — see "Constructor cleanup" below.

### Changes

- `PluginDiscovery::discoverInModule()` returns `PluginDefinition[]` (already-parsed) instead of raw file paths.
- Extraction + `loadClass` + reflection moves out of `Application::discoverPlugins()` into `PluginDiscovery`.
- `PluginDiscovery` keeps the cheap `str_contains('#[Plugin')` pre-filter so non-plugin files don't pay for extraction + autoload + reflection.
- `Application::discoverPlugins()` simplified to iterate definitions and register.

### Constructor cleanup

`PluginDiscovery` and `PreferenceDiscovery` no longer take `ClassFileParser` via constructor — they `new` one internally. The parser is a stateless utility class with one implementation that's never mocked, so the injection was ceremony: tests had to construct a parser inline just to satisfy the signature. Removing it cuts test boilerplate and avoids a public-API break for anyone who was instantiating these directly.

`Application` no longer threads `$this->classFileParser` through to either discovery class. The property remains for `CommandDiscovery`, which still uses it.