### PR TITLE
fix: harden release pipeline (deterministic changelog, self-healing Packagist)

### DIFF
--- a/.claude/release-process.md
+++ b/.claude/release-process.md
@@ -121,7 +121,7 @@ The script does everything else, in order:
 4. Confirms the tag does not already exist
 5. Verifies PHP 8.5 is the active interpreter (override with `PHP_BIN`)
 6. Runs the full test suite **including** the `integration-destructive` group (`vendor/bin/pest --parallel`). Must pass.
-7. Generates release notes via the GitHub API (`POST /repos/.../releases/generate-notes`) — the same content GitHub would auto-produce server-side
+7. Generates release notes deterministically from git history: walks `git log PREV_TAG..HEAD`, extracts every `#NN` reference, fetches each PR by number via `gh api repos/.../pulls/N`, buckets by label per `.github/release.yml`, and computes new contributors via the GitHub search API. We do **not** use `gh api releases/generate-notes` — that endpoint matches PRs to the tag range by their stored `merge_commit_sha`, which can go stale during rapid concurrent merges and silently drop PRs. Walking git ourselves removes that dependency entirely.
 8. Prepends a new `## [VERSION] - YYYY-MM-DD` section to `CHANGELOG.md` directly under the insertion marker, then commits `chore: changelog for VERSION` on `main`
 9. Pushes `main` (changelog commit included)
 10. Creates annotated tag `VERSION` and pushes it
@@ -131,20 +131,21 @@ The script does everything else, in order:
 After the tag is pushed, everything else is automatic:
 - GitHub Actions split workflow runs: https://github.com/marko-php/marko/actions
 - All packages are tagged in their split repos
-- Packagist updates within seconds via webhooks
+- Packagist updates within seconds via webhooks (`split.yml` self-registers any package not already on Packagist, then notifies)
 - Verify: https://packagist.org/packages/marko/
 
 **Requirements for the release script:**
-- `gh` CLI authenticated against the `marko-php` org (used for `releases/generate-notes` and `release create`)
+- `gh` CLI authenticated against the `marko-php` org (used to fetch PR data and create the GitHub Release)
 - `jq` installed
 - `CHANGELOG.md` at repo root containing the literal insertion marker line:
   ```
   <!-- new-entries-below — do not remove this marker; bin/release.sh inserts new versions directly below it -->
   ```
+- Every release-worthy commit on `develop` has a `#NN` reference in its message (the default for both merge commits and squash merges via the GitHub UI)
 
 **If tests fail:** Fix the failing tests and re-run `./bin/release.sh`. Do not skip tests. The script aborts before touching `CHANGELOG.md` or creating any tag, so a failed run leaves no garbage commits.
 
-**If `gh api` fails (rate limit, network):** The script aborts before tagging. Re-run once the API is reachable.
+**If a PR is missing from the generated notes:** the only realistic cause is a commit on `develop` that doesn't reference its PR with `#NN`. Add a `(#NN)` to the commit message (or amend before tagging) and re-run. The script lists every PR it found at the start of generation so missing ones are visible immediately.
 
 ---
 
@@ -170,10 +171,11 @@ When a new package is added under `packages/`:
    }
    ```
 
-2. Run the add-package script (creates split repo + registers on Packagist + updates root `composer.json`):
+2. Update root `composer.json` to register the path repository and `replace`/`require` entries. Either run the helper:
    ```bash
    GITHUB_ORG=marko-php PACKAGIST_USERNAME=xxx PACKAGIST_TOKEN=xxx ./bin/add-package.sh new-feature
    ```
+   …or edit `composer.json` by hand if you don't have Packagist credentials. The Packagist registration the script performs is no longer required up front — `split.yml` now self-heals (see step 5).
 
 3. Commit and push to `develop`:
    ```bash
@@ -182,11 +184,11 @@ When a new package is added under `packages/`:
    git push origin develop
    ```
 
-4. The split workflow automatically pushes the package code to `marko-php/marko-new-feature`
+4. The split workflow automatically creates the split repo on GitHub and pushes the package code to `marko-php/marko-new-feature`. Code is available as `dev-develop` immediately for anyone who already had the package registered on Packagist.
 
-5. Packagist auto-updates via webhook — the package becomes available as `dev-develop`
+5. On the next release tag, `split.yml`'s "Notify Packagist" step detects that `marko/new-feature` is unregistered (HTTP 404 from `update-package`), calls `create-package` to register it, then retries the update so the new tag is indexed. No manual Packagist step required. This is what makes contributor-submitted package PRs work end-to-end without the contributor needing your Packagist credentials.
 
-6. On next release (`./bin/release.sh X.Y.Z`), the package gets a proper version tag
+6. The package gets its first version tag at the same time as the rest of the framework via `./bin/release.sh X.Y.Z`.
 
 ---
 

--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -69,7 +69,33 @@ jobs:
         env:
           PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
         run: |
-          curl -sf -X POST https://packagist.org/api/update-package \
+          PKG_URL="https://github.com/${SPLIT_ORG}/marko-${{ matrix.package }}"
+
+          # Try to update first. If Packagist returns 404 the package isn't
+          # registered yet — self-heal by calling create-package, then retry
+          # the update so the new tag actually gets indexed. This removes
+          # the manual `register-packagist.sh` step from the new-package
+          # workflow: contributors can add `packages/foo/` via PR and the
+          # first release tag will register + publish it automatically.
+          HTTP=$(curl -s -o /tmp/packagist_resp -w "%{http_code}" \
+            -X POST https://packagist.org/api/update-package \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer markshust:${PACKAGIST_TOKEN}" \
-            -d "{\"repository\":\"https://github.com/${SPLIT_ORG}/marko-${{ matrix.package }}\"}"
+            -d "{\"repository\":\"${PKG_URL}\"}")
+
+          if [[ "$HTTP" == "404" ]]; then
+            echo "marko/${{ matrix.package }} not registered on Packagist — registering now..."
+            curl -sf -X POST \
+              "https://packagist.org/api/create-package?username=markshust&apiToken=${PACKAGIST_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "{\"repository\":{\"url\":\"${PKG_URL}\"}}"
+            echo "Registered. Re-running update so the tag gets indexed..."
+            curl -sf -X POST https://packagist.org/api/update-package \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer markshust:${PACKAGIST_TOKEN}" \
+              -d "{\"repository\":\"${PKG_URL}\"}"
+          elif [[ "$HTTP" -ge 400 ]]; then
+            echo "Packagist update failed with HTTP ${HTTP}:"
+            cat /tmp/packagist_resp
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,9 @@ Entries from `0.4.0` onward are generated automatically by `bin/release.sh` from
 
 ## [0.1.1] - 2026-04-05
 
-Maintenance release. No user-facing changes.
+### Maintenance
+* fix(split): notify Packagist after tag push to prevent missed updates by @markshust in https://github.com/marko-php/marko/pull/2
+* feat(release-workflow): add automated release workflow and contribution conventions by @markshust in https://github.com/marko-php/marko/pull/5
 
 ## [0.1.0] - 2026-03-30
 

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -69,16 +69,10 @@ echo ""
 echo "  ✓ All tests passing"
 echo ""
 
-# Push main to remote BEFORE generating release notes — the GitHub
-# `releases/generate-notes` API enumerates PRs by walking commits visible
-# on the remote, so any merges that haven't been pushed yet are silently
-# omitted. Push first, then generate notes, then commit the changelog and
-# push again with the tag.
-echo "Pushing main branch (so generate-notes sees all merge commits)..."
-git push origin main
-echo ""
-
-# Update CHANGELOG.md (requires gh + jq)
+# Update CHANGELOG.md (requires gh + jq).
+# With the deterministic generator below we no longer need to pre-push
+# main — git log reads from the local repo and PR data is fetched by
+# number, so nothing depends on remote main being current.
 CHANGELOG_FILE="CHANGELOG.md"
 CHANGELOG_MARKER="<!-- new-entries-below — do not remove this marker; bin/release.sh inserts new versions directly below it -->"
 NOTES_FILE=""
@@ -104,50 +98,161 @@ if ! grep -qF "$CHANGELOG_MARKER" "$CHANGELOG_FILE"; then
     exit 1
 fi
 
+# Generate release notes deterministically from git history.
+#
+# Why we don't use `gh api releases/generate-notes`: that API matches PRs to
+# the tag range by their stored `merge_commit_sha`, which can go stale when
+# multiple PRs merge in close succession (GitHub leaves the field pointing
+# at an old test-merge commit instead of the actual one). When that happens
+# the API silently drops the PR with no warning. We hit this on 0.4.0 when
+# PR #42 was omitted.
+#
+# Walking git log ourselves and looking each PR up by number sidesteps the
+# entire SHA-matching dance. Categories below are kept in lockstep with
+# `.github/release.yml` — add a category there, add it here too.
 PREV_TAG=""
 if PREV_TAG_CANDIDATE=$(git describe --tags --abbrev=0 2>/dev/null); then
     PREV_TAG="$PREV_TAG_CANDIDATE"
 fi
 
-echo "Generating release notes via gh API (previous tag: ${PREV_TAG:-none})..."
-NOTES_FILE=$(mktemp)
-trap 'rm -f "$NOTES_FILE"' EXIT
-
-if [[ -n "$PREV_TAG" ]]; then
-    gh api -X POST "repos/$GH_REPO/releases/generate-notes" \
-        -f tag_name="$TAG" \
-        -f previous_tag_name="$PREV_TAG" \
-        -f target_commitish=main \
-        --jq .body > "$NOTES_FILE"
-else
-    gh api -X POST "repos/$GH_REPO/releases/generate-notes" \
-        -f tag_name="$TAG" \
-        -f target_commitish=main \
-        --jq .body > "$NOTES_FILE"
-fi
-
-if [[ ! -s "$NOTES_FILE" ]]; then
-    echo "Error: gh API returned empty release notes."
+if [[ -z "$PREV_TAG" ]]; then
+    echo "Error: no previous tag found. Cannot determine release range."
     exit 1
 fi
 
-# Build CHANGELOG section: strip GitHub-Release-specific framing (HTML comment, "What's Changed"
-# heading, and "Full Changelog" footer link). Keep category subheadings (### Bug Fixes, etc.)
-# and PR/contributor lines.
-TODAY=$(date +%Y-%m-%d)
-CHANGELOG_SECTION_FILE=$(mktemp)
-trap 'rm -f "$NOTES_FILE" "$CHANGELOG_SECTION_FILE"' EXIT
+echo "Generating release notes from git history (range: ${PREV_TAG}..HEAD)..."
 
+PR_NUMBERS=$(git log --oneline "${PREV_TAG}..HEAD" | grep -oE '#[0-9]+' | tr -d '#' | sort -n -u)
+
+if [[ -z "$PR_NUMBERS" ]]; then
+    echo "Error: no merged PRs found between ${PREV_TAG} and HEAD."
+    echo "Every release-worthy commit must reference its PR with #NN in the message."
+    exit 1
+fi
+
+PR_COUNT=$(echo "$PR_NUMBERS" | wc -l | tr -d ' ')
+echo "  Found ${PR_COUNT} PR(s): $(echo "$PR_NUMBERS" | tr '\n' ' ')"
+
+# Category order = output order. Format: label_name|section_title
+# Mirror of `.github/release.yml` — keep in sync.
+CATEGORIES=(
+    "breaking|Breaking Changes"
+    "enhancement|New Features"
+    "bug|Bug Fixes"
+    "documentation|Documentation"
+    "refactor|Refactoring"
+    "testing|Testing"
+    "ci|CI"
+    "maintenance|Maintenance"
+)
+
+PR_DATA_DIR=$(mktemp -d)
+NOTES_FILE=$(mktemp)
+CHANGELOG_SECTION_FILE=$(mktemp)
+trap 'rm -rf "$PR_DATA_DIR"; rm -f "$NOTES_FILE" "$CHANGELOG_SECTION_FILE"' EXIT
+
+OTHER_FILE="${PR_DATA_DIR}/other"
+AUTHORS_FILE="${PR_DATA_DIR}/authors"
+: > "$AUTHORS_FILE"
+
+for num in $PR_NUMBERS; do
+    pr_json=$(gh api "repos/${GH_REPO}/pulls/${num}" 2>/dev/null) || {
+        echo "  ⚠ Could not fetch PR #${num}, skipping"
+        continue
+    }
+
+    title=$(printf '%s' "$pr_json" | jq -r '.title')
+    author=$(printf '%s' "$pr_json" | jq -r '.user.login // "unknown"')
+    labels=$(printf '%s' "$pr_json" | jq -r '.labels[].name')
+
+    matched=""
+    for entry in "${CATEGORIES[@]}"; do
+        label="${entry%%|*}"
+        if printf '%s\n' "$labels" | grep -qx "$label"; then
+            matched="$label"
+            break
+        fi
+    done
+
+    line="* ${title} by @${author} in https://github.com/${GH_REPO}/pull/${num}"
+    if [[ -n "$matched" ]]; then
+        printf '%s\n' "$line" >> "${PR_DATA_DIR}/${matched}"
+    else
+        printf '%s\n' "$line" >> "$OTHER_FILE"
+        echo "  ⚠ PR #${num} has no recognized category label — bucketed under 'Other Changes'"
+    fi
+
+    printf '%s\t%s\n' "$author" "$num" >> "$AUTHORS_FILE"
+done
+
+# Detect new contributors: authors with zero merged PRs in this repo before PREV_TAG.
+PREV_TAG_DATE=$(git log -1 --format=%cI "$PREV_TAG")
+NEW_CONTRIBUTORS_FILE="${PR_DATA_DIR}/new-contributors"
+: > "$NEW_CONTRIBUTORS_FILE"
+
+UNIQUE_AUTHORS=$(awk -F'\t' '{print $1}' "$AUTHORS_FILE" | sort -u)
+for author in $UNIQUE_AUTHORS; do
+    [[ "$author" == "unknown" ]] && continue
+    prior_count=$(gh api -X GET search/issues \
+        -f q="repo:${GH_REPO} is:pr is:merged author:${author} merged:<${PREV_TAG_DATE}" \
+        --jq '.total_count' 2>/dev/null) || prior_count="?"
+
+    if [[ "$prior_count" == "0" ]]; then
+        first_pr=$(awk -F'\t' -v a="$author" '$1==a {print $2; exit}' "$AUTHORS_FILE")
+        printf '* @%s made their first contribution in https://github.com/%s/pull/%s\n' \
+            "$author" "$GH_REPO" "$first_pr" >> "$NEW_CONTRIBUTORS_FILE"
+    fi
+done
+
+# Emit GitHub Release body (with "What's Changed" framing + Full Changelog footer).
+{
+    echo "## What's Changed"
+    for entry in "${CATEGORIES[@]}"; do
+        label="${entry%%|*}"
+        section_title="${entry#*|}"
+        cat_file="${PR_DATA_DIR}/${label}"
+        if [[ -s "$cat_file" ]]; then
+            echo "### ${section_title}"
+            cat "$cat_file"
+        fi
+    done
+    if [[ -s "$OTHER_FILE" ]]; then
+        echo "### Other Changes"
+        cat "$OTHER_FILE"
+    fi
+    if [[ -s "$NEW_CONTRIBUTORS_FILE" ]]; then
+        echo ""
+        echo "## New Contributors"
+        cat "$NEW_CONTRIBUTORS_FILE"
+    fi
+    echo ""
+    echo "**Full Changelog**: https://github.com/${GH_REPO}/compare/${PREV_TAG}...${TAG}"
+} > "$NOTES_FILE"
+
+# Emit CHANGELOG.md section (no "What's Changed" header, no Full Changelog footer
+# — the version heading and the project's link to GitHub Releases serve those roles).
+TODAY=$(date +%Y-%m-%d)
 {
     echo "## [${VERSION}] - ${TODAY}"
     echo ""
-    sed -E \
-        -e '/^<!-- Release notes generated/d' \
-        -e "/^## What'?s Changed$/d" \
-        -e '/^\*\*Full Changelog\*\*:/d' \
-        "$NOTES_FILE" \
-    | awk 'NF {p=1} p {print}' \
-    | awk '{lines[NR]=$0} END {n=NR; while (n>0 && lines[n]=="") n--; for (i=1;i<=n;i++) print lines[i]}'
+    for entry in "${CATEGORIES[@]}"; do
+        label="${entry%%|*}"
+        section_title="${entry#*|}"
+        cat_file="${PR_DATA_DIR}/${label}"
+        if [[ -s "$cat_file" ]]; then
+            echo "### ${section_title}"
+            cat "$cat_file"
+        fi
+    done
+    if [[ -s "$OTHER_FILE" ]]; then
+        echo "### Other Changes"
+        cat "$OTHER_FILE"
+    fi
+    if [[ -s "$NEW_CONTRIBUTORS_FILE" ]]; then
+        echo ""
+        echo "## New Contributors"
+        cat "$NEW_CONTRIBUTORS_FILE"
+    fi
     echo ""
 } > "$CHANGELOG_SECTION_FILE"
 
@@ -175,7 +280,7 @@ echo "Committing changelog..."
 git add "$CHANGELOG_FILE"
 git commit -m "chore: changelog for ${VERSION}"
 
-echo "Pushing main branch with changelog commit..."
+echo "Pushing main branch..."
 git push origin main
 
 echo "Creating tag ${TAG}..."


### PR DESCRIPTION
## Summary

Three related fixes to the release/publish pipeline, motivated by problems we hit cutting `0.4.0` and `0.4.1`.

### `bin/release.sh` — deterministic changelog generator

Replaces the `gh api releases/generate-notes` call with a generator that walks `git log PREV_TAG..HEAD` for `#NN` references and fetches each PR by number. The API matched PRs to the tag range by their stored `merge_commit_sha`, which can go stale during rapid concurrent merges — exactly what dropped PR #42 from the `0.4.0` notes. Walking git ourselves removes that dependency.

The generator:
- Lists PRs at the start of generation so anything missing is visible immediately (loud errors).
- Buckets PRs by label per `.github/release.yml`. Unlabeled PRs go into `### Other Changes` with a warning.
- Computes "New Contributors" via the GitHub search API (PRs with zero merged history before `PREV_TAG`).
- Emits two outputs from the same data: a CHANGELOG.md section and a GitHub Release body, guaranteed identical.

### `.github/workflows/split.yml` — self-healing Packagist

On HTTP 404 from `update-package`, the workflow now calls `create-package` to register the package, then retries the update so the new tag actually gets indexed. This removes the manual `register-packagist.sh` requirement when adding a new package: contributors can submit a PR adding `packages/foo/` and the first release tag will register + publish it automatically. Without this, the three packages added in `0.4.0` (vite, debugbar, inertia) had failing split runs because they were never registered on Packagist.

### `CHANGELOG.md` — backfill 0.1.1

The original auto-generator dropped two unlabeled PRs (#2, #5) from the `0.1.1` GitHub Release. Restoring them under "Maintenance" since both were release-tooling work.

### `.claude/release-process.md` — documentation

Updated step-by-step flow to reflect the new generator and self-healing Packagist step.

## Why a single PR

All three changes touch the same release/publish pipeline and were all surfaced by the same `0.4.0` postmortem. Reviewing them together gives a coherent picture; splitting them would force re-explaining the context three times.

## Test plan

- [x] `bash -n bin/release.sh` syntax clean
- [x] Generator dry-run against `0.3.1..0.4.0` correctly produces all 10 PRs (including PR #42 that the API silently dropped) in correct categories
- [ ] End-to-end verification with the next release (`0.4.2`) — first run of the deterministic generator
- [ ] Self-healing Packagist verified when `0.4.2` tag triggers `split.yml` for vite/debugbar/inertia (the three currently-unregistered packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)