### PR TITLE
fix(tests): eliminate uniqid() parallel-flake and PHP 8.5 setAccessible() deprecation

### DIFF
--- a/packages/admin/tests/Unit/Discovery/AdminSectionDiscoveryTest.php
+++ b/packages/admin/tests/Unit/Discovery/AdminSectionDiscoveryTest.php
@@ -36,7 +36,7 @@ function cleanupAdminTestDirectory(
 }
 
 it('discovers classes with AdminSection attribute in a module', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-admin-discovery-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-admin-discovery-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     $classCode = <<<'PHP'
@@ -81,7 +81,7 @@ PHP;
 });
 
 it('skips classes without AdminSection attribute', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-admin-discovery-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-admin-discovery-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     $classCode = <<<'PHP'
@@ -150,7 +150,7 @@ it('discovers AdminPermission attributes on AdminSection classes', function (): 
 });
 
 it('returns empty array when module has no admin sections', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-admin-discovery-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-admin-discovery-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create a PHP file without AdminSection attribute
@@ -184,8 +184,8 @@ PHP;
 });
 
 it('discovers sections across multiple modules', function (): void {
-    $tempDir1 = sys_get_temp_dir() . '/marko-admin-discovery-test-' . uniqid();
-    $tempDir2 = sys_get_temp_dir() . '/marko-admin-discovery-test-' . uniqid();
+    $tempDir1 = sys_get_temp_dir() . '/marko-admin-discovery-test-' . bin2hex(random_bytes(8));
+    $tempDir2 = sys_get_temp_dir() . '/marko-admin-discovery-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir1 . '/src', 0755, true);
     mkdir($tempDir2 . '/src', 0755, true);
 

--- a/packages/cache-file/tests/Unit/FileCacheDriverTest.php
+++ b/packages/cache-file/tests/Unit/FileCacheDriverTest.php
@@ -11,7 +11,7 @@ use Marko\Testing\Fake\FakeConfigRepository;
 
 function getCacheTestPath(): string
 {
-    return sys_get_temp_dir() . '/marko-cache-test-' . uniqid();
+    return sys_get_temp_dir() . '/marko-cache-test-' . bin2hex(random_bytes(8));
 }
 
 function cleanupCacheTestPath(
@@ -282,7 +282,7 @@ it('throws exception for key with invalid characters', function (): void {
 })->throws(InvalidKeyException::class, 'Invalid cache key');
 
 it('creates cache directory if not exists', function (): void {
-    $newPath = sys_get_temp_dir() . '/marko-cache-new-' . uniqid();
+    $newPath = sys_get_temp_dir() . '/marko-cache-new-' . bin2hex(random_bytes(8));
     $config = createTestCacheConfig($newPath);
     $driver = new FileCacheDriver($config);
 

--- a/packages/cli/tests/CliKernelTest.php
+++ b/packages/cli/tests/CliKernelTest.php
@@ -8,7 +8,7 @@ use Marko\Core\Command\Output;
 
 function createTempProjectDir(): string
 {
-    $tempDir = sys_get_temp_dir() . '/marko-cli-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-cli-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/vendor/marko/core', 0755, true);
 
     return $tempDir;

--- a/packages/cli/tests/ProjectFinderTest.php
+++ b/packages/cli/tests/ProjectFinderTest.php
@@ -31,7 +31,7 @@ function removeDirectory(
 
 function createTempDir(): string
 {
-    return sys_get_temp_dir() . '/marko-test-' . uniqid();
+    return sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
 }
 
 it('finds project root when in project directory', function () {

--- a/packages/config/tests/Feature/ConfigIntegrationTest.php
+++ b/packages/config/tests/Feature/ConfigIntegrationTest.php
@@ -88,7 +88,7 @@ describe('Config Integration', function (): void {
 
     it('config file uses environment variable when set', function () {
         // Create temporary directory structure
-        $tempDir = sys_get_temp_dir() . '/marko-config-env-test-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-config-env-test-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/app-config', 0755, true);
 
         try {
@@ -126,7 +126,7 @@ PHP);
 
     it('config file uses default when environment variable is not set', function () {
         // Create temporary directory structure
-        $tempDir = sys_get_temp_dir() . '/marko-config-env-default-test-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-config-env-default-test-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/app-config', 0755, true);
 
         try {
@@ -181,7 +181,7 @@ PHP);
 
     it('throws ConfigLoadException when config file has PHP syntax error', function () {
         // Create temporary directory structure
-        $tempDir = sys_get_temp_dir() . '/marko-config-syntax-error-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-config-syntax-error-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/app-config', 0755, true);
 
         try {
@@ -217,7 +217,7 @@ PHP);
 
     it('throws ConfigLoadException when config file returns non-array', function () {
         // Create temporary directory structure
-        $tempDir = sys_get_temp_dir() . '/marko-config-non-array-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-config-non-array-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/app-config', 0755, true);
 
         try {
@@ -249,7 +249,7 @@ PHP);
 
     it('full config lifecycle with temporary module structure', function () {
         // Create temporary directory structure
-        $tempDir = sys_get_temp_dir() . '/marko-config-test-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-config-test-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/module-x/config', 0755, true);
         mkdir($tempDir . '/module-y/config', 0755, true);
         mkdir($tempDir . '/app-config', 0755, true);
@@ -325,7 +325,7 @@ PHP);
 
     it('multi-tenant scenario with default and scoped values', function () {
         // Create temporary directory structure
-        $tempDir = sys_get_temp_dir() . '/marko-config-multitenant-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-config-multitenant-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/app-config', 0755, true);
 
         try {
@@ -397,7 +397,7 @@ PHP);
 
     it('withScope creates properly scoped instance for multi-tenant access', function () {
         // Create temporary directory structure
-        $tempDir = sys_get_temp_dir() . '/marko-config-withscope-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-config-withscope-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/app-config', 0755, true);
 
         try {

--- a/packages/core/tests/Command/CommandDiscoveryTest.php
+++ b/packages/core/tests/Command/CommandDiscoveryTest.php
@@ -10,7 +10,7 @@ use Marko\Core\Module\ModuleManifest;
 
 it('discovers command classes in module src directories', function (): void {
     // Create a temp directory structure with command files
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create a command class file with Command attribute
@@ -60,7 +60,7 @@ PHP;
 
 it('ignores classes without Command attribute', function (): void {
     // Create a temp directory structure
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create a class without Command attribute
@@ -97,7 +97,7 @@ PHP;
 
 it('ignores directories without src folder', function (): void {
     // Create a temp directory without src folder
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
 
     $manifest = new ModuleManifest(
@@ -117,7 +117,7 @@ it('ignores directories without src folder', function (): void {
 
 it('returns array of CommandDefinition objects', function (): void {
     // Create a temp directory structure with command files
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     $commandCode = <<<'PHP'
@@ -164,7 +164,7 @@ PHP;
 });
 
 it('extracts command name from attribute', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     $commandCode = <<<'PHP'
@@ -211,7 +211,7 @@ PHP;
 });
 
 it('extracts description from attribute', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     $commandCode = <<<'PHP'
@@ -258,7 +258,7 @@ PHP;
 });
 
 it('throws CommandException when command class missing execute method', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create a command class without execute method (and without interface so it can load)
@@ -297,7 +297,7 @@ PHP;
 });
 
 it('throws CommandException when command class does not implement CommandInterface', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create a command class with execute method but not implementing interface
@@ -339,7 +339,7 @@ PHP;
 });
 
 it('discovers aliases from Command attribute', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     $commandCode = <<<'PHP'
@@ -386,7 +386,7 @@ PHP;
 });
 
 it('creates CommandDefinition with empty aliases when none specified', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     $commandCode = <<<'PHP'
@@ -433,7 +433,7 @@ PHP;
 });
 
 it('creates CommandDefinition with aliases when specified in attribute', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     $commandCode = <<<'PHP'
@@ -481,7 +481,7 @@ PHP;
 
 it('discovers commands from multiple modules', function (): void {
     // Create first module
-    $tempDir1 = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir1 = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir1 . '/src', 0755, true);
 
     $commandCode1 = <<<'PHP'
@@ -510,7 +510,7 @@ PHP;
     file_put_contents($tempDir1 . '/src/ModuleACommand.php', $commandCode1);
 
     // Create second module
-    $tempDir2 = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir2 = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir2 . '/src', 0755, true);
 
     $commandCode2 = <<<'PHP'

--- a/packages/core/tests/Unit/ApplicationTest.php
+++ b/packages/core/tests/Unit/ApplicationTest.php
@@ -89,7 +89,7 @@ function appTestCreateModule(
 }
 
 it('scans all three directories for modules during boot', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
     $modulesDir = $baseDir . '/modules';
     $appDir = $baseDir . '/app';
@@ -119,7 +119,7 @@ it('scans all three directories for modules during boot', function (): void {
 });
 
 it('ignores dependencies that are not discovered Marko modules', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     // Create a module that requires a package not in our modules list
@@ -147,7 +147,7 @@ it('ignores dependencies that are not discovered Marko modules', function (): vo
 });
 
 it('detects and reports circular dependencies', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     // Create modules with circular dependency: A depends on B, B depends on A
@@ -176,7 +176,7 @@ it('detects and reports circular dependencies', function (): void {
 });
 
 it('sorts modules in correct load order', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     // Create modules where C depends on B depends on A
@@ -207,7 +207,7 @@ it('sorts modules in correct load order', function (): void {
 });
 
 it('registers bindings from all modules', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     // Create a module with bindings
@@ -241,7 +241,7 @@ it('registers bindings from all modules', function (): void {
 
 it('discovers and registers preferences', function (): void {
     // Use unique class names to avoid conflicts between test runs
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -316,7 +316,7 @@ PHP;
 
 it('discovers and registers plugins', function (): void {
     // Use unique class names to avoid conflicts between test runs
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -389,7 +389,7 @@ PHP;
 });
 
 it('discovers and registers plugins in ApplicationTest with new naming', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -457,7 +457,7 @@ PHP;
 
 it('discovers and registers observers', function (): void {
     // Use unique class names to avoid conflicts between test runs
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -528,7 +528,7 @@ PHP;
 });
 
 it('provides access to configured container', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     appTestCreateModule($vendorDir . '/acme/core', 'acme/core');
@@ -549,7 +549,7 @@ it('provides access to configured container', function (): void {
 });
 
 it('provides access to event dispatcher', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     appTestCreateModule($vendorDir . '/acme/core', 'acme/core');
@@ -570,7 +570,7 @@ it('provides access to event dispatcher', function (): void {
 });
 
 it('bootstrap.php creates and boots Application instance', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
     $modulesDir = $baseDir . '/modules';
     $appDir = $baseDir . '/app';
@@ -603,7 +603,7 @@ it('bootstrap.php creates and boots Application instance', function (): void {
 });
 
 it('parses all discovered module manifests', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     appTestCreateModule(
@@ -636,7 +636,7 @@ it('parses all discovered module manifests', function (): void {
 
 it('registers PSR-4 autoloaders for modules source during boot', function (): void {
     // Use unique namespace to avoid conflicts between test runs
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $modulesDir = $baseDir . '/modules';
 
@@ -706,7 +706,7 @@ PHP;
 
 it('skips autoloader registration for vendor modules', function (): void {
     // Count autoloaders before and after boot to verify vendor modules don't add autoloaders
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -775,7 +775,7 @@ PHP;
 
 it('resolves class from app module without explicit require in root composer.json', function (): void {
     // This simulates app/blog working without being in demo/composer.json require
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $appDir = $baseDir . '/app';
 
@@ -868,7 +868,7 @@ PHP;
 
 it('resolves class from modules directory without explicit require in root composer.json', function (): void {
     // This simulates modules/custom-checkout working without being in root composer.json
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $modulesDir = $baseDir . '/modules';
 
@@ -935,7 +935,7 @@ PHP;
 });
 
 it('discovers commands during application boot', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -987,7 +987,7 @@ PHP;
 });
 
 it('exposes commandRegistry property on Application', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     appTestCreateModule($vendorDir . '/acme/core', 'acme/core');
@@ -1006,7 +1006,7 @@ it('exposes commandRegistry property on Application', function (): void {
 });
 
 it('exposes commandRunner property on Application', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     appTestCreateModule($vendorDir . '/acme/core', 'acme/core');
@@ -1025,7 +1025,7 @@ it('exposes commandRunner property on Application', function (): void {
 });
 
 it('registers commands from all enabled modules', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
     $modulesDir = $baseDir . '/modules';
@@ -1139,7 +1139,7 @@ PHP;
 });
 
 it('skips modules without src directory during command discovery', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     // Create a module without src directory
@@ -1160,7 +1160,7 @@ it('skips modules without src directory during command discovery', function (): 
 });
 
 it('skips modules without command classes', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -1198,7 +1198,7 @@ PHP;
 });
 
 it('makes commandRunner available after boot', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -1253,7 +1253,7 @@ PHP;
 });
 
 it('calls module boot callbacks after bindings are registered', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -1307,7 +1307,7 @@ PHP;
 });
 
 it('passes container to boot callbacks', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -1353,7 +1353,7 @@ PHP;
 });
 
 it('auto-injects dependencies into module boot callbacks', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -1402,7 +1402,7 @@ PHP;
 });
 
 it('continues to work with boot callbacks that receive ContainerInterface', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -1445,7 +1445,7 @@ PHP;
 });
 
 it('runs boot callbacks after all framework services are registered', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -1491,7 +1491,7 @@ PHP;
 });
 
 it('registers the container as an instance of ContainerInterface', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     appTestCreateModule($vendorDir . '/acme/core', 'acme/core');
@@ -1542,7 +1542,7 @@ it('throws RuntimeException when accessing router property without routing insta
 it('still assigns Router instance correctly when routing is available', function (): void {
     // When routing IS available (it is in the test environment), booting the
     // app should populate $_router so $app->router returns an object.
-    $baseDir = sys_get_temp_dir() . '/marko_router_test_' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko_router_test_' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
     mkdir($vendorDir, 0o777, true);
 
@@ -1561,7 +1561,7 @@ it('still assigns Router instance correctly when routing is available', function
 });
 
 it('has an initialize() method that performs all discovery and wiring', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     appTestCreateModule($vendorDir . '/acme/core', 'acme/core');
@@ -1616,7 +1616,7 @@ it('CliKernel.php calls initialize() instead of boot()', function (): void {
 });
 
 it('creates an application with inferred paths from base path using Application::boot()', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . bin2hex(random_bytes(8));
     mkdir($baseDir, 0755, true);
 
     $app = Application::boot($baseDir);
@@ -1627,7 +1627,7 @@ it('creates an application with inferred paths from base path using Application:
 });
 
 it('sets vendorPath to basePath/vendor', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . bin2hex(random_bytes(8));
     mkdir($baseDir, 0755, true);
 
     $app = Application::boot($baseDir);
@@ -1638,7 +1638,7 @@ it('sets vendorPath to basePath/vendor', function (): void {
 });
 
 it('sets modulesPath to basePath/modules', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . bin2hex(random_bytes(8));
     mkdir($baseDir, 0755, true);
 
     $app = Application::boot($baseDir);
@@ -1649,7 +1649,7 @@ it('sets modulesPath to basePath/modules', function (): void {
 });
 
 it('sets appPath to basePath/app', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . bin2hex(random_bytes(8));
     mkdir($baseDir, 0755, true);
 
     $app = Application::boot($baseDir);
@@ -1660,7 +1660,7 @@ it('sets appPath to basePath/app', function (): void {
 });
 
 it('calls initialize() during boot() so the application is fully initialized', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . bin2hex(random_bytes(8));
     mkdir($baseDir, 0755, true);
 
     $app = Application::boot($baseDir);
@@ -1675,7 +1675,7 @@ it('calls initialize() during boot() so the application is fully initialized', f
 });
 
 it('returns the Application instance (return type self)', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-boot-test-' . bin2hex(random_bytes(8));
     mkdir($baseDir, 0755, true);
 
     $result = Application::boot($baseDir);
@@ -1777,7 +1777,7 @@ it('returns void', function (): void {
 });
 
 it('creates PluginInterceptor and injects it into Container via setter during initialization', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     appTestCreateModule($vendorDir . '/acme/core', 'acme/core');
@@ -1793,7 +1793,6 @@ it('creates PluginInterceptor and injects it into Container via setter during in
     // Use reflection to verify the container has a PluginInterceptor set
     $reflection = new ReflectionClass($app->container);
     $property = $reflection->getProperty('pluginInterceptor');
-    $property->setAccessible(true);
     $interceptor = $property->getValue($app->container);
 
     expect($interceptor)->toBeInstanceOf(PluginInterceptor::class);
@@ -1802,7 +1801,7 @@ it('creates PluginInterceptor and injects it into Container via setter during in
 });
 
 it('uses the same PluginRegistry instance for both discovery and interception', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -1859,12 +1858,10 @@ PHP;
     // The registry on the app and the one inside the interceptor must be the same instance
     $containerReflection = new ReflectionClass($app->container);
     $interceptorProp = $containerReflection->getProperty('pluginInterceptor');
-    $interceptorProp->setAccessible(true);
     $interceptor = $interceptorProp->getValue($app->container);
 
     $interceptorReflection = new ReflectionClass($interceptor);
     $registryProp = $interceptorReflection->getProperty('registry');
-    $registryProp->setAccessible(true);
     $interceptorRegistry = $registryProp->getValue($interceptor);
 
     expect($interceptorRegistry)->toBe($app->pluginRegistry);
@@ -1873,7 +1870,7 @@ PHP;
 });
 
 it('resolves objects with plugin interception after full initialization', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -1939,7 +1936,7 @@ PHP;
 });
 
 it('creates PluginRegistry before plugin discovery and reuses it for PluginInterceptor', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 

--- a/packages/core/tests/Unit/BootstrapTest.php
+++ b/packages/core/tests/Unit/BootstrapTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Marko\Core\Application;
 
 it('still returns an Application instance from the bootstrap closure', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-bootstrap-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-bootstrap-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
     $modulesDir = $baseDir . '/modules';
     $appDir = $baseDir . '/app';
@@ -34,13 +34,13 @@ it('still returns an Application instance from the bootstrap closure', function 
 });
 
 it('loads environment variables during initialize() using class_exists(EnvLoader::class) guard', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-bootstrap-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-bootstrap-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     mkdir($vendorDir, 0755, true);
 
     // Write a .env file in the base path (dirname of vendorPath)
-    $envKey = 'MARKO_TEST_INIT_ENV_' . strtoupper(uniqid());
+    $envKey = 'MARKO_TEST_INIT_ENV_' . strtoupper(bin2hex(random_bytes(8)));
     file_put_contents($baseDir . '/.env', $envKey . '=initialize_loaded');
 
     // Call initialize() directly — env loading must happen inside initialize()
@@ -63,14 +63,14 @@ it('loads environment variables during initialize() using class_exists(EnvLoader
 });
 
 it('derives basePath for env loading via dirname($this->vendorPath) inside initialize()', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-bootstrap-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-bootstrap-test-' . bin2hex(random_bytes(8));
     // Use a non-standard vendor path name to confirm dirname() is used
     $vendorDir = $baseDir . '/my-vendor';
 
     mkdir($vendorDir, 0755, true);
 
     // Write .env in the derived base path (dirname of vendorDir = baseDir)
-    $envKey = 'MARKO_TEST_DERIVE_BASE_' . strtoupper(uniqid());
+    $envKey = 'MARKO_TEST_DERIVE_BASE_' . strtoupper(bin2hex(random_bytes(8)));
     file_put_contents($baseDir . '/.env', $envKey . '=derived_base');
 
     $app = new Application(
@@ -92,7 +92,7 @@ it('derives basePath for env loading via dirname($this->vendorPath) inside initi
 });
 
 it('still accepts explicit vendorPath, modulesPath, and appPath parameters', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-bootstrap-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-bootstrap-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
     $modulesDir = $baseDir . '/modules';
     $appDir = $baseDir . '/app';

--- a/packages/core/tests/Unit/Container/PreferenceTest.php
+++ b/packages/core/tests/Unit/Container/PreferenceTest.php
@@ -39,7 +39,7 @@ it('creates Preference attribute with replaces parameter', function (): void {
 });
 
 it('discovers classes with Preference attribute in module src directories', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-preference-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-preference-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src/Preference', 0755, true);
 
     // Create a preference class file

--- a/packages/core/tests/Unit/Discovery/ClassFileParserTest.php
+++ b/packages/core/tests/Unit/Discovery/ClassFileParserTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Marko\Core\Discovery\ClassFileParser;
 
 it('extracts class name from file with namespace', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
 
     $code = <<<'PHP'
@@ -32,7 +32,7 @@ PHP;
 });
 
 it('extracts class name from file without namespace', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
 
     $code = <<<'PHP'
@@ -55,7 +55,7 @@ PHP;
 });
 
 it('returns null for file without class', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
 
     $code = <<<'PHP'
@@ -84,7 +84,7 @@ it('returns null for non-existent file', function (): void {
 });
 
 it('finds php files recursively', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/subdir/nested', 0755, true);
 
     file_put_contents($tempDir . '/Root.php', '<?php class Root {}');
@@ -121,7 +121,7 @@ it('returns empty iterator for non-existent directory', function (): void {
 });
 
 it('handles deeply nested namespaces', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
 
     $code = <<<'PHP'

--- a/packages/core/tests/Unit/Event/ObserverDiscoveryTest.php
+++ b/packages/core/tests/Unit/Event/ObserverDiscoveryTest.php
@@ -13,7 +13,7 @@ class DiscoveryTestEvent extends Event {}
 
 it('discovers observer classes in module src directories', function (): void {
     // Create a temp directory structure with observer files
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create an observer class file with Observer attribute
@@ -56,7 +56,7 @@ PHP;
 
 it('extracts event class/name from Observer attribute', function (): void {
     // Create a temp directory structure with observer files
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create an observer class file
@@ -99,7 +99,7 @@ PHP;
 
 it('throws exception when observer missing handle method', function (): void {
     // Create a temp directory structure with observer files
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create an observer class file without handle method
@@ -139,7 +139,7 @@ PHP;
 });
 
 it('skips files that reference missing Marko package classes', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create an observer file that implements a non-existent Marko interface
@@ -180,7 +180,7 @@ PHP;
 });
 
 it('throws Error when file references missing non-Marko class', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src', 0755, true);
 
     // Create an observer file that references a non-Marko missing class

--- a/packages/core/tests/Unit/Module/ModuleDiscoveryTest.php
+++ b/packages/core/tests/Unit/Module/ModuleDiscoveryTest.php
@@ -67,7 +67,7 @@ function createTestModule(
 }
 
 it('parses a module with composer.json into ModuleManifest object', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     createTestModule($tempDir, 'acme/blog');
 
     $parser = new ManifestParser();
@@ -79,7 +79,7 @@ it('parses a module with composer.json into ModuleManifest object', function ():
 });
 
 it('extracts module name from composer.json', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     createTestModule($tempDir, 'acme/blog');
 
     $parser = new ManifestParser();
@@ -91,7 +91,7 @@ it('extracts module name from composer.json', function (): void {
 });
 
 it('extracts module version from composer.json', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     createTestModule($tempDir, 'acme/blog', '2.5.3');
 
     $parser = new ManifestParser();
@@ -103,7 +103,7 @@ it('extracts module version from composer.json', function (): void {
 });
 
 it('works without module.php file using sensible defaults', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
 
     // Create module with ONLY composer.json, no module.php
     createTestModule($tempDir, 'acme/minimal');
@@ -123,7 +123,7 @@ it('works without module.php file using sensible defaults', function (): void {
 });
 
 it('extracts enabled state from module.php defaulting to true', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
 
     // Test default (no module.php = enabled true)
     createTestModule($tempDir, 'acme/blog');
@@ -136,7 +136,7 @@ it('extracts enabled state from module.php defaulting to true', function (): voi
     cleanupDirectory($tempDir);
 
     // Test explicit false
-    $tempDir2 = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir2 = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     createTestModule($tempDir2, 'acme/disabled', '1.0.0', [], ['enabled' => false]);
 
     $manifest = $parser->parse($tempDir2);
@@ -147,7 +147,7 @@ it('extracts enabled state from module.php defaulting to true', function (): voi
 });
 
 it('extracts require dependencies from composer.json', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     createTestModule($tempDir, 'acme/blog', '1.0.0', [
         'php' => '^8.5',
         'marko/core' => '^1.0',
@@ -168,7 +168,7 @@ it('extracts require dependencies from composer.json', function (): void {
 });
 
 it('extracts sequence hints (after/before) from module.php', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     createTestModule($tempDir, 'acme/blog', '1.0.0', [], [
         'sequence' => [
             'after' => ['marko/core', 'marko/database'],
@@ -191,7 +191,7 @@ it('extracts sequence hints (after/before) from module.php', function (): void {
 });
 
 it('extracts bindings from module.php', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     createTestModule($tempDir, 'acme/blog', '1.0.0', [], [
         'bindings' => [
             'Acme\Blog\Contracts\PostRepositoryInterface' => 'Acme\Blog\Repositories\PostRepository',
@@ -211,7 +211,7 @@ it('extracts bindings from module.php', function (): void {
 });
 
 it('throws ModuleException when composer.json is missing', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
     // No composer.json created
 
@@ -223,7 +223,7 @@ it('throws ModuleException when composer.json is missing', function (): void {
 });
 
 it('throws ModuleException when composer.json is invalid JSON', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
     file_put_contents($tempDir . '/composer.json', '{ invalid json }');
 
@@ -235,7 +235,7 @@ it('throws ModuleException when composer.json is invalid JSON', function (): voi
 });
 
 it('throws ModuleException when composer.json missing required name field', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
     file_put_contents($tempDir . '/composer.json', json_encode(['version' => '1.0.0']));
 
@@ -257,7 +257,7 @@ it('throws ModuleException when composer.json missing required name field', func
 });
 
 it('throws ModuleException when module.php has syntax errors', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
     file_put_contents($tempDir . '/composer.json', json_encode(['name' => 'acme/blog']));
     file_put_contents(
@@ -273,7 +273,7 @@ it('throws ModuleException when module.php has syntax errors', function (): void
 });
 
 it('discovers modules in vendor directory two levels deep', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     // Create vendor/marko/core
@@ -299,7 +299,7 @@ it('discovers modules in vendor directory two levels deep', function (): void {
 });
 
 it('discovers modules in modules directory recursively', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $modulesDir = $baseDir . '/modules';
 
     // Create modules/custom-module
@@ -325,7 +325,7 @@ it('discovers modules in modules directory recursively', function (): void {
 });
 
 it('discovers modules in app directory one level deep', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $appDir = $baseDir . '/app';
 
     // Create app/blog
@@ -351,7 +351,7 @@ it('discovers modules in app directory one level deep', function (): void {
 });
 
 it('skips directories without composer.json file', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
     $appDir = $baseDir . '/app';
 
@@ -383,7 +383,7 @@ it('skips directories without composer.json file', function (): void {
 });
 
 it('skips packages without extra.marko.module marker', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     // Create a Marko module WITH extra.marko.module: true
@@ -405,7 +405,7 @@ it('skips packages without extra.marko.module marker', function (): void {
 });
 
 it('skips packages with extra.marko.module set to false', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
 
     // Create a package with extra.marko.module: false (explicitly not a Marko module)
@@ -432,7 +432,7 @@ it('skips packages with extra.marko.module set to false', function (): void {
 });
 
 it('uses same detection rule for vendor, modules, and app directories', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
     $modulesDir = $baseDir . '/modules';
     $appDir = $baseDir . '/app';
@@ -465,7 +465,7 @@ it('uses same detection rule for vendor, modules, and app directories', function
 });
 
 it('returns discovered modules with their source directory (vendor/modules/app)', function (): void {
-    $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     $vendorDir = $baseDir . '/vendor';
     $modulesDir = $baseDir . '/modules';
     $appDir = $baseDir . '/app';
@@ -497,7 +497,7 @@ it('returns discovered modules with their source directory (vendor/modules/app)'
 });
 
 it('filters out php and extension requirements from dependencies', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     createTestModule($tempDir, 'acme/blog', '1.0.0', [
         'php' => '^8.5',
         'ext-json' => '*',
@@ -522,7 +522,7 @@ it('filters out php and extension requirements from dependencies', function (): 
 });
 
 it('extracts psr-4 autoload configuration from composer.json into ModuleManifest', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
 
     // Create composer.json with autoload.psr-4 configuration
@@ -549,7 +549,7 @@ it('extracts psr-4 autoload configuration from composer.json into ModuleManifest
 });
 
 it('stores autoload as empty array when composer.json has no autoload section', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
 
     // Create composer.json WITHOUT autoload section
@@ -570,7 +570,7 @@ it('stores autoload as empty array when composer.json has no autoload section', 
 });
 
 it('extracts boot callback from module.php', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
 
     // Create composer.json
@@ -601,7 +601,7 @@ PHP;
 });
 
 it('defaults boot to null when not specified in module.php', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     createTestModule($tempDir, 'acme/no-boot');
 
     $parser = new ManifestParser();

--- a/packages/core/tests/Unit/Plugin/PluginDiscoveryTest.php
+++ b/packages/core/tests/Unit/Plugin/PluginDiscoveryTest.php
@@ -84,7 +84,7 @@ PHP;
 }
 
 it('discovers plugin classes in module src directories', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-plugin-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-plugin-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src/Plugin', 0755, true);
 
     // Create a plugin class file
@@ -128,7 +128,7 @@ it('discovers plugin classes in module src directories', function (): void {
 });
 
 it('discovers plugin classes in module src directories with new naming', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-plugin-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-plugin-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/src/Plugin', 0755, true);
 
     // Create a plugin class file using new unprefixed method naming with #[Before] attribute

--- a/packages/database-mysql/tests/Connection/MySqlConnectionTest.php
+++ b/packages/database-mysql/tests/Connection/MySqlConnectionTest.php
@@ -26,7 +26,7 @@ function createTestDatabaseConfig(
     ?string $sslCert = null,
     ?string $sslKey = null,
 ): DatabaseConfig {
-    $tempDir = sys_get_temp_dir() . '/marko_mysql_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_mysql_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/config', recursive: true);
 
     $configArray = [

--- a/packages/database-mysql/tests/Module/ModuleBindingsTest.php
+++ b/packages/database-mysql/tests/Module/ModuleBindingsTest.php
@@ -54,7 +54,7 @@ describe('MySQL module.php bindings', function (): void {
 
     it('throws ConfigurationException when config file missing', function (): void {
         // Create temp directory WITHOUT config
-        $tempDir = sys_get_temp_dir() . '/marko_mysql_noconfig_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_mysql_noconfig_' . bin2hex(random_bytes(8));
         mkdir($tempDir, recursive: true);
 
         try {

--- a/packages/database-mysql/tests/Query/MySqlQueryBuilderAggregatesTest.php
+++ b/packages/database-mysql/tests/Query/MySqlQueryBuilderAggregatesTest.php
@@ -14,7 +14,7 @@ use ReflectionClass;
 
 function createAggregatesTestConfig(): DatabaseConfig
 {
-    $tempDir = sys_get_temp_dir() . '/marko_mysql_agg_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_mysql_agg_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/config', recursive: true);
     file_put_contents(
         $tempDir . '/config/database.php',

--- a/packages/database-mysql/tests/Query/MySqlQueryBuilderTest.php
+++ b/packages/database-mysql/tests/Query/MySqlQueryBuilderTest.php
@@ -16,7 +16,7 @@ use ReflectionClass;
 
 function createQueryBuilderTestConfig(): DatabaseConfig
 {
-    $tempDir = sys_get_temp_dir() . '/marko_mysql_qb_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_mysql_qb_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/config', recursive: true);
     file_put_contents(
         $tempDir . '/config/database.php',

--- a/packages/database-pgsql/tests/Connection/PgSqlConnectionTest.php
+++ b/packages/database-pgsql/tests/Connection/PgSqlConnectionTest.php
@@ -26,7 +26,7 @@ function createTestPgSqlConfig(
     ?string $sslCert = null,
     ?string $sslKey = null,
 ): DatabaseConfig {
-    $tempDir = sys_get_temp_dir() . '/marko_pgsql_test_' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko_pgsql_test_' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/config', recursive: true);
 
     $configArray = [

--- a/packages/database-pgsql/tests/Module/ModuleBindingsTest.php
+++ b/packages/database-pgsql/tests/Module/ModuleBindingsTest.php
@@ -43,7 +43,7 @@ describe('PostgreSQL module.php bindings', function (): void {
 
     it('throws ConfigurationException when config file missing', function (): void {
         // Create temp directory WITHOUT config
-        $tempDir = sys_get_temp_dir() . '/marko_pgsql_noconfig_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_pgsql_noconfig_' . bin2hex(random_bytes(8));
         mkdir($tempDir, recursive: true);
 
         try {

--- a/packages/database/tests/Command/StatusCommandTest.php
+++ b/packages/database/tests/Command/StatusCommandTest.php
@@ -121,7 +121,7 @@ function setupStatusTest(
     array $dataPending = [],
     array $dataApplied = [],
 ): StatusTestContext {
-    $migrationsPath = sys_get_temp_dir() . '/marko_status_test_' . uniqid();
+    $migrationsPath = sys_get_temp_dir() . '/marko_status_test_' . bin2hex(random_bytes(8));
     mkdir($migrationsPath, 0777, true);
 
     $content = getStatusMigrationContent();

--- a/packages/database/tests/DatabaseConfigTest.php
+++ b/packages/database/tests/DatabaseConfigTest.php
@@ -10,7 +10,7 @@ describe('DatabaseConfig', function (): void {
     it('uses getcwd as default base path when no path provided', function (): void {
         // Save current directory and change to temp directory with config
         $originalCwd = getcwd();
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 
@@ -51,7 +51,7 @@ PHP;
 
     it('accepts explicit base path to override default', function (): void {
         // Create a temporary config directory and file for testing
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 
@@ -90,7 +90,7 @@ PHP;
 
     it('loads config from basePath/config/database.php', function (): void {
         // Create a temporary config directory and file for testing
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 
@@ -127,7 +127,7 @@ PHP;
     });
 
     it('throws ConfigurationException when config file not found', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         mkdir($tempDir, 0755, true);
 
         try {
@@ -142,7 +142,7 @@ PHP;
     });
 
     it('loads optional SSL config when present', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 
@@ -177,7 +177,7 @@ PHP;
     });
 
     it('loads ssl_verify_server_cert when present', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 
@@ -211,7 +211,7 @@ PHP;
     });
 
     it('loads ssl_cert and ssl_key when present', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 
@@ -245,7 +245,7 @@ PHP;
     });
 
     it('defaults SSL config to null when not present', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 
@@ -280,7 +280,7 @@ PHP;
     });
 
     it('throws ConfigurationException when ssl_cert is set without ssl_key', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 
@@ -313,7 +313,7 @@ PHP;
     });
 
     it('throws ConfigurationException when ssl_key is set without ssl_cert', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 
@@ -346,7 +346,7 @@ PHP;
     });
 
     it('throws ConfigurationException when required keys missing', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $configDir = $tempDir . '/config';
         mkdir($configDir, 0755, true);
 

--- a/packages/database/tests/Entity/EntityDiscoveryTest.php
+++ b/packages/database/tests/Entity/EntityDiscoveryTest.php
@@ -84,7 +84,7 @@ function cleanupDir(
 
 beforeEach(function (): void {
     $this->discovery = new EntityDiscovery(new ClassFileParser());
-    $this->uniqueId = uniqid();
+    $this->uniqueId = bin2hex(random_bytes(8));
     $this->tempDir = sys_get_temp_dir() . '/entity-discovery-' . $this->uniqueId;
     mkdir($this->tempDir, 0777, true);
 });

--- a/packages/database/tests/Feature/DriverErrorHandlingTest.php
+++ b/packages/database/tests/Feature/DriverErrorHandlingTest.php
@@ -44,7 +44,7 @@ describe('Driver Error Handling', function (): void {
 
     it('validates database configuration from file', function (): void {
         // Create a temporary config file
-        $tempDir = sys_get_temp_dir() . '/marko_config_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_config_test_' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/config', 0777, true);
 
         file_put_contents($tempDir . '/config/database.php', <<<'PHP'
@@ -75,7 +75,7 @@ PHP);
     });
 
     it('throws when config file not found', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_nonexistent_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_nonexistent_' . bin2hex(random_bytes(8));
         mkdir($tempDir);
 
         $paths = new ProjectPaths($tempDir);
@@ -86,7 +86,7 @@ PHP);
     });
 
     it('throws when required config key missing', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_config_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_config_test_' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/config', 0777, true);
 
         // Missing 'password' key

--- a/packages/database/tests/Feature/EntityToMigrationWorkflowTest.php
+++ b/packages/database/tests/Feature/EntityToMigrationWorkflowTest.php
@@ -184,7 +184,7 @@ describe('Entity to Migration Workflow', function (): void {
             ->toContain('workflow_users');
 
         // Step 5: Generate migration file
-        $tempDir = sys_get_temp_dir() . '/marko_workflow_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_workflow_test_' . bin2hex(random_bytes(8));
         mkdir($tempDir);
 
         $projectPaths = new ProjectPaths($tempDir);

--- a/packages/database/tests/Feature/MigrationExecutionTest.php
+++ b/packages/database/tests/Feature/MigrationExecutionTest.php
@@ -16,7 +16,7 @@ use RuntimeException;
 describe('Migration Execution', function (): void {
     beforeEach(function (): void {
         // Create a temp directory structure with database/migrations for ProjectPaths
-        $this->basePath = sys_get_temp_dir() . '/marko_migration_test_' . uniqid();
+        $this->basePath = sys_get_temp_dir() . '/marko_migration_test_' . bin2hex(random_bytes(8));
         $this->migrationsPath = $this->basePath . '/database/migrations';
         mkdir($this->migrationsPath, 0777, true);
         $this->paths = new ProjectPaths($this->basePath);

--- a/packages/database/tests/Migration/DataMigrationDiscoveryTest.php
+++ b/packages/database/tests/Migration/DataMigrationDiscoveryTest.php
@@ -8,7 +8,7 @@ use Marko\Database\Tests\Migration\Helpers;
 
 describe('DataMigrationDiscovery', function (): void {
     beforeEach(function (): void {
-        $this->tempDir = sys_get_temp_dir() . '/marko_data_migration_test_' . uniqid();
+        $this->tempDir = sys_get_temp_dir() . '/marko_data_migration_test_' . bin2hex(random_bytes(8));
         mkdir($this->tempDir, 0777, true);
     });
 

--- a/packages/database/tests/Migration/DataMigratorIntegrationTest.php
+++ b/packages/database/tests/Migration/DataMigratorIntegrationTest.php
@@ -11,7 +11,7 @@ use Marko\Database\Tests\Migration\Helpers;
 
 describe('DataMigrator Integration', function (): void {
     beforeEach(function (): void {
-        $this->tempDir = sys_get_temp_dir() . '/marko_data_migrator_test_' . uniqid();
+        $this->tempDir = sys_get_temp_dir() . '/marko_data_migrator_test_' . bin2hex(random_bytes(8));
         mkdir($this->tempDir, 0777, true);
 
         // Create directory structure

--- a/packages/database/tests/Migration/MigrationGeneratorTest.php
+++ b/packages/database/tests/Migration/MigrationGeneratorTest.php
@@ -14,7 +14,7 @@ use Marko\Database\Tests\Migration\Helpers;
 
 describe('MigrationGenerator', function (): void {
     beforeEach(function (): void {
-        $this->tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+        $this->tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
         mkdir($this->tempDir, 0755, true);
     });
 

--- a/packages/database/tests/Migration/MigratorTest.php
+++ b/packages/database/tests/Migration/MigratorTest.php
@@ -12,7 +12,7 @@ use Marko\Database\Tests\Migration\Helpers;
 describe('Migrator', function (): void {
     beforeEach(function (): void {
         // Create a temp directory structure with database/migrations for ProjectPaths
-        $this->basePath = sys_get_temp_dir() . '/marko_test_base_' . uniqid();
+        $this->basePath = sys_get_temp_dir() . '/marko_test_base_' . bin2hex(random_bytes(8));
         $this->migrationsPath = $this->basePath . '/database/migrations';
         mkdir($this->migrationsPath, 0777, true);
         $this->paths = new ProjectPaths($this->basePath);

--- a/packages/database/tests/Seed/SeederDiscoveryTest.php
+++ b/packages/database/tests/Seed/SeederDiscoveryTest.php
@@ -61,7 +61,7 @@ function cleanupDir(
 
 describe('SeederDiscovery', function (): void {
     it('discovers seeders via #[Seeder] attribute', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/Seed', 0755, true);
 
         $seederCode = <<<'PHP'
@@ -102,7 +102,7 @@ PHP;
     });
 
     it('ignores classes without #[Seeder] attribute', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/Seed', 0755, true);
 
         $classCode = <<<'PHP'
@@ -132,7 +132,7 @@ PHP;
     });
 
     it('extracts order from attribute', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/Seed', 0755, true);
 
         $seederCode = <<<'PHP'
@@ -171,13 +171,13 @@ PHP;
     });
 
     it('discovers seeders in vendor/*/*/Seed/', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $vendorPath = $tempDir . '/vendor/acme/blog/Seed';
         mkdir($vendorPath, 0755, true);
 
         createSeederFile(
             $vendorPath . '/VendorSeeder.php',
-            'VendorAcmeBlog' . uniqid(),
+            'VendorAcmeBlog' . bin2hex(random_bytes(8)),
             'VendorSeeder',
             'vendor-seeder',
         );
@@ -194,13 +194,13 @@ PHP;
     });
 
     it('discovers seeders in modules/*/*/Seed/', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $modulesPath = $tempDir . '/modules/acme/blog/Seed';
         mkdir($modulesPath, 0755, true);
 
         createSeederFile(
             $modulesPath . '/ModuleSeeder.php',
-            'ModulesAcmeBlog' . uniqid(),
+            'ModulesAcmeBlog' . bin2hex(random_bytes(8)),
             'ModuleSeeder',
             'module-seeder',
         );
@@ -217,13 +217,13 @@ PHP;
     });
 
     it('discovers seeders in app/*/Seed/', function (): void {
-        $tempDir = sys_get_temp_dir() . '/marko_test_' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko_test_' . bin2hex(random_bytes(8));
         $appPath = $tempDir . '/app/blog/Seed';
         mkdir($appPath, 0755, true);
 
         createSeederFile(
             $appPath . '/AppSeeder.php',
-            'AppBlog' . uniqid(),
+            'AppBlog' . bin2hex(random_bytes(8)),
             'AppSeeder',
             'app-seeder',
         );

--- a/packages/dev-server/tests/Command/DevDownCommandTest.php
+++ b/packages/dev-server/tests/Command/DevDownCommandTest.php
@@ -13,7 +13,7 @@ use Marko\Testing\Fake\FakeConfigRepository;
 
 function devDownTmpDir(): string
 {
-    $tmpDir = sys_get_temp_dir() . '/dev-down-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/dev-down-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
 
     return $tmpDir;

--- a/packages/dev-server/tests/Command/DevOpenCommandTest.php
+++ b/packages/dev-server/tests/Command/DevOpenCommandTest.php
@@ -15,7 +15,7 @@ use Marko\DevServer\Process\ProcessEntry;
  */
 function devOpenTmpDir(): string
 {
-    $tmpDir = sys_get_temp_dir() . '/dev-open-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/dev-open-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
 
     return $tmpDir;

--- a/packages/dev-server/tests/Command/DevStatusCommandTest.php
+++ b/packages/dev-server/tests/Command/DevStatusCommandTest.php
@@ -14,7 +14,7 @@ use Marko\DevServer\Process\ProcessEntry;
  */
 function devStatusTmpDir(): string
 {
-    $tmpDir = sys_get_temp_dir() . '/dev-status-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/dev-status-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
 
     return $tmpDir;

--- a/packages/dev-server/tests/Command/DevUpCommandTest.php
+++ b/packages/dev-server/tests/Command/DevUpCommandTest.php
@@ -82,7 +82,7 @@ function createDevUpCommand(
     ?string $tempDir = null,
     ?PubSubDetector $pubsubDetector = null,
 ): array {
-    $dir = $tempDir ?? sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $dir = $tempDir ?? sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     if (!is_dir($dir)) {
         mkdir($dir, 0755, true);
     }
@@ -265,7 +265,7 @@ it('overrides port with --port flag', function (): void {
 });
 
 it('starts Docker when docker config is true and compose file exists', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-docker-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-docker-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
     file_put_contents($tempDir . '/compose.yaml', "version: '3'\nservices:\n  app:\n    image: nginx\n");
 
@@ -307,7 +307,7 @@ it('uses custom Docker command when docker config is a string', function (): voi
 });
 
 it('starts frontend when frontend config is true and package.json has dev script', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-frontend-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-frontend-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
     file_put_contents($tempDir . '/package.json', json_encode(['scripts' => ['dev' => 'vite']]));
 
@@ -459,7 +459,7 @@ it('overrides config port with -p space syntax', function (): void {
 });
 
 it('runs docker without -d flag as a managed process', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-docker-fg-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-docker-fg-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
     file_put_contents($tempDir . '/compose.yaml', "version: '3'\nservices:\n  app:\n    image: nginx\n");
 
@@ -558,7 +558,7 @@ it('includes custom processes in PID file when detached', function (): void {
 });
 
 it('never appends -d to docker command even in detach mode', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-docker-det-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-docker-det-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir, 0755, true);
     file_put_contents($tempDir . '/compose.yaml', "version: '3'\nservices:\n  app:\n    image: nginx\n");
 
@@ -597,7 +597,7 @@ it('starts pubsub:listen as managed process in DevUpCommand when detected', func
 });
 
 it('throws DevServerException when public/index.php does not exist', function (): void {
-    $dir = sys_get_temp_dir() . '/marko-no-index-' . uniqid();
+    $dir = sys_get_temp_dir() . '/marko-no-index-' . bin2hex(random_bytes(8));
     mkdir($dir, 0755, true);
     // Deliberately no public/index.php created
 
@@ -618,7 +618,7 @@ it('throws DevServerException when public/index.php does not exist', function ()
 })->throws(DevServerException::class);
 
 it('includes helpful message with bootstrap code in the exception', function (): void {
-    $dir = sys_get_temp_dir() . '/marko-no-index-msg-' . uniqid();
+    $dir = sys_get_temp_dir() . '/marko-no-index-msg-' . bin2hex(random_bytes(8));
     mkdir($dir, 0755, true);
 
     $fakeConfig = new FakeConfigRepository(CONFIG_DEFAULTS);
@@ -646,7 +646,7 @@ it('includes helpful message with bootstrap code in the exception', function ():
 });
 
 it('throws before any processes start when public/index.php is missing', function (): void {
-    $dir = sys_get_temp_dir() . '/marko-no-index-proc-' . uniqid();
+    $dir = sys_get_temp_dir() . '/marko-no-index-proc-' . bin2hex(random_bytes(8));
     mkdir($dir, 0755, true);
 
     $fakeConfig = new FakeConfigRepository(array_merge(CONFIG_DEFAULTS, [
@@ -678,7 +678,7 @@ it('throws before any processes start when public/index.php is missing', functio
 });
 
 it('starts PHP server normally when public/index.php exists', function (): void {
-    $dir = sys_get_temp_dir() . '/marko-with-index-' . uniqid();
+    $dir = sys_get_temp_dir() . '/marko-with-index-' . bin2hex(random_bytes(8));
     mkdir($dir . '/public', 0755, true);
     file_put_contents($dir . '/public/index.php', '<?php');
 
@@ -801,7 +801,7 @@ it('skips pubsub process when pubsub config is false', function (): void {
 });
 
 it('throws DevServerException when services are already running', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/marko-already-running-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko-already-running-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
 
     $pidFile = new PidFile($tmpDir);
@@ -818,7 +818,7 @@ it('throws DevServerException when services are already running', function (): v
 })->throws(DevServerException::class, 'Development environment is already running');
 
 it('allows dev:up when PID file has only stopped processes', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/marko-stopped-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko-stopped-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
 
     $pidFile = new PidFile($tmpDir);
@@ -837,7 +837,7 @@ it('allows dev:up when PID file has only stopped processes', function (): void {
 });
 
 it('suggests marko down in exception when services are already running', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/marko-suggest-down-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko-suggest-down-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
 
     $pidFile = new PidFile($tmpDir);

--- a/packages/dev-server/tests/Detection/DockerDetectorTest.php
+++ b/packages/dev-server/tests/Detection/DockerDetectorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Marko\DevServer\Detection\DockerDetector;
 
 it('detects compose.yaml in project root', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/compose.yaml', 'version: "3"');
 
@@ -19,7 +19,7 @@ it('detects compose.yaml in project root', function (): void {
 });
 
 it('detects docker-compose.yml in project root', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/docker-compose.yml', 'version: "3"');
 
@@ -33,7 +33,7 @@ it('detects docker-compose.yml in project root', function (): void {
 });
 
 it('returns null when no compose file exists', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
 
     $detector = new DockerDetector($tmpDir);
@@ -45,7 +45,7 @@ it('returns null when no compose file exists', function (): void {
 });
 
 it('returns up command without detached flag', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/compose.yaml', 'version: "3"');
 
@@ -60,7 +60,7 @@ it('returns up command without detached flag', function (): void {
 });
 
 it('returns down command for stopping containers', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/compose.yaml', 'version: "3"');
 
@@ -75,7 +75,7 @@ it('returns down command for stopping containers', function (): void {
 });
 
 it('checks compose files in priority order', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
 
     // Create all compose files - compose.yaml should take priority
@@ -98,7 +98,7 @@ it('checks compose files in priority order', function (): void {
 });
 
 it('uses compose file path in command with -f flag', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/docker-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/docker-compose.yml', 'version: "3"');
 

--- a/packages/dev-server/tests/Detection/FrontendDetectorTest.php
+++ b/packages/dev-server/tests/Detection/FrontendDetectorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Marko\DevServer\Detection\FrontendDetector;
 
 it('detects dev script in package.json', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/package.json', json_encode(['scripts' => ['dev' => 'node build.js']]));
 
@@ -19,7 +19,7 @@ it('detects dev script in package.json', function (): void {
 });
 
 it('returns null when package.json does not exist', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
 
     $detector = new FrontendDetector($tmpDir);
@@ -31,7 +31,7 @@ it('returns null when package.json does not exist', function (): void {
 });
 
 it('returns null when package.json has no dev script', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/package.json', json_encode(['scripts' => ['build' => 'node build.js']]));
 
@@ -45,7 +45,7 @@ it('returns null when package.json has no dev script', function (): void {
 });
 
 it('uses bun when bun.lockb exists', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/package.json', json_encode(['scripts' => ['dev' => 'node build.js']]));
     file_put_contents($tmpDir . '/bun.lockb', '');
@@ -61,7 +61,7 @@ it('uses bun when bun.lockb exists', function (): void {
 });
 
 it('uses pnpm when pnpm-lock.yaml exists', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/package.json', json_encode(['scripts' => ['dev' => 'node build.js']]));
     file_put_contents($tmpDir . '/pnpm-lock.yaml', '');
@@ -77,7 +77,7 @@ it('uses pnpm when pnpm-lock.yaml exists', function (): void {
 });
 
 it('uses yarn when yarn.lock exists', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/package.json', json_encode(['scripts' => ['dev' => 'node build.js']]));
     file_put_contents($tmpDir . '/yarn.lock', '');
@@ -93,7 +93,7 @@ it('uses yarn when yarn.lock exists', function (): void {
 });
 
 it('defaults to npm when no lockfile found', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/package.json', json_encode(['scripts' => ['dev' => 'node build.js']]));
 
@@ -107,7 +107,7 @@ it('defaults to npm when no lockfile found', function (): void {
 });
 
 it('defaults to npm when only package-lock.json exists', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/frontend-detector-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     file_put_contents($tmpDir . '/package.json', json_encode(['scripts' => ['dev' => 'node build.js']]));
     file_put_contents($tmpDir . '/package-lock.json', '{}');

--- a/packages/dev-server/tests/Process/PidFileTest.php
+++ b/packages/dev-server/tests/Process/PidFileTest.php
@@ -21,7 +21,7 @@ function removeDir(string $dir): void
 }
 
 it('writes process entries to JSON file', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir . '/.marko', 0755, true);
     $pidFile = new PidFile($tmpDir);
 
@@ -50,7 +50,7 @@ it('writes process entries to JSON file', function (): void {
 });
 
 it('creates .marko directory if it does not exist', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     // Do NOT create .marko directory - test that PidFile creates it
     $pidFile = new PidFile($tmpDir);
@@ -72,7 +72,7 @@ it('creates .marko directory if it does not exist', function (): void {
 });
 
 it('stores process name, pid, command, port, and start time', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     $pidFile = new PidFile($tmpDir);
 
@@ -97,7 +97,7 @@ it('stores process name, pid, command, port, and start time', function (): void 
 });
 
 it('checks if a process is still running', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     $pidFile = new PidFile($tmpDir);
 
@@ -109,7 +109,7 @@ it('checks if a process is still running', function (): void {
 });
 
 it('removes the PID file via clear method', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     $pidFile = new PidFile($tmpDir);
 
@@ -131,7 +131,7 @@ it('removes the PID file via clear method', function (): void {
 });
 
 it('detects a process group as running when parent died but child lives', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     $pidFile = new PidFile($tmpDir);
 
@@ -172,7 +172,7 @@ it('detects a process group as running when parent died but child lives', functi
 });
 
 it('returns empty array when file does not exist', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     $pidFile = new PidFile($tmpDir);
 
@@ -184,7 +184,7 @@ it('returns empty array when file does not exist', function (): void {
 });
 
 it('reads process entries from JSON file', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/pid-file-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir . '/.marko', 0755, true);
     $pidFile = new PidFile($tmpDir);
 

--- a/packages/env/tests/Unit/EnvLoaderTest.php
+++ b/packages/env/tests/Unit/EnvLoaderTest.php
@@ -9,7 +9,7 @@ beforeEach(function () {
     $this->originalEnv = $_ENV;
 
     // Create temp directory for test fixtures
-    $this->tempDir = sys_get_temp_dir() . '/marko-env-test-' . uniqid();
+    $this->tempDir = sys_get_temp_dir() . '/marko-env-test-' . bin2hex(random_bytes(8));
     mkdir($this->tempDir, 0777, true);
 });
 

--- a/packages/filesystem-local/tests/Unit/LocalFilesystemTest.php
+++ b/packages/filesystem-local/tests/Unit/LocalFilesystemTest.php
@@ -11,7 +11,7 @@ use Marko\Filesystem\Values\FileInfo;
 
 function getTestBasePath(): string
 {
-    return sys_get_temp_dir() . '/marko-filesystem-test-' . uniqid();
+    return sys_get_temp_dir() . '/marko-filesystem-test-' . bin2hex(random_bytes(8));
 }
 
 function cleanupTestPath(

--- a/packages/layout/tests/Unit/DiscoveringComponentCollectorTest.php
+++ b/packages/layout/tests/Unit/DiscoveringComponentCollectorTest.php
@@ -51,7 +51,7 @@ function makeInnerCollector(): ComponentCollector
 
 it('discovers classes with Component attribute from module src directories', function (): void {
     // Create a temp module with a src/ dir containing a PHP file
-    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . bin2hex(random_bytes(8));
     $srcDir = $tmpDir . '/src';
     mkdir($srcDir, 0755, true);
 
@@ -86,7 +86,7 @@ it('discovers classes with Component attribute from module src directories', fun
 });
 
 it('skips classes without Component attribute', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . bin2hex(random_bytes(8));
     $srcDir = $tmpDir . '/src';
     mkdir($srcDir, 0755, true);
 
@@ -117,7 +117,7 @@ it('skips classes without Component attribute', function (): void {
 });
 
 it('skips files that fail to load gracefully', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . bin2hex(random_bytes(8));
     $srcDir = $tmpDir . '/src';
     mkdir($srcDir, 0755, true);
 
@@ -153,7 +153,7 @@ it('skips files that fail to load gracefully', function (): void {
 });
 
 it('merges explicitly passed class names with discovered classes', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . bin2hex(random_bytes(8));
     $srcDir = $tmpDir . '/src';
     mkdir($srcDir, 0755, true);
 
@@ -239,7 +239,7 @@ it('delegates discoverFromClass to inner collector', function (): void {
 });
 
 it('handles modules without src directories gracefully', function (): void {
-    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko-layout-test-' . bin2hex(random_bytes(8));
     mkdir($tmpDir, 0755, true);
     // No src/ directory created
 
@@ -262,8 +262,8 @@ it('handles modules without src directories gracefully', function (): void {
 });
 
 it('scans all modules from ModuleRepositoryInterface', function (): void {
-    $tmpDir1 = sys_get_temp_dir() . '/marko-layout-test-' . uniqid();
-    $tmpDir2 = sys_get_temp_dir() . '/marko-layout-test-' . uniqid();
+    $tmpDir1 = sys_get_temp_dir() . '/marko-layout-test-' . bin2hex(random_bytes(8));
+    $tmpDir2 = sys_get_temp_dir() . '/marko-layout-test-' . bin2hex(random_bytes(8));
     $srcDir1 = $tmpDir1 . '/src';
     $srcDir2 = $tmpDir2 . '/src';
     mkdir($srcDir1, 0755, true);

--- a/packages/log-file/tests/Unit/Driver/FileLoggerTest.php
+++ b/packages/log-file/tests/Unit/Driver/FileLoggerTest.php
@@ -9,7 +9,7 @@ use Marko\Log\LogLevel;
 
 function createTempLogDir(): string
 {
-    $dir = sys_get_temp_dir() . '/marko-log-test-' . uniqid();
+    $dir = sys_get_temp_dir() . '/marko-log-test-' . bin2hex(random_bytes(8));
     mkdir($dir, 0755, true);
 
     return $dir;
@@ -210,7 +210,7 @@ it('interpolates placeholders in message', function () {
 });
 
 it('creates log directory if it does not exist', function () {
-    $dir = sys_get_temp_dir() . '/marko-log-test-create-' . uniqid();
+    $dir = sys_get_temp_dir() . '/marko-log-test-create-' . bin2hex(random_bytes(8));
 
     expect(is_dir($dir))->toBeFalse();
 

--- a/packages/log-file/tests/Unit/Rotation/SizeRotationTest.php
+++ b/packages/log-file/tests/Unit/Rotation/SizeRotationTest.php
@@ -7,7 +7,7 @@ use Marko\Log\File\Rotation\SizeRotation;
 
 function createTempRotationDir(): string
 {
-    $dir = sys_get_temp_dir() . '/marko-rotation-test-' . uniqid();
+    $dir = sys_get_temp_dir() . '/marko-rotation-test-' . bin2hex(random_bytes(8));
     mkdir($dir, 0755, true);
 
     return $dir;

--- a/packages/media-gd/tests/Unit/GdImageProcessorTest.php
+++ b/packages/media-gd/tests/Unit/GdImageProcessorTest.php
@@ -17,7 +17,7 @@ function createTestImage(
     int $width = 100,
     int $height = 100,
 ): string {
-    $path = sys_get_temp_dir() . '/marko-test-' . uniqid() . '.png';
+    $path = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8)) . '.png';
     $image = imagecreatetruecolor($width, $height);
     $color = imagecolorallocate($image, 255, 0, 0);
     imagefill($image, 0, 0, $color);

--- a/packages/routing/tests/RoutingBootstrapperTest.php
+++ b/packages/routing/tests/RoutingBootstrapperTest.php
@@ -68,7 +68,7 @@ function routingTestCreateModule(
 }
 
 it('registers Router in container during boot', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -91,7 +91,7 @@ it('registers Router in container during boot', function (): void {
 });
 
 it('discovers routes from all loaded modules', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -146,7 +146,7 @@ PHP;
 });
 
 it('resolves RouteCollection through container', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -169,7 +169,7 @@ it('resolves RouteCollection through container', function (): void {
 });
 
 it('applies Preference inheritance during discovery', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
     $appDir = $baseDir . '/app';
@@ -265,7 +265,7 @@ PHP;
 });
 
 it('provides getRouter method on Application', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -287,7 +287,7 @@ it('provides getRouter method on Application', function (): void {
 });
 
 it('returns Router as singleton in container', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -312,7 +312,7 @@ it('returns Router as singleton in container', function (): void {
 
 it('runs route discovery after module loading', function (): void {
     // This test ensures routes are discovered from modules loaded in order
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -398,7 +398,7 @@ PHP;
 });
 
 it('detects route conflicts during boot and fails fast', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
 
@@ -478,7 +478,7 @@ PHP;
 });
 
 it('discovers routes from vendor, modules, and app directories', function (): void {
-    $uniqueId = uniqid();
+    $uniqueId = bin2hex(random_bytes(8));
     $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
     $vendorDir = $baseDir . '/vendor';
     $modulesDir = $baseDir . '/modules';

--- a/packages/session-file/tests/Unit/FileSessionHandlerTest.php
+++ b/packages/session-file/tests/Unit/FileSessionHandlerTest.php
@@ -9,7 +9,7 @@ use Marko\Testing\Fake\FakeConfigRepository;
 
 function getSessionTestPath(): string
 {
-    return sys_get_temp_dir() . '/marko-session-test-' . uniqid();
+    return sys_get_temp_dir() . '/marko-session-test-' . bin2hex(random_bytes(8));
 }
 
 function cleanupSessionTestPath(

--- a/packages/translation-file/tests/FileTranslationLoaderTest.php
+++ b/packages/translation-file/tests/FileTranslationLoaderTest.php
@@ -7,7 +7,7 @@ use Marko\Translation\File\Loader\FileTranslationLoader;
 
 function translationCreateTempLangDir(): string
 {
-    $tmpDir = sys_get_temp_dir() . '/marko_translation_test_' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko_translation_test_' . bin2hex(random_bytes(8));
     mkdir($tmpDir . '/lang/en', 0777, true);
 
     return $tmpDir;

--- a/packages/translation-file/tests/NamespacedTranslationsTest.php
+++ b/packages/translation-file/tests/NamespacedTranslationsTest.php
@@ -7,7 +7,7 @@ use Marko\Translation\File\Loader\FileTranslationLoader;
 
 function translationNsCreateTempDir(): string
 {
-    $tmpDir = sys_get_temp_dir() . '/marko_ns_translation_test_' . uniqid();
+    $tmpDir = sys_get_temp_dir() . '/marko_ns_translation_test_' . bin2hex(random_bytes(8));
     mkdir($tmpDir . '/lang/en', 0777, true);
 
     return $tmpDir;
@@ -53,7 +53,7 @@ function translationNsCleanupTempDir(
 
 it('registers a namespace with addNamespace and loads from that path', function () {
     $appDir = translationNsCreateTempDir();
-    $blogDir = sys_get_temp_dir() . '/marko_blog_lang_' . uniqid();
+    $blogDir = sys_get_temp_dir() . '/marko_blog_lang_' . bin2hex(random_bytes(8));
     mkdir($blogDir . '/en', 0777, true);
     translationNsWriteLangFile($blogDir, 'en', 'messages', '<?php return ["welcome" => "Welcome to Blog!"];');
 
@@ -72,7 +72,7 @@ it('registers a namespace with addNamespace and loads from that path', function 
 
 it('loads namespaced translations from {namespacePath}/{locale}/{group}.php', function () {
     $appDir = translationNsCreateTempDir();
-    $blogDir = sys_get_temp_dir() . '/marko_blog_lang2_' . uniqid();
+    $blogDir = sys_get_temp_dir() . '/marko_blog_lang2_' . bin2hex(random_bytes(8));
     mkdir($blogDir . '/fr', 0777, true);
     translationNsWriteLangFile($blogDir, 'fr', 'validation', '<?php return ["required" => "Ce champ est requis."];');
 
@@ -91,7 +91,7 @@ it('loads namespaced translations from {namespacePath}/{locale}/{group}.php', fu
 
 it('returns empty array when namespaced translation file does not exist', function () {
     $appDir = translationNsCreateTempDir();
-    $blogDir = sys_get_temp_dir() . '/marko_blog_lang3_' . uniqid();
+    $blogDir = sys_get_temp_dir() . '/marko_blog_lang3_' . bin2hex(random_bytes(8));
     mkdir($blogDir, 0777, true);
 
     try {
@@ -110,7 +110,7 @@ it('returns empty array when namespaced translation file does not exist', functi
 it('caches namespaced translations independently from default translations', function () {
     $appDir = translationNsCreateTempDir();
     file_put_contents($appDir . '/lang/en/messages.php', '<?php return ["welcome" => "App Welcome!"];');
-    $blogDir = sys_get_temp_dir() . '/marko_blog_lang4_' . uniqid();
+    $blogDir = sys_get_temp_dir() . '/marko_blog_lang4_' . bin2hex(random_bytes(8));
     mkdir($blogDir . '/en', 0777, true);
     translationNsWriteLangFile($blogDir, 'en', 'messages', '<?php return ["welcome" => "Blog Welcome!"];');
 
@@ -131,8 +131,8 @@ it('caches namespaced translations independently from default translations', fun
 
 it('supports multiple namespaces simultaneously', function () {
     $appDir = translationNsCreateTempDir();
-    $blogDir = sys_get_temp_dir() . '/marko_blog_lang5_' . uniqid();
-    $shopDir = sys_get_temp_dir() . '/marko_shop_lang5_' . uniqid();
+    $blogDir = sys_get_temp_dir() . '/marko_blog_lang5_' . bin2hex(random_bytes(8));
+    $shopDir = sys_get_temp_dir() . '/marko_shop_lang5_' . bin2hex(random_bytes(8));
     mkdir($blogDir . '/en', 0777, true);
     mkdir($shopDir . '/en', 0777, true);
     translationNsWriteLangFile($blogDir, 'en', 'messages', '<?php return ["title" => "Blog Title"];');

--- a/packages/view-latte/tests/LatteEngineFactoryTest.php
+++ b/packages/view-latte/tests/LatteEngineFactoryTest.php
@@ -21,7 +21,7 @@ describe('LatteEngineFactory', function (): void {
     });
 
     test('configures cache directory', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $viewConfig = $this->createMock(ViewConfig::class);
@@ -48,7 +48,7 @@ describe('LatteEngineFactory', function (): void {
     });
 
     test('configures auto refresh', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-refresh-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-refresh-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         // Test with auto refresh enabled
@@ -84,7 +84,7 @@ describe('LatteEngineFactory', function (): void {
     });
 
     test('configures strict types', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-strict-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-strict-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         // Test with strict types enabled

--- a/packages/view-latte/tests/LatteViewTest.php
+++ b/packages/view-latte/tests/LatteViewTest.php
@@ -21,7 +21,7 @@ describe('LatteView', function (): void {
     });
 
     test('render returns Response with HTML', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $templatePath = $cacheDir . '/test.latte';
@@ -49,7 +49,7 @@ describe('LatteView', function (): void {
     });
 
     test('renderToString returns HTML string', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $templatePath = $cacheDir . '/test.latte';
@@ -75,7 +75,7 @@ describe('LatteView', function (): void {
     });
 
     test('passes data to template', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $templatePath = $cacheDir . '/test.latte';
@@ -103,7 +103,7 @@ describe('LatteView', function (): void {
     });
 
     test('uses resolver for template paths', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $templatePath = $cacheDir . '/resolved.latte';
@@ -128,7 +128,7 @@ describe('LatteView', function (): void {
     });
 
     test('handles template syntax errors', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $templatePath = $cacheDir . '/invalid.latte';
@@ -154,7 +154,7 @@ describe('LatteView', function (): void {
     });
 
     test('uses configured extension via resolver', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         // Use a custom extension to prove LatteView accepts any path from resolver
@@ -180,7 +180,7 @@ describe('LatteView', function (): void {
     });
 
     test('includes use namespaced template resolution', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         // Create the item template that will be included
@@ -218,7 +218,7 @@ describe('LatteView', function (): void {
     });
 
     test('includes reject relative paths', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-view-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         // Create a template with a relative include (not allowed)

--- a/packages/view-latte/tests/ModuleLoaderTest.php
+++ b/packages/view-latte/tests/ModuleLoaderTest.php
@@ -16,7 +16,7 @@ describe('ModuleLoader', function (): void {
     });
 
     test('getContent resolves template and returns file contents', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/module-loader-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/module-loader-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $templatePath = $cacheDir . '/test.latte';
@@ -75,7 +75,7 @@ describe('ModuleLoader', function (): void {
     });
 
     test('getUniqueId returns resolved absolute path', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/module-loader-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/module-loader-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $templatePath = $cacheDir . '/test.latte';

--- a/packages/view-latte/tests/Unit/Extensions/SlotExtensionTest.php
+++ b/packages/view-latte/tests/Unit/Extensions/SlotExtensionTest.php
@@ -16,7 +16,7 @@ describe('SlotExtension', function (): void {
     });
 
     test('it outputs empty string when slot has no content', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-slot-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-slot-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $engine = new Engine();
@@ -37,7 +37,7 @@ describe('SlotExtension', function (): void {
     });
 
     test('it outputs pre-rendered HTML for a named slot', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-slot-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-slot-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $engine = new Engine();
@@ -58,7 +58,7 @@ describe('SlotExtension', function (): void {
     });
 
     test('it handles nested slot names with dot-notation', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-slot-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-slot-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $engine = new Engine();
@@ -79,7 +79,7 @@ describe('SlotExtension', function (): void {
     });
 
     test('it works with multiple slots in the same template', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-slot-test-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-slot-test-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $engine = new Engine();
@@ -104,7 +104,7 @@ describe('SlotExtension', function (): void {
     });
 
     test('it integrates with LatteEngineFactory for automatic registration', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-slot-factory-' . uniqid();
+        $cacheDir = sys_get_temp_dir() . '/latte-slot-factory-' . bin2hex(random_bytes(8));
         mkdir($cacheDir, 0755, true);
 
         $viewConfig = $this->createMock(ViewConfig::class);

--- a/packages/view/tests/Feature/IntegrationTest.php
+++ b/packages/view/tests/Feature/IntegrationTest.php
@@ -21,7 +21,7 @@ use Marko\View\ViewInterface;
 describe('View Integration', function (): void {
     test('renders template end to end', function (): void {
         // Setup temp directory for templates and cache
-        $tempDir = sys_get_temp_dir() . '/marko-integration-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-integration-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/resources/views/post', 0755, true);
         mkdir($tempDir . '/cache', 0755, true);
 
@@ -82,7 +82,7 @@ describe('View Integration', function (): void {
 
     test('module bindings resolve correctly', function (): void {
         // Setup temp directory for templates and cache
-        $tempDir = sys_get_temp_dir() . '/marko-integration-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-integration-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/resources/views', 0755, true);
         mkdir($tempDir . '/cache', 0755, true);
 
@@ -160,7 +160,7 @@ describe('View Integration', function (): void {
 
     test('template not found produces helpful error', function (): void {
         // Setup temp directory (without the template)
-        $tempDir = sys_get_temp_dir() . '/marko-integration-' . uniqid();
+        $tempDir = sys_get_temp_dir() . '/marko-integration-' . bin2hex(random_bytes(8));
         mkdir($tempDir . '/resources/views', 0755, true);
         mkdir($tempDir . '/cache', 0755, true);
 

--- a/packages/view/tests/ModuleTemplateResolverTest.php
+++ b/packages/view/tests/ModuleTemplateResolverTest.php
@@ -24,7 +24,7 @@ it('ModuleTemplateResolver implements TemplateResolverInterface', function (): v
 });
 
 it('ModuleTemplateResolver resolves templates with module prefix', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/resources/views/post', 0755, true);
     file_put_contents($tempDir . '/resources/views/post/show.latte', 'test');
 
@@ -55,7 +55,7 @@ it('ModuleTemplateResolver resolves templates with module prefix', function (): 
 });
 
 it('ModuleTemplateResolver resolves templates without module prefix', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/resources/views/shared', 0755, true);
     file_put_contents($tempDir . '/resources/views/shared/header.latte', 'header content');
 
@@ -88,9 +88,9 @@ it('ModuleTemplateResolver resolves templates without module prefix', function (
 
 it('ModuleTemplateResolver searches in module priority order', function (): void {
     // app > modules > vendor (app overrides modules, modules override vendor)
-    $vendorDir = sys_get_temp_dir() . '/marko-test-vendor-' . uniqid();
-    $modulesDir = sys_get_temp_dir() . '/marko-test-modules-' . uniqid();
-    $appDir = sys_get_temp_dir() . '/marko-test-app-' . uniqid();
+    $vendorDir = sys_get_temp_dir() . '/marko-test-vendor-' . bin2hex(random_bytes(8));
+    $modulesDir = sys_get_temp_dir() . '/marko-test-modules-' . bin2hex(random_bytes(8));
+    $appDir = sys_get_temp_dir() . '/marko-test-app-' . bin2hex(random_bytes(8));
 
     // Create all directories with templates
     mkdir($vendorDir . '/resources/views/post', 0755, true);
@@ -156,8 +156,8 @@ it('ModuleTemplateResolver searches in module priority order', function (): void
 
 it('ModuleTemplateResolver respects app override priority', function (): void {
     // App modules override vendor modules - app template is found first
-    $vendorDir = sys_get_temp_dir() . '/marko-test-vendor-' . uniqid();
-    $appDir = sys_get_temp_dir() . '/marko-test-app-' . uniqid();
+    $vendorDir = sys_get_temp_dir() . '/marko-test-vendor-' . bin2hex(random_bytes(8));
+    $appDir = sys_get_temp_dir() . '/marko-test-app-' . bin2hex(random_bytes(8));
 
     // Create both directories with templates
     mkdir($vendorDir . '/resources/views/post', 0755, true);
@@ -206,7 +206,7 @@ it('ModuleTemplateResolver respects app override priority', function (): void {
 });
 
 it('ModuleTemplateResolver throws TemplateNotFoundException when not found', function (): void {
-    $tempDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+    $tempDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
     mkdir($tempDir . '/resources/views', 0755, true);
 
     $modules = [
@@ -233,8 +233,8 @@ it('ModuleTemplateResolver throws TemplateNotFoundException when not found', fun
 });
 
 it('ModuleTemplateResolver includes all paths in not found error', function (): void {
-    $tempDir1 = sys_get_temp_dir() . '/marko-test-app-' . uniqid();
-    $tempDir2 = sys_get_temp_dir() . '/marko-test-vendor-' . uniqid();
+    $tempDir1 = sys_get_temp_dir() . '/marko-test-app-' . bin2hex(random_bytes(8));
+    $tempDir2 = sys_get_temp_dir() . '/marko-test-vendor-' . bin2hex(random_bytes(8));
     mkdir($tempDir1, 0755, true);
     mkdir($tempDir2, 0755, true);
 
@@ -279,8 +279,8 @@ it('ModuleTemplateResolver includes all paths in not found error', function (): 
 });
 
 it('ModuleTemplateResolver getSearchedPaths returns all paths checked', function (): void {
-    $tempDir1 = sys_get_temp_dir() . '/marko-test-1-' . uniqid();
-    $tempDir2 = sys_get_temp_dir() . '/marko-test-2-' . uniqid();
+    $tempDir1 = sys_get_temp_dir() . '/marko-test-1-' . bin2hex(random_bytes(8));
+    $tempDir2 = sys_get_temp_dir() . '/marko-test-2-' . bin2hex(random_bytes(8));
     mkdir($tempDir1, 0755, true);
     mkdir($tempDir2, 0755, true);
 

--- a/tests/IntegrationVerificationTest.php
+++ b/tests/IntegrationVerificationTest.php
@@ -45,7 +45,7 @@ it(
     function () use ($root): void {
         $php = PHP_BINARY;
         $resultFile = tempnam(sys_get_temp_dir(), 'marko_result_');
-        $isolatedRoot = sys_get_temp_dir() . '/marko-clean-install-' . uniqid();
+        $isolatedRoot = sys_get_temp_dir() . '/marko-clean-install-' . bin2hex(random_bytes(8));
     
         $script = <<<'SCRIPT'
 <?php


### PR DESCRIPTION
## Summary

Two related test-suite hygiene fixes that surfaced during the 0.5.0 release run:

- **Replace bare `uniqid()` with `bin2hex(random_bytes(8))`** across all 54 test files that used it for temp-directory naming. PHP's `uniqid()` is microtime-based and the docs explicitly warn it doesn't guarantee uniqueness without entropy — when pest runs with `--parallel` (10 worker processes), two workers can call `uniqid()` in the same microsecond, get the same string, and race on filesystem state.
- **Remove three `ReflectionProperty::setAccessible(true)` calls** in `packages/core/tests/Unit/ApplicationTest.php`. Deprecated in PHP 8.5 because reflection on private/protected properties has worked without it since PHP 8.1. The calls were no-ops emitting deprecation notices on every test run.

## Why

During the 0.5.0 release attempt, `ApplicationTest::"it calls module boot callbacks after bindings are registered"` failed once in a parallel run with `Failed asserting that false is true.` The test passed in isolation and on the next parallel re-run. Root cause: two parallel workers got the same `uniqid()` value, used it for the same `$baseDir = sys_get_temp_dir() . '/marko-test-' . $uniqueId`, and one worker's `appTestCleanupDirectory()` wiped the other worker's `module.php` before `$app->initialize()` could load it — so the boot callback never fired and the asserted `$GLOBALS` flag stayed false.

This is a release-blocking issue: any future `./bin/release.sh` run could hit the same flake and abort. Fixing once removes the class of failure entirely.

The deprecation cleanup is a small companion fix found while investigating — `pest --display-deprecations` showed the three setAccessible calls firing, and removing them brought the deprecation count from 2 → 0.

## Fix Mechanics

`uniqid()` collisions:
\`\`\`diff
- $baseDir = sys_get_temp_dir() . '/marko-test-' . uniqid();
+ $baseDir = sys_get_temp_dir() . '/marko-test-' . bin2hex(random_bytes(8));
\`\`\`

Same call shape, but `bin2hex(random_bytes(8))` returns 16 hex chars of cryptographic entropy — effectively zero collision probability vs `uniqid()`'s microtime-derived 13 chars. Drop-in compatible with all use sites (opaque identifier in temp paths and namespace suffixes).

The single `uniqid('test_', true)` call in `media-gd` tests is left alone — it already includes the `more_entropy` argument.

`setAccessible(true)` removal: just delete the line. Since PHP 8.1, `ReflectionProperty::getValue()` on a private/protected property works without prior `setAccessible(true)`.

## Test plan

- [x] Full destructive suite (`pest -c phpunit.xml --parallel`) run **3 times consecutively** post-fix:
  - Run 1: 4898 passed, 0 failed, 0 deprecated, 138 notices, 2 skipped
  - Run 2: 4898 passed, 0 failed, 0 deprecated, 138 notices, 2 skipped
  - Run 3: 4898 passed, 0 failed, 0 deprecated, 138 notices, 2 skipped
- [x] Pre-fix state: intermittent 1-test failure + persistent 2 deprecation notices
- [x] No production code touched — `packages/*/src/**` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)