### PR TITLE
fix: push main before generating release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,24 @@ Entries from `0.4.0` onward are generated automatically by `bin/release.sh` from
 
 ## [0.4.0] - 2026-05-01
 
+### New Features
+* feat: close database layer gaps for 1.0 by @markshust in https://github.com/marko-php/marko/pull/40
+* feat: Add marko/vite package by @ps-carvalho in https://github.com/marko-php/marko/pull/42
+* feat: add marko/debugbar package by @ps-carvalho in https://github.com/marko-php/marko/pull/43
+* feat: Add marko/inertia package by @ps-carvalho in https://github.com/marko-php/marko/pull/47
+### Documentation
+* docs: use composer test for faster local test runs by @markshust in https://github.com/marko-php/marko/pull/38
+* docs: document integration-destructive group and run it in release script by @markshust in https://github.com/marko-php/marko/pull/39
+* docs: expand PR review process with package-PR checklist by @markshust in https://github.com/marko-php/marko/pull/46
+### Refactoring
+* refactor: preference discovery and class extraction logic by @iamlasse in https://github.com/marko-php/marko/pull/44
+* refactor: offload plugin discovery to PluginDiscovery class by @iamlasse in https://github.com/marko-php/marko/pull/45
+### Maintenance
+* feat: add CHANGELOG.md with release-script automation by @markshust in https://github.com/marko-php/marko/pull/48
 
+## New Contributors
+* @ps-carvalho made their first contribution in https://github.com/marko-php/marko/pull/42
+* @iamlasse made their first contribution in https://github.com/marko-php/marko/pull/44
 
 ## [0.3.1] - 2026-04-21
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -69,6 +69,15 @@ echo ""
 echo "  ✓ All tests passing"
 echo ""
 
+# Push main to remote BEFORE generating release notes — the GitHub
+# `releases/generate-notes` API enumerates PRs by walking commits visible
+# on the remote, so any merges that haven't been pushed yet are silently
+# omitted. Push first, then generate notes, then commit the changelog and
+# push again with the tag.
+echo "Pushing main branch (so generate-notes sees all merge commits)..."
+git push origin main
+echo ""
+
 # Update CHANGELOG.md (requires gh + jq)
 CHANGELOG_FILE="CHANGELOG.md"
 CHANGELOG_MARKER="<!-- new-entries-below — do not remove this marker; bin/release.sh inserts new versions directly below it -->"
@@ -166,7 +175,7 @@ echo "Committing changelog..."
 git add "$CHANGELOG_FILE"
 git commit -m "chore: changelog for ${VERSION}"
 
-echo "Pushing main branch..."
+echo "Pushing main branch with changelog commit..."
 git push origin main
 
 echo "Creating tag ${TAG}..."


### PR DESCRIPTION
## Summary

Cutting `0.4.0` exposed a timing bug in `bin/release.sh`. The script was calling GitHub's `releases/generate-notes` API **before** pushing `main`, so the API saw no commits between `0.3.1` and remote `main` and returned an empty body. Both the `CHANGELOG.md` entry and the GitHub Release body for `0.4.0` came back blank.

Fix: push `main` to the remote first, then call the API, then commit the changelog, then push `main` again with the tag. `main` now gets pushed twice per release (once with the develop merge, once with the changelog commit) — that's the cost of keeping `CHANGELOG.md` and the GitHub Release body identical.

Also restores the `0.4.0` entry in `CHANGELOG.md` to match the GitHub Release body, which was hand-patched after the failed run.

## Test plan

- [x] `bash -n bin/release.sh` syntax clean
- [ ] End-to-end verification with the next release (`0.4.1`) — first real run of the corrected flow

## Side note

While recovering `0.4.0` we noticed `gh api releases/generate-notes` silently omitted PR #42 because GitHub's stored `mergeCommitSha` for that PR didn't match the actual commit on `main`. That's a pre-existing GitHub-side quirk, not something this PR addresses — release.sh has no signal to detect it. Worth spot-checking the generated notes against `git log --first-parent --merges` after each future release until we know how often it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)