### PR TITLE
feat(entity-extension): add entity extension system

### DIFF
--- a/.claude/plans/entity-extension/001-entity-extension-base-and-attribute.md
+++ b/.claude/plans/entity-extension/001-entity-extension-base-and-attribute.md
@@ -1,0 +1,31 @@
+# Task 001: EntityExtension base class + `#[ExtensionOf]` attribute
+
+**Status**: completed
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+Create the two foundational primitives for the entity extension system: the `EntityExtension` abstract base class (parallel to `Entity`) and the `#[ExtensionOf]` attribute that declares which entity class an extension targets. These have no logic — they're the type anchors everything else builds on.
+
+## Context
+- Related files: `packages/database/src/Entity/Entity.php`, `packages/database/src/Attributes/Column.php`
+- Both live in `packages/database` — no new package needed
+- `ExtensionOf` cannot be a class name (`extends` is a reserved PHP keyword, class names are case-insensitive so `Extends` is also forbidden); use `ExtensionOf`
+- The attribute target is `TARGET_CLASS` — it goes on the extension class, not on properties
+- The attribute MUST be declared as `readonly` and constructed with constructor property promotion, mirroring `packages/database/src/Attributes/Table.php`
+- The attribute's stored class is exposed as a public `entityClass` property (typed `string`, but documented as `class-string<Entity>` via phpdoc) for consumers to read
+- Validation that the argument is a valid `Entity` subclass happens in discovery (task 003), not in the attribute constructor
+- `EntityExtension` is `abstract` and has no body — pure type anchor (parallel to `Entity`)
+
+## Requirements (Test Descriptions)
+- [ ] `it can be extended to create a concrete extension class`
+- [ ] `it rejects direct instantiation as an abstract class`
+- [ ] `it has an ExtensionOf attribute that accepts an entity class string`
+- [ ] `it targets class-level application only`
+- [ ] `it stores the entity class in the attribute`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- `EntityExtension` lives at `Marko\Database\Entity\EntityExtension`
+- `ExtensionOf` lives at `Marko\Database\Attributes\ExtensionOf`
+- Code follows project standards

--- a/.claude/plans/entity-extension/002-extension-metadata-and-factory.md
+++ b/.claude/plans/entity-extension/002-extension-metadata-and-factory.md
@@ -1,0 +1,55 @@
+# Task 002: ExtensionMetadata + EntityExtensionMetadataFactory
+
+**Status**: completed
+**Depends on**: [001]
+**Retry count**: 0
+
+## Description
+Create `ExtensionMetadata` — a value object that holds parsed column and property metadata for a single extension class — and `EntityExtensionMetadataFactory` that parses an `EntityExtension` subclass via reflection, extracting `#[Column]`-annotated properties. This is similar to `EntityMetadataFactory` but without requiring `#[Table]` or a primary key.
+
+## Context
+- Related files:
+  - `packages/database/src/Entity/EntityMetadata.php` — reference shape
+  - `packages/database/src/Entity/EntityMetadataFactory.php` — reference for property parsing logic
+  - `packages/database/src/Entity/PropertyMetadata.php`
+  - `packages/database/src/Entity/ColumnMetadata.php`
+  - `packages/database/src/Attributes/Column.php`
+- `ExtensionMetadata` holds: `extensionClass`, `entityClass`, `properties: array<string, PropertyMetadata>`, `columns: array<ColumnMetadata>`. It MUST be declared `readonly` with constructor property promotion (parallel to `EntityMetadata`).
+- The factory must reuse the same PHP→DB type inference and camelCase→snake_case logic as `EntityMetadataFactory`; do not duplicate with different behaviour, but duplication is acceptable since the classes have different validation rules
+- BackedEnum default values must be converted to their backing value, matching `EntityMetadataFactory` behaviour
+- JSON column type/nullable mismatch validation (parallel to `EntityMetadataFactory`) must be enforced
+- Extension classes must have at least one `#[Column]` property — throw `EntityException` if none found (new factory method on `EntityException`: `extensionHasNoColumns`)
+- Extension classes must not declare a primary key column — throw `EntityException` if one is found (new factory method: `extensionDeclaresPrimaryKey`)
+- Extension classes must not declare relationships (`#[HasOne]`, `#[HasMany]`, `#[BelongsTo]`, `#[BelongsToMany]`) — these are out of scope; throw `EntityException` if any found (new factory method: `extensionDeclaresRelationship`)
+- Extension classes must not declare `#[Table]` or `#[Index]` attributes — throw `EntityException` if any found
+- The factory reads the `#[ExtensionOf]` attribute on the extension class to populate `entityClass`; if missing, throw `EntityException` (new factory method: `extensionMissingExtensionOf`)
+
+## Requirements (Test Descriptions)
+- [ ] `it parses public Column-annotated properties into ExtensionMetadata`
+- [ ] `it stores the extension class and entity class on ExtensionMetadata`
+- [ ] `it throws when extension class has no Column-annotated properties`
+- [ ] `it throws when extension class declares a primary key column`
+- [ ] `it throws when extension class declares a relationship attribute`
+- [ ] `it throws when extension class is missing the ExtensionOf attribute`
+- [ ] `it infers database types from PHP scalar types`
+- [ ] `it converts camelCase property names to snake_case column names`
+- [ ] `it uses explicit column name from Column attribute when provided`
+- [ ] `it correctly marks nullable properties`
+- [ ] `it captures declared default values`
+- [ ] `it converts BackedEnum default values to their backing value`
+- [ ] `it throws when extension class does not extend EntityExtension`
+- [ ] `it throws when a json column type does not match the PHP array type`
+- [ ] `it caches parsed metadata by class`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- `ExtensionMetadata` lives at `Marko\Database\Entity\ExtensionMetadata`
+- `EntityExtensionMetadataFactory` lives at `Marko\Database\Entity\EntityExtensionMetadataFactory`
+- New static factory methods added to `Marko\Database\Exceptions\EntityException`:
+  - `extensionHasNoColumns(string $extensionClass)`
+  - `extensionDeclaresPrimaryKey(string $extensionClass, string $propertyName)`
+  - `extensionDeclaresRelationship(string $extensionClass, string $propertyName)`
+  - `extensionDeclaresTableAttribute(string $extensionClass)` (only if `#[Table]` is found on an extension)
+  - `extensionMissingExtensionOf(string $extensionClass)`
+  - `notExtendsEntityExtension(string $extensionClass)`
+- Code follows project standards

--- a/.claude/plans/entity-extension/003-registry-and-discovery.md
+++ b/.claude/plans/entity-extension/003-registry-and-discovery.md
@@ -1,0 +1,50 @@
+# Task 003: EntityExtensionRegistry + EntityExtensionDiscovery
+
+**Status**: completed
+**Depends on**: [001, 002]
+**Retry count**: 0
+
+## Description
+Create `EntityExtensionRegistry` — a singleton that maps entity class strings to their registered extension class strings — and `EntityExtensionDiscovery` that scans `src/EntityExtension/` directories across vendor/modules/app for classes bearing `#[ExtensionOf]`. Discovery validates that the target entity class is actually an `Entity` subclass.
+
+## Context
+- Related files:
+  - `packages/database/src/Entity/EntityDiscovery.php` — exact parallel; follow its scanning pattern
+  - `packages/core/src/Discovery/ClassFileParser.php` — used to find/load PHP files
+  - `packages/database/src/Entity/Entity.php`
+  - `packages/database/src/Entity/EntityExtension.php` (from task 001)
+  - `packages/database/src/Attributes/ExtensionOf.php` (from task 001)
+  - `packages/database/src/Entity/EntityExtensionMetadataFactory.php` (from task 002)
+- `EntityExtensionDiscovery` takes a `ClassFileParser` via constructor (mirror `EntityDiscovery`)
+- `EntityExtensionDiscovery` scans:
+  - `vendor/*/*/src/EntityExtension/` (two vendor levels, like `EntityDiscovery`)
+  - `modules/*/*/src/EntityExtension/` (two module levels)
+  - `app/*/EntityExtension/` and `app/*/src/EntityExtension/`
+- Each `discoverIn*` method MUST return `array<array{0: class-string<Entity>, 1: class-string<EntityExtension>}>` — i.e. a list of `[entityClass, extensionClass]` pairs. This is consumed by the boot wiring in task 009.
+- Discovery throws a loud `EntityException` if `#[ExtensionOf]` names a class that does not extend `Entity` (new factory method on `EntityException`: `extensionOfTargetNotEntity`)
+- Discovery silently skips files without `#[ExtensionOf]` or that don't extend `EntityExtension`
+- `EntityExtensionRegistry::register(string $entityClass, string $extensionClass)` is idempotent (safe to call twice with the same pair)
+- `EntityExtensionRegistry::getExtensions(string $entityClass): array<class-string<EntityExtension>>` returns all registered extension classes for an entity, empty array if none
+- `EntityExtensionRegistry` is not responsible for parsing; it only holds the mapping
+- `EntityExtensionRegistry` is mutable (state added via `register()`); do NOT mark it `readonly`
+
+## Requirements (Test Descriptions)
+- [ ] `it registers an extension class against its target entity class`
+- [ ] `it returns all registered extension classes for an entity`
+- [ ] `it returns empty array for entity with no registered extensions`
+- [ ] `it is idempotent when registering the same pair twice`
+- [ ] `it discovers extension classes in vendor src/EntityExtension directories`
+- [ ] `it discovers extension classes in modules src/EntityExtension directories`
+- [ ] `it discovers extension classes in app EntityExtension directories`
+- [ ] `it skips classes without ExtensionOf attribute`
+- [ ] `it skips classes that do not extend EntityExtension`
+- [ ] `it throws when ExtensionOf target class does not extend Entity`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- `EntityExtensionRegistry` lives at `Marko\Database\Entity\EntityExtensionRegistry`
+- `EntityExtensionDiscovery` lives at `Marko\Database\Entity\EntityExtensionDiscovery`
+- `EntityExtensionRegistry` exposes `register(string $entityClass, string $extensionClass): void` and `getExtensions(string $entityClass): array<class-string<EntityExtension>>`
+- `EntityExtensionDiscovery` exposes `discoverInVendor()`, `discoverInModules()`, `discoverInApp()`, each returning `array<array{0: class-string<Entity>, 1: class-string<EntityExtension>}>`
+- New factory method added to `Marko\Database\Exceptions\EntityException`: `extensionOfTargetNotEntity(string $extensionClass, string $targetClass)`
+- Code follows project standards

--- a/.claude/plans/entity-extension/004-entity-extension-bag.md
+++ b/.claude/plans/entity-extension/004-entity-extension-bag.md
@@ -1,0 +1,29 @@
+# Task 004: Entity — extension bag, `extension()`, `setExtension()`
+
+**Status**: completed
+**Depends on**: [001]
+**Retry count**: 0
+
+## Description
+Modify the `Entity` base class to carry a private extension bag and expose two methods: `setExtension()` for the hydrator to attach extension instances, and `extension()` — a `@template`-typed generic accessor — for consumers to retrieve typed extension instances. This is the only change to `Entity`.
+
+## Context
+- Related files: `packages/database/src/Entity/Entity.php`
+- The extension bag is `private array $extensions = []` keyed by extension class name (`class-string<EntityExtension>`)
+- Both methods MUST be `public` — `setExtension()` is called from `EntityHydrator` (task 006) and `Repository` consumers; `extension()` is the read accessor for consumers
+- `extension()` must use `@template T of EntityExtension` and `@param class-string<T>` / `@return T|null` so that PhpStorm, Psalm, and PHPStan all resolve the return type from the argument. The concrete return type hint is `?EntityExtension`
+- `setExtension()` accepts `EntityExtension $extension` and stores it keyed by `$extension::class`
+- Calling `setExtension()` twice with the same class overwrites the previous instance (last write wins)
+- `Entity` is not currently abstract-with-no-properties on purpose; the existing `EntityTest` instantiates an anonymous subclass with declared public properties — the added `$extensions` private property must not collide with any existing public property name. Verify the new property name `extensions` is not already declared on any entity in the repo before finalising. (Quick grep: search for `public.*\$extensions` across `packages/*/src/Entity/`.)
+- Tests for `Entity` currently only cover that it is abstract; add new tests in a separate test class or file rather than modifying existing tests if they would break
+
+## Requirements (Test Descriptions)
+- [ ] `it returns null for an extension that has not been set`
+- [ ] `it returns the extension instance after it is set`
+- [ ] `it overwrites a previously set extension of the same class`
+- [ ] `it stores multiple extensions independently by class`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- IDE type inference: `$entity->extension(MyExtension::class)` resolves to `MyExtension|null` via `@template`
+- Code follows project standards

--- a/.claude/plans/entity-extension/005-entity-metadata-factory-merge.md
+++ b/.claude/plans/entity-extension/005-entity-metadata-factory-merge.md
@@ -1,0 +1,46 @@
+# Task 005: EntityMetadata extensions field + EntityMetadataFactory merge
+
+**Status**: completed
+**Depends on**: [002, 003]
+**Retry count**: 0
+
+## Description
+Add an `extensions` field to `EntityMetadata` (a map of extension class → `ExtensionMetadata`) and update `EntityMetadataFactory` to query `EntityExtensionRegistry` when parsing an entity, building and attaching `ExtensionMetadata` for each registered extension. Detect and loudly report column name conflicts between the base entity and its extensions, or between two extensions.
+
+## Context
+- Related files:
+  - `packages/database/src/Entity/EntityMetadata.php` (currently `readonly class`)
+  - `packages/database/src/Entity/EntityMetadataFactory.php`
+  - `packages/database/src/Entity/ExtensionMetadata.php` (from task 002)
+  - `packages/database/src/Entity/EntityExtensionRegistry.php` (from task 003)
+  - `packages/database/src/Entity/EntityExtensionMetadataFactory.php` (from task 002)
+  - `packages/database/tests/Entity/EntityMetadataTest.php` — may need updating
+  - `packages/database/tests/Entity/EntityMetadataFactoryTest.php` — instantiates `new EntityMetadataFactory()`; must continue to work
+  - `packages/database/tests/Entity/EntityMetadataFactoryRelationshipTest.php` — instantiates `new EntityMetadataFactory()`; must continue to work
+  - All 26+ test files that call `new EntityMetadataFactory()` (search for the pattern across the monorepo before editing)
+- `EntityMetadata` gains a constructor parameter and property `public array $extensions = []` typed as `array<class-string<EntityExtension>, ExtensionMetadata>`, default empty. Because `EntityMetadata` is declared `readonly`, the field MUST be added as the LAST constructor parameter with a default of `[]` so all existing call-sites (`new EntityMetadata(entityClass: ..., tableName: ..., ...)`) continue to compile. Add appropriate phpdoc.
+- `EntityMetadataFactory` gains a constructor dependency on `EntityExtensionRegistry` and `EntityExtensionMetadataFactory`. **BREAKING-CHANGE MITIGATION**: both new constructor parameters MUST be nullable with a default of `null`. When `null`, the factory behaves as before (no extensions merged). The container will still inject real instances in production (because both are autowirable); only test code that does `new EntityMetadataFactory()` without args remains green without modification. Document this explicitly in a class-level comment.
+- After parsing the base entity properties, IF `$this->registry !== null && $this->extensionMetadataFactory !== null`, the factory calls `$this->registry->getExtensions($entityClass)`, parses each via `EntityExtensionMetadataFactory::parse()`, and builds an `array<class-string<EntityExtension>, ExtensionMetadata>` keyed by extension class name; this is passed to the `EntityMetadata` constructor.
+- Column conflict detection: collect all column names (base + all extensions); if any column name appears more than once, throw `EntityException` (new factory method: `extensionColumnConflict(string $entityClass, string $columnName, string $sourceA, string $sourceB)`) naming both the base/extension sources and the conflicting column name. `$sourceA`/`$sourceB` are either the entity class or an extension class.
+- Property NAME collisions are also possible (two extensions could declare the same public property name even if their column names differ). Detect and throw the same exception class (new factory method: `extensionPropertyConflict`).
+- The metadata cache must be invalidated/rebuilt if extensions are added after first parse — in practice the registry is fully populated before any parse call (boot ordering, task 009), so this is safe. Do not implement cache invalidation, but add a comment to that effect on the cache field.
+
+## Requirements (Test Descriptions)
+- [ ] `it includes an empty extensions map by default on EntityMetadata`
+- [ ] `it constructs EntityMetadataFactory with null registry and factory for backward compatibility`
+- [ ] `it populates extensions from the registry when parsing an entity with registered extensions`
+- [ ] `it leaves extensions empty when no extensions are registered for the entity`
+- [ ] `it leaves extensions empty when constructed without a registry`
+- [ ] `it throws when an extension column name collides with a base entity column name`
+- [ ] `it throws when two extension column names collide with each other`
+- [ ] `it throws when an extension property name collides with a base entity property name`
+- [ ] `it caches entity metadata including extensions`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Existing `EntityMetadataTest` and `EntityMetadataFactoryRelationshipTest` tests continue to pass without modification
+- All 26+ test files that instantiate `new EntityMetadataFactory()` directly continue to compile and pass
+- New factory methods added to `Marko\Database\Exceptions\EntityException`:
+  - `extensionColumnConflict(string $entityClass, string $columnName, string $sourceA, string $sourceB)`
+  - `extensionPropertyConflict(string $entityClass, string $propertyName, string $sourceA, string $sourceB)`
+- Code follows project standards

--- a/.claude/plans/entity-extension/006-entity-hydrator-extensions.md
+++ b/.claude/plans/entity-extension/006-entity-hydrator-extensions.md
@@ -1,0 +1,42 @@
+# Task 006: EntityHydrator — hydrate extensions from same DB row
+
+**Status**: completed
+**Depends on**: [004, 005]
+**Retry count**: 0
+
+## Description
+Update `EntityHydrator::hydrate()` to also hydrate all extension objects registered for the entity from the same DB row and attach them to the entity via `setExtension()`. Because extension columns are in the same table, the row already contains them — no extra query is needed.
+
+## Context
+- Related files:
+  - `packages/database/src/Entity/EntityHydrator.php`
+  - `packages/database/src/Entity/Entity.php` (modified in task 004)
+  - `packages/database/src/Entity/EntityMetadata.php` (modified in task 005)
+  - `packages/database/src/Entity/ExtensionMetadata.php` (from task 002)
+  - `packages/database/tests/Entity/EntityHydratorTest.php` — extend with extension scenarios
+- `EntityHydrator::convertToPhpType()` is currently `private` and takes a `PropertyMetadata`. Since `ExtensionMetadata::$properties` is also `array<string, PropertyMetadata>`, the existing private method works as-is for extension property conversion when called from inside `EntityHydrator`. Do NOT change its visibility; reuse it directly from the new extension-hydration code path inside the same class.
+- After hydrating base entity properties (existing logic), iterate `$metadata->extensions`
+- For each `ExtensionMetadata`:
+  1. Create a new instance of the extension class via `ReflectionClass::newInstanceWithoutConstructor()`
+  2. For each property in `ExtensionMetadata::$properties`, look up the column name, read the value from `$row`, convert to PHP type via the existing private `convertToPhpType()`, and set the property via reflection
+  3. **Partial-row handling**: if NONE of the extension's column names are present in `$row`, skip hydrating that extension entirely (do not attach it). If SOME are present and others are not, hydrate the present ones and leave the missing ones uninitialised (matching base-entity hydrator behaviour at line 53 of `EntityHydrator.php`, which uses `continue` when a column is missing).
+  4. Call `$entity->setExtension($extensionInstance)` to attach
+- Original values tracking (for dirty detection) does NOT apply to extension instances in this iteration — do not write to `$this->originalValues` for extension property values
+
+## Requirements (Test Descriptions)
+- [ ] `it attaches a hydrated extension instance to the entity when its columns are in the row`
+- [ ] `it hydrates extension property values from the DB row`
+- [ ] `it skips attaching an extension when none of its columns are present in the row`
+- [ ] `it partially hydrates an extension when only some of its columns are present in the row`
+- [ ] `it hydrates multiple extensions from the same row independently`
+- [ ] `it converts extension column values to the correct PHP types`
+- [ ] `it converts nullable extension column values to null`
+- [ ] `it converts JSON extension column values to arrays`
+- [ ] `it converts BackedEnum extension column values via the enum class`
+- [ ] `it does not affect base entity hydration when no extensions are registered`
+- [ ] `it does not include extension property values in the originalValues dirty-tracking map`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Existing hydrator tests continue to pass
+- Code follows project standards

--- a/.claude/plans/entity-extension/007-repository-extension-columns.md
+++ b/.claude/plans/entity-extension/007-repository-extension-columns.md
@@ -1,0 +1,48 @@
+# Task 007: Repository — include extension columns in INSERT/UPDATE
+
+**Status**: pending
+**Depends on**: [005, 006]
+**Retry count**: 0
+
+## Description
+Update `Repository::insert()` and `Repository::update()` to include extension column data when persisting entities. For INSERT: extract all extension data and merge with base data. For UPDATE: always write all extension columns (no dirty-checking on extensions). When an extension is not attached to the entity being saved, apply the null/default/error policy per column.
+
+## Context
+- Related files:
+  - `packages/database/src/Repository/Repository.php`
+  - `packages/database/src/Entity/EntityMetadata.php` (with extensions)
+  - `packages/database/src/Entity/ExtensionMetadata.php`
+  - `packages/database/src/Entity/PropertyMetadata.php`
+  - `packages/database/src/Entity/EntityHydrator.php` — may need a new public helper (see below)
+  - `packages/database/src/Exceptions/RepositoryException.php` — add new factory method
+  - `packages/database/tests/Repository/RepositoryTest.php` — extend with extension tests
+- **Null/default/error policy** when extension is not attached:
+  - Column nullable → use `null`
+  - Column non-nullable AND `PropertyMetadata::$default` is not `null` → use that default
+  - Column non-nullable AND no default → throw `RepositoryException` with a clear message naming the extension class and the column (new factory method: `RepositoryException::extensionRequired(string $entityClass, string $extensionClass, string $columnName)`)
+- **Extraction**: add a new public helper `EntityHydrator::extractExtensions(Entity $entity, EntityMetadata $metadata): array<string, mixed>` that returns column-name => DB-value for every extension column on the entity, applying the null/default/error policy above. This keeps reflection-based conversion logic centralised in the hydrator. `Repository::insert()` and `Repository::update()` then merge the result with the base `extract()` output.
+- **UPDATE early-return bug**: `Repository::update()` currently returns early when `count($dirtyProperties) === 0`. Since UPDATE must always write all extension columns, this short-circuit must change: only skip if BOTH `$dirtyProperties` is empty AND `$metadata->extensions` is empty. When base is clean but extensions exist, still issue the UPDATE statement for extension columns only (plus WHERE on PK).
+- For UPDATE, always write ALL extension columns (not just dirty ones). The SET clause includes all extension column names, even if unchanged. This is a conscious simplification.
+- **`insertBatch()` consistency**: `extractBatchRow()` is called per-entity and the column sets are compared via `array_keys`. Because all rows in a batch share the same entity class and the extension column set is determined by `$metadata->extensions` (not by which extensions are attached), `extractBatchRow()` must always include the SAME extension columns for every row in the batch — applying the null/default policy per-row independently. If any row in the batch lacks an extension that another row has AND the policy throws (non-nullable, no default), the batch fails for that entity (loud error). Document this explicitly.
+- Auto-increment PK exclusion in `extractBatchRow()` only strips the base entity PK column — extension columns are never primary keys (enforced by task 002), so they are always included.
+- The base-entity `extract()` already converts BackedEnum and DateTimeImmutable values; the new extension extractor must do the same (reuse `convertToDbValue` logic — currently `private` in hydrator; if needed, factor it into a shared private method called by both `extract()` and `extractExtensions()`).
+
+## Requirements (Test Descriptions)
+- [ ] `it includes extension columns in the INSERT statement when extension is attached`
+- [ ] `it uses null for nullable extension columns when extension is not attached`
+- [ ] `it uses declared default for non-nullable extension columns when extension is not attached`
+- [ ] `it throws when a non-nullable extension column has no default and no extension is attached`
+- [ ] `it includes extension columns in the UPDATE statement`
+- [ ] `it still issues an UPDATE for extension columns when no base entity properties are dirty`
+- [ ] `it does not issue an UPDATE when there are no dirty base properties and no extensions registered`
+- [ ] `it includes extension columns in batch insert`
+- [ ] `it writes correct extension values for multiple extensions on the same entity`
+- [ ] `it converts BackedEnum extension property values to backing values before persisting`
+- [ ] `it converts DateTimeImmutable extension property values to formatted strings before persisting`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Existing repository tests continue to pass without modification
+- New factory method added to `Marko\Database\Exceptions\RepositoryException`: `extensionRequired(string $entityClass, string $extensionClass, string $columnName)`
+- New public method on `EntityHydrator`: `extractExtensions(Entity $entity, EntityMetadata $metadata): array<string, mixed>`
+- Code follows project standards

--- a/.claude/plans/entity-extension/008-schema-builder-extension-columns.md
+++ b/.claude/plans/entity-extension/008-schema-builder-extension-columns.md
@@ -1,0 +1,32 @@
+# Task 008: SchemaBuilder — include extension columns in table schema
+
+**Status**: pending
+**Depends on**: [005]
+**Retry count**: 0
+
+## Description
+Update `SchemaBuilder::build()` to append columns from all registered extensions onto the table schema it produces. Since extension columns live in the same table, they must be included in the `Table` value object that the diff/migration system uses.
+
+## Context
+- Related files:
+  - `packages/database/src/Entity/SchemaBuilder.php`
+  - `packages/database/src/Entity/EntityMetadata.php` (with extensions from task 005)
+  - `packages/database/src/Entity/ExtensionMetadata.php`
+  - `packages/database/tests/Entity/SchemaBuilderTest.php` — extend with extension scenarios
+- `SchemaBuilder::build()` currently maps `$metadata->columns` to `Column` schema objects. Build a merged `ColumnMetadata[]` array consisting of `$metadata->columns` followed by every extension's `$extensionMetadata->columns`, then map the merged set through `buildColumn()` in a single pass.
+- Foreign key building (`buildForeignKeys()`) must receive the SAME merged `ColumnMetadata[]` set, so that extension columns with `references` produce FK schema entries. The FK name format `fk_{tableName}_{columnName}` already disambiguates extension FKs by column name.
+- Extension columns do not contribute indexes (out of scope); do not add index logic.
+- **Column ordering**: base entity columns appear FIRST (preserving primary key position), then extension columns appended in registry-iteration order. Document that the ordering between extensions is non-deterministic across systems and SHOULD NOT be relied on for migration diffs that compare ordinal positions — only column names matter for the diff system (see `packages/database/src/Diff/`).
+- **Column conflict assumption**: this task assumes column name conflicts have already been rejected in task 005's metadata factory pass. `SchemaBuilder` does NOT re-validate.
+
+## Requirements (Test Descriptions)
+- [ ] `it includes extension columns in the built Table schema`
+- [ ] `it builds correct column types for extension columns`
+- [ ] `it includes foreign key constraints from extension columns that reference other tables`
+- [ ] `it produces the same Table as before when no extensions are registered`
+- [ ] `it includes columns from multiple extensions`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Existing `SchemaBuilderTest` tests continue to pass
+- Code follows project standards

--- a/.claude/plans/entity-extension/009-boot-wiring.md
+++ b/.claude/plans/entity-extension/009-boot-wiring.md
@@ -1,0 +1,56 @@
+# Task 009: Boot wiring — populate registry via discovery in module.php
+
+**Status**: completed
+**Depends on**: [003]
+**Retry count**: 0
+
+## Description
+Wire `EntityExtensionRegistry` as a singleton in `database/module.php` and populate it at boot via `EntityExtensionDiscovery`. The registry must be fully populated before any repository is resolved from the container.
+
+## Context
+- Related files:
+  - `packages/database/module.php` — currently only declares `bindings`; this task adds `singletons` and `boot` keys
+  - `packages/database/src/Entity/EntityExtensionRegistry.php` (from task 003)
+  - `packages/database/src/Entity/EntityExtensionDiscovery.php` (from task 003)
+  - `packages/database/src/Entity/EntityExtensionMetadataFactory.php` (from task 002)
+  - `Marko\Core\Path\ProjectPaths` — already in container, provides `->vendor`, `->modules`, `->app`
+- **Current state of `module.php`**: only has the `bindings` array (with `SeederDiscoveryInterface` and the `SeederRunner` closure). There is NO `singletons` or `boot` key today. Both must be ADDED, not edited.
+- Reference for `boot` autowiring: `packages/debugbar/module.php` (`'boot' => static function (Debugbar $debugbar): void { ... }`) and `packages/notification/module.php`. The `Application::bootModules()` method (`packages/core/src/Application.php`, around line 178-184) uses `$this->container->call($module->boot)`, so parameter type-hints are autowired from the container.
+- Pattern to follow:
+  ```php
+  // In module.php top-level return array:
+  'singletons' => [
+      EntityExtensionRegistry::class => EntityExtensionRegistry::class,
+  ],
+  'boot' => static function (
+      EntityExtensionRegistry $registry,
+      EntityExtensionDiscovery $discovery,
+      ProjectPaths $paths,
+  ): void {
+      $pairs = array_merge(
+          $discovery->discoverInVendor($paths->vendor),
+          $discovery->discoverInModules($paths->modules),
+          $discovery->discoverInApp($paths->app),
+      );
+      foreach ($pairs as [$entityClass, $extensionClass]) {
+          $registry->register($entityClass, $extensionClass);
+      }
+  },
+  ```
+- The discover methods return `array<array{0: class-string<Entity>, 1: class-string<EntityExtension>}>` per task 003 — destructuring is safe.
+- `EntityExtensionRegistry` MUST be in `singletons` so the registry instance shared with `EntityMetadataFactory` (injected via the container) is the same one populated at boot.
+- `EntityExtensionDiscovery` and `EntityExtensionMetadataFactory` are autowirable (no special binding needed); both will resolve via the container.
+- **Boot ordering caveat**: per `Application::bootModules()` in core, boot callbacks run AFTER all modules' bindings are registered. The registry will be populated before any controller/route handler resolves a Repository, so first-parse metadata will include extensions. Test wiring (unit tests that instantiate `EntityMetadataFactory` directly) does NOT trigger boot — those tests pass `null` registry per task 005's backward-compat shim.
+- This task only touches `module.php`; no new PHP classes are needed.
+
+## Requirements (Test Descriptions)
+- [x] `it registers EntityExtensionRegistry as a singleton in the container`
+- [x] `it declares a boot callback in module.php that populates the registry from discovery`
+
+Note: these are integration-level assertions. Test by `require`-ing `packages/database/module.php` and asserting the array contains a `singletons` key with `EntityExtensionRegistry::class` and a `boot` key whose value is a callable. Structural assertions on the module.php export array are sufficient for this task; full container-boot integration is covered by the existing `PackageScaffoldingTest` patterns. Do NOT shell out to spin up a full app.
+
+## Acceptance Criteria
+- All requirements have passing tests
+- `EntityExtensionRegistry` is in `singletons`
+- Boot callback populates the registry using `EntityExtensionDiscovery` and `ProjectPaths`
+- Code follows project standards

--- a/.claude/plans/entity-extension/010-readme.md
+++ b/.claude/plans/entity-extension/010-readme.md
@@ -1,0 +1,34 @@
+# Task 010: README
+
+**Status**: completed
+**Depends on**: [007, 008, 009]
+**Retry count**: 0
+
+## Description
+Update the `marko/database` package README to document the entity extension system. The README should cover how to declare an extension, what the framework does automatically, how to access extensions on fetched entities, the save-time null/default/error policy, and column conflict behaviour.
+
+## Context
+- Related files: `packages/database/README.md`
+- Follow the existing README structure and tone
+- Document the complete developer workflow:
+  1. Create an `EntityExtension` subclass in `src/EntityExtension/`
+  2. Annotate with `#[ExtensionOf(TargetEntity::class)]`
+  3. Declare `#[Column]` properties
+  4. Run migrations to add the new columns
+  5. Access via `$entity->extension(MyExtension::class)`
+  6. Set before saving: `$entity->setExtension(new MyExtension(...))`
+- Include a note about the null/default/error policy on save
+- Include a note about the column conflict detection (column name AND property name collisions)
+- Include a note that UPDATEs always rewrite ALL extension columns (no dirty tracking on extensions)
+- Include a note that an extension is skipped during hydration when none of its columns are present in the row (so freshly added extensions before migration won't crash hydration)
+- Include a note that extensions cannot declare primary keys, relationships, indexes, or `#[Table]`
+- Do NOT document out-of-scope items (separate-table extensions, dirty tracking on extensions)
+
+## Requirements (Test Descriptions)
+- [x] `it has a README that documents entity extensions`
+
+A structural test that asserts `README.md` exists and contains the string `EntityExtension` is sufficient.
+
+## Acceptance Criteria
+- README exists and covers the entity extension feature
+- Code follows project standards

--- a/.claude/plans/entity-extension/_plan.md
+++ b/.claude/plans/entity-extension/_plan.md
@@ -1,0 +1,89 @@
+# Plan: Entity Extension
+
+## Created
+2026-05-11
+
+## Status
+completed
+
+## Objective
+Allow any module to add columns to an existing entity's table without modifying the entity class. Extensions are discovered automatically, merged into the entity's schema at boot, hydrated transparently from the same DB row, and accessed via a typed `extension()` method that IDEs understand via `@template`.
+
+## Related Issues
+none
+
+## Discovery Notes
+The current entity system is entirely reflection-based: `EntityMetadataFactory` reads `#[Column]` from declared public properties; `EntityHydrator` sets those properties via reflection; `Repository` types everything against a compile-time `ENTITY_CLASS` constant. All data lives in one table per entity.
+
+Extension columns must also live in the same table (same-table strategy; separate-table is out of scope). Since `__get`/`__set` are forbidden, extended data cannot be accessed as direct properties on the base entity — instead, a typed `extension()` accessor is used. The `@template` annotation on that method gives IDEs full type resolution without any code generation.
+
+`ProjectPaths` (already in the container) provides vendor/modules/app path strings, matching the pattern used by `SeederRunner` wiring in `database/module.php`.
+
+`SchemaBuilder.build()` iterates `metadata->columns` directly — it only needs to be taught to also iterate extension columns from a new `extensions` field on `EntityMetadata`.
+
+## Scope
+
+### In Scope
+- `EntityExtension` abstract base class
+- `#[ExtensionOf]` attribute declaring which entity class an extension targets
+- `ExtensionMetadata` value object (properties + columns, no table/PK)
+- `EntityExtensionMetadataFactory` — parses extension classes
+- `EntityExtensionRegistry` — singleton, maps entity class → list of extension classes
+- `EntityExtensionDiscovery` — scans `src/EntityExtension/` directories in vendor/modules/app
+- `Entity` gains private `$extensions` bag, `extension()` generic accessor, `setExtension()`
+- `EntityMetadata` gains `extensions: array<class-string, ExtensionMetadata>` field
+- `EntityMetadataFactory` injects registry, merges extension metadata, detects column conflicts
+- `EntityHydrator` hydrates extension objects from same DB row, attaches to entity
+- `Repository::insert()` and `update()` include extension columns (null/default/error logic)
+- `SchemaBuilder::build()` includes extension columns in the table schema
+- Boot wiring in `database/module.php` — registry populated via discovery at boot
+
+### Out of Scope
+- Separate-table storage for extension data
+- Dirty-checking on extension properties (updates always write all extension columns)
+- Relationships on extension classes
+- Indexes declared on extension classes
+
+## Success Criteria
+- [ ] Any module can declare an `EntityExtension` subclass in `src/EntityExtension/` and have its columns auto-discovered and merged into the target entity's table schema
+- [ ] Repositories hydrate extensions transparently from the same DB row with no explicit `with()` call
+- [ ] `$entity->extension(MyExtension::class)` returns `MyExtension|null`, IDE infers the return type
+- [ ] Saving an entity without an extension attached: nullable columns → NULL, declared defaults → default value, non-nullable with no default → loud exception
+- [ ] Column name collision between two extensions on the same entity → loud exception at boot
+- [ ] All tests passing
+- [ ] Code follows project standards
+
+## Task Overview
+| Task | Description | Depends On | Status |
+|------|-------------|------------|--------|
+| 001 | EntityExtension base class + `#[ExtensionOf]` attribute | - | completed |
+| 002 | ExtensionMetadata + EntityExtensionMetadataFactory | 001 | completed |
+| 003 | EntityExtensionRegistry + EntityExtensionDiscovery | 001, 002 | completed |
+| 004 | Entity: extension bag, `extension()`, `setExtension()` | 001 | completed |
+| 005 | EntityMetadata: extensions field + EntityMetadataFactory: merge extensions | 002, 003 | completed |
+| 006 | EntityHydrator: hydrate extensions from same DB row | 004, 005 | completed |
+| 007 | Repository: include extension columns in INSERT/UPDATE | 005, 006 | pending |
+| 008 | SchemaBuilder: include extension columns in table schema | 005 | pending |
+| 009 | Boot wiring: populate registry via discovery in module.php | 003 | completed |
+| 010 | README | 007, 008, 009 | completed |
+
+## Architecture Notes
+- Extension columns live in the base entity's table — `SELECT *` returns them automatically, so extensions are always available on fetched entities (no lazy-loading concept needed).
+- `EntityExtensionRegistry` must be a singleton (wired in `module.php` `singletons`). It is populated in the `boot` callback before any repository is used.
+- `EntityMetadataFactory` already caches by class; merging extensions into the cache means the overhead is paid exactly once per entity class per process.
+- UPDATE always writes all extension columns (no dirty-checking on extensions) to avoid needing a parallel WeakMap for extension original values. This is a known limitation and acceptable for the initial implementation.
+- The `#[ExtensionOf]` attribute argument cannot be validated at attribute-definition time (PHP attributes are lazy); validation happens in `EntityExtensionDiscovery` when the class is discovered.
+- **Backward compatibility for `EntityMetadataFactory`**: the factory's new constructor parameters (`EntityExtensionRegistry`, `EntityExtensionMetadataFactory`) are both nullable with `null` defaults. This keeps existing test code that does `new EntityMetadataFactory()` working (26+ test files in `packages/database/tests/` and `packages/admin-auth/tests/`). Container-injected instances get real dependencies; direct test instantiation falls back to "no extensions" behaviour.
+- **`EntityMetadata` is `readonly`**: the new `extensions` field is added as the LAST constructor parameter with default `[]` so all existing call-sites continue to work without modification.
+- **`Repository::update()` early-return**: the current `if (count($dirtyProperties) === 0) return;` short-circuit must be updated to also account for extension columns; otherwise saves on clean base entities with extensions never persist.
+- **`Repository::insertBatch()` column-set consistency**: the batch path verifies all rows have the same column set via `array_keys`. Extension columns are determined by metadata, not per-entity attachment, so column sets remain consistent — but the null/default/error policy is applied per-row and can fail for individual rows independently.
+- **Discovery method return shape**: `EntityExtensionDiscovery::discoverIn*` returns `array<array{0: class-string<Entity>, 1: class-string<EntityExtension>}>` (list of pairs); both task 003 (definition) and task 009 (consumption) agree on this shape.
+- **`EntityHydrator::convertToPhpType` reuse**: kept `private`; extension hydration code path lives inside `EntityHydrator` and calls the private method directly. No visibility change required.
+
+## Risks & Mitigations
+- Extension columns conflicting with base entity columns: detected and thrown as a loud exception in `EntityMetadataFactory` when merging.
+- Extension columns conflicting with other extension columns: same detection pass.
+- Extension property names conflicting with base entity property names (separate from column names): same detection pass.
+- Registry not yet populated when MetadataFactory is called: registry is a singleton populated in boot before the first repository resolution; unit tests wire the registry explicitly or pass `null` to the factory constructor for backward-compat.
+- Constructor change to `EntityMetadataFactory` breaking 26+ test sites: mitigated by nullable defaults on the new parameters.
+- Extension class on entity that hasn't been migrated yet (column missing in `$row`): hydrator skips that extension entirely if NO columns are present, or partially hydrates if SOME are present (matching base-entity behaviour); SAVE-time policy applies independently.

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -37,6 +37,93 @@ class PostRepository extends Repository
 }
 ```
 
+## Entity Extensions
+
+Any module can add columns to an existing entity's table without modifying the original entity class. Extensions are auto-discovered, merged into the entity's schema at boot, and hydrated transparently from the same DB row.
+
+### Declaring an Extension
+
+Create a class in `src/EntityExtension/` that extends `EntityExtension` and annotate it with `#[ExtensionOf]`:
+
+```php
+use Marko\Database\Attributes\Column;
+use Marko\Database\Attributes\ExtensionOf;
+use Marko\Database\Entity\EntityExtension;
+
+#[ExtensionOf(Product::class)]
+class PricingExtension extends EntityExtension
+{
+    #[Column]
+    public float $price;
+
+    #[Column(nullable: true)]
+    public ?string $currency = null;
+}
+```
+
+The framework discovers this class automatically — no registration step required.
+
+### Running Migrations
+
+After declaring an extension, run a schema diff and migration to add the new columns to the existing table. The columns live in the base entity's table (`products` in this example), so a standard `SELECT *` query returns them automatically.
+
+### Accessing Extensions
+
+```php
+$product = $productRepository->find(1);
+
+$pricing = $product->extension(PricingExtension::class); // PricingExtension|null
+
+if ($pricing !== null) {
+    echo $pricing->price;
+}
+```
+
+The `extension()` method is typed with `@template`, so IDEs infer the exact return type without any code generation.
+
+### Setting Extensions Before Saving
+
+Attach an extension instance before inserting or updating:
+
+```php
+$product = new Product();
+$product->sku = 'ABC-123';
+$product->name = 'Widget';
+
+$extension = new PricingExtension();
+$extension->price = 9.99;
+$product->setExtension($extension);
+
+$productRepository->insert($product);
+```
+
+### Save-Time Policy (When Extension Is Not Attached)
+
+If an entity is saved without a particular extension attached, the framework applies the following policy per column:
+
+| Column type | Behaviour |
+|---|---|
+| Nullable (`?type`) | Written as `NULL` |
+| Non-nullable with a default value | Written as the declared default |
+| Non-nullable with no default | Throws `RepositoryException` loudly |
+
+### Behaviour Notes
+
+- **Hydration**: if none of an extension's columns are present in the DB row (e.g. the migration has not been run yet), the extension is silently skipped and `extension()` returns `null`. This prevents crashes during a rolling deployment where the column was just added.
+- **Updates**: all extension columns are always written on every `UPDATE`, regardless of whether their values changed. Extension properties are not dirty-tracked.
+- **Column conflicts**: if two extensions (or an extension and the base entity) declare the same column name or property name, the framework throws an exception at boot — never at runtime.
+
+### Restrictions
+
+Extension classes **cannot** declare:
+
+- A `#[Table]` attribute
+- A primary key column (`primaryKey: true`)
+- Relationship properties
+- Index annotations
+
+Violating any of these restrictions throws an exception when the extension is parsed.
+
 ## Documentation
 
 Full usage, API reference, and examples: [marko/database](https://marko.build/docs/packages/database/)

--- a/packages/database/module.php
+++ b/packages/database/module.php
@@ -5,11 +5,30 @@ declare(strict_types=1);
 use Marko\Core\Container\ContainerInterface;
 use Marko\Core\Path\ProjectPaths;
 use Marko\Database\Connection\TransactionInterface;
+use Marko\Database\Entity\EntityExtensionDiscovery;
+use Marko\Database\Entity\EntityExtensionRegistry;
 use Marko\Database\Seed\SeederDiscovery;
 use Marko\Database\Seed\SeederDiscoveryInterface;
 use Marko\Database\Seed\SeederRunner;
 
 return [
+    'singletons' => [
+        EntityExtensionRegistry::class => EntityExtensionRegistry::class,
+    ],
+    'boot' => static function (
+        EntityExtensionRegistry $registry,
+        EntityExtensionDiscovery $discovery,
+        ProjectPaths $paths,
+    ): void {
+        $pairs = array_merge(
+            $discovery->discoverInVendor($paths->vendor),
+            $discovery->discoverInModules($paths->modules),
+            $discovery->discoverInApp($paths->app),
+        );
+        foreach ($pairs as [$entityClass, $extensionClass]) {
+            $registry->register($entityClass, $extensionClass);
+        }
+    },
     'bindings' => [
         SeederDiscoveryInterface::class => SeederDiscovery::class,
         SeederRunner::class => function (ContainerInterface $container): SeederRunner {

--- a/packages/database/src/Attributes/ExtensionOf.php
+++ b/packages/database/src/Attributes/ExtensionOf.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Attributes;
+
+use Attribute;
+use Marko\Database\Entity\Entity;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+readonly class ExtensionOf
+{
+    /**
+     * @param class-string<Entity> $entityClass
+     */
+    public function __construct(
+        public string $entityClass,
+    ) {}
+}

--- a/packages/database/src/Entity/Entity.php
+++ b/packages/database/src/Entity/Entity.php
@@ -4,4 +4,23 @@ declare(strict_types=1);
 
 namespace Marko\Database\Entity;
 
-abstract class Entity {}
+abstract class Entity
+{
+    /** @var array<class-string<EntityExtension>, EntityExtension> */
+    private array $extensions = [];
+
+    public function setExtension(EntityExtension $extension): void
+    {
+        $this->extensions[$extension::class] = $extension;
+    }
+
+    /**
+     * @template T of EntityExtension
+     * @param class-string<T> $class
+     * @return T|null
+     */
+    public function extension(string $class): ?EntityExtension
+    {
+        return $this->extensions[$class] ?? null;
+    }
+}

--- a/packages/database/src/Entity/EntityExtension.php
+++ b/packages/database/src/Entity/EntityExtension.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Entity;
+
+abstract class EntityExtension {}

--- a/packages/database/src/Entity/EntityExtensionDiscovery.php
+++ b/packages/database/src/Entity/EntityExtensionDiscovery.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Entity;
+
+use Marko\Core\Discovery\ClassFileParser;
+use Marko\Database\Attributes\ExtensionOf;
+use Marko\Database\Exceptions\EntityException;
+use ReflectionClass;
+
+/**
+ * Discovers entity extension classes with #[ExtensionOf] attribute across modules.
+ */
+class EntityExtensionDiscovery
+{
+    public function __construct(
+        private ClassFileParser $classFileParser,
+    ) {}
+
+    /**
+     * Discover extensions in vendor/vendor-name/package-name/src/EntityExtension directories.
+     *
+     * @return array<array{0: class-string<Entity>, 1: class-string<EntityExtension>}>
+     *
+     * @throws EntityException
+     */
+    public function discoverInVendor(string $vendorPath): array
+    {
+        if (!is_dir($vendorPath)) {
+            return [];
+        }
+
+        $pairs = [];
+
+        foreach (glob($vendorPath . '/*/*/src/EntityExtension', GLOB_ONLYDIR) as $dir) {
+            $pairs = array_merge($pairs, $this->discoverInPath($dir));
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * Discover extensions in modules/vendor-name/module-name/src/EntityExtension directories.
+     *
+     * @return array<array{0: class-string<Entity>, 1: class-string<EntityExtension>}>
+     *
+     * @throws EntityException
+     */
+    public function discoverInModules(string $modulesPath): array
+    {
+        if (!is_dir($modulesPath)) {
+            return [];
+        }
+
+        $pairs = [];
+
+        foreach (glob($modulesPath . '/*/*/src/EntityExtension', GLOB_ONLYDIR) as $dir) {
+            $pairs = array_merge($pairs, $this->discoverInPath($dir));
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * Discover extensions in app/module-name/EntityExtension and app/module-name/src/EntityExtension directories.
+     *
+     * @return array<array{0: class-string<Entity>, 1: class-string<EntityExtension>}>
+     *
+     * @throws EntityException
+     */
+    public function discoverInApp(string $appPath): array
+    {
+        if (!is_dir($appPath)) {
+            return [];
+        }
+
+        $pairs = [];
+
+        foreach (glob($appPath . '/*/EntityExtension', GLOB_ONLYDIR) as $dir) {
+            $pairs = array_merge($pairs, $this->discoverInPath($dir));
+        }
+
+        foreach (glob($appPath . '/*/src/EntityExtension', GLOB_ONLYDIR) as $dir) {
+            $pairs = array_merge($pairs, $this->discoverInPath($dir));
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * Discover extensions in a specific path.
+     *
+     * @return array<array{0: class-string<Entity>, 1: class-string<EntityExtension>}>
+     *
+     * @throws EntityException
+     */
+    public function discoverInPath(string $path): array
+    {
+        if (!is_dir($path)) {
+            return [];
+        }
+
+        $pairs = [];
+
+        foreach ($this->classFileParser->findPhpFiles($path) as $file) {
+            $filePath = $file->getPathname();
+            $className = $this->classFileParser->extractClassName($filePath);
+
+            if ($className === null) {
+                continue;
+            }
+
+            if (!$this->classFileParser->loadClass($filePath, $className)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($className);
+
+            // Must extend EntityExtension
+            if (!$reflection->isSubclassOf(EntityExtension::class)) {
+                continue;
+            }
+
+            // Must have #[ExtensionOf] attribute
+            $extensionOfAttrs = $reflection->getAttributes(ExtensionOf::class);
+            if (count($extensionOfAttrs) === 0) {
+                continue;
+            }
+
+            $entityClass = $extensionOfAttrs[0]->newInstance()->entityClass;
+
+            // Validate that target entity extends Entity
+            if (!is_subclass_of($entityClass, Entity::class)) {
+                throw EntityException::extensionOfTargetNotEntity($className, $entityClass);
+            }
+
+            $pairs[] = [$entityClass, $className];
+        }
+
+        return $pairs;
+    }
+}

--- a/packages/database/src/Entity/EntityExtensionMetadataFactory.php
+++ b/packages/database/src/Entity/EntityExtensionMetadataFactory.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Entity;
+
+use BackedEnum;
+use Marko\Database\Attributes\BelongsTo;
+use Marko\Database\Attributes\BelongsToMany;
+use Marko\Database\Attributes\Column;
+use Marko\Database\Attributes\ExtensionOf;
+use Marko\Database\Attributes\HasMany;
+use Marko\Database\Attributes\HasOne;
+use Marko\Database\Attributes\Index;
+use Marko\Database\Attributes\Table;
+use Marko\Database\Exceptions\EntityException;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionProperty;
+
+/**
+ * Parses entity extension classes and extracts metadata from attributes.
+ */
+class EntityExtensionMetadataFactory
+{
+    /**
+     * PHP type to database type mapping.
+     */
+    private const array TYPE_MAP = [
+        'int' => 'integer',
+        'string' => 'varchar',
+        'float' => 'decimal',
+        'bool' => 'boolean',
+        'array' => 'json',
+    ];
+
+    /**
+     * @var array<class-string, ExtensionMetadata>
+     */
+    private array $cache = [];
+
+    /**
+     * Parse an extension class and return its metadata.
+     *
+     * @param class-string $extensionClass
+     *
+     * @throws EntityException
+     */
+    public function parse(string $extensionClass): ExtensionMetadata
+    {
+        if (isset($this->cache[$extensionClass])) {
+            return $this->cache[$extensionClass];
+        }
+
+        $reflection = new ReflectionClass($extensionClass);
+
+        $this->validateExtension($reflection, $extensionClass);
+
+        $entityClass = $this->extractEntityClass($reflection, $extensionClass);
+        $columns = [];
+        $properties = [];
+
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $this->validateNoRelationship($property, $extensionClass);
+
+            $columnAttributes = $property->getAttributes(Column::class);
+
+            if (count($columnAttributes) === 0) {
+                continue;
+            }
+
+            $columnAttr = $columnAttributes[0]->newInstance();
+            $propertyName = $property->getName();
+
+            if ($columnAttr->primaryKey) {
+                throw EntityException::extensionDeclaresPrimaryKey($extensionClass, $propertyName);
+            }
+
+            $columnName = $columnAttr->name ?? $this->camelToSnakeCase($propertyName);
+            $type = $property->getType();
+
+            if (!$type instanceof ReflectionNamedType) {
+                throw EntityException::missingTypeDeclaration($extensionClass, $propertyName);
+            }
+
+            $phpType = $type->getName();
+            $dbType = $columnAttr->type ?? $this->inferDatabaseType($phpType);
+            $nullable = $type->allowsNull();
+            $default = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
+
+            // Convert BackedEnum default values to their backing value for database storage
+            if ($default instanceof BackedEnum) {
+                $default = $default->value;
+            }
+
+            if ($columnAttr->type === 'json' && $phpType !== 'array') {
+                throw EntityException::jsonColumnTypeMismatch($extensionClass, $propertyName, $phpType);
+            }
+
+            if ($columnAttr->type === 'json' && $columnAttr->nullable !== null && $columnAttr->nullable !== $nullable) {
+                throw EntityException::jsonColumnNullableMismatch(
+                    $extensionClass,
+                    $propertyName,
+                    $columnAttr->nullable,
+                    $nullable,
+                );
+            }
+
+            $columns[] = new ColumnMetadata(
+                name: $columnName,
+                type: $dbType,
+                length: $columnAttr->length,
+                nullable: $nullable,
+                default: $columnAttr->default ?? $default,
+                unique: $columnAttr->unique,
+                primaryKey: false,
+                autoIncrement: false,
+                references: $columnAttr->references,
+                onDelete: $columnAttr->onDelete,
+                onUpdate: $columnAttr->onUpdate,
+            );
+
+            // Detect if the type is a BackedEnum
+            $enumClass = null;
+            if (enum_exists($phpType) && is_subclass_of($phpType, BackedEnum::class)) {
+                $enumClass = $phpType;
+            }
+
+            $properties[$propertyName] = new PropertyMetadata(
+                name: $propertyName,
+                columnName: $columnName,
+                type: $phpType,
+                nullable: $nullable,
+                isPrimaryKey: false,
+                isAutoIncrement: false,
+                enumClass: $enumClass,
+                default: $columnAttr->default ?? $default,
+                columnType: $columnAttr->type,
+            );
+        }
+
+        if (count($columns) === 0) {
+            throw EntityException::extensionHasNoColumns($extensionClass);
+        }
+
+        $metadata = new ExtensionMetadata(
+            extensionClass: $extensionClass,
+            entityClass: $entityClass,
+            properties: $properties,
+            columns: $columns,
+        );
+
+        $this->cache[$extensionClass] = $metadata;
+
+        return $metadata;
+    }
+
+    /**
+     * Clear the metadata cache.
+     */
+    public function clearCache(): void
+    {
+        $this->cache = [];
+    }
+
+    /**
+     * Validate that the extension class is properly configured.
+     *
+     * @param ReflectionClass<object> $reflection
+     * @param class-string $extensionClass
+     *
+     * @throws EntityException
+     */
+    private function validateExtension(
+        ReflectionClass $reflection,
+        string $extensionClass,
+    ): void {
+        if (!$reflection->isSubclassOf(EntityExtension::class)) {
+            throw EntityException::notExtendsEntityExtension($extensionClass);
+        }
+
+        if (count($reflection->getAttributes(Table::class)) > 0
+            || count($reflection->getAttributes(Index::class)) > 0
+        ) {
+            throw EntityException::extensionDeclaresTableAttribute($extensionClass);
+        }
+    }
+
+    /**
+     * Extract the entity class from the #[ExtensionOf] attribute.
+     *
+     * @param ReflectionClass<object> $reflection
+     * @param class-string $extensionClass
+     * @return class-string<Entity>
+     *
+     * @throws EntityException
+     */
+    private function extractEntityClass(
+        ReflectionClass $reflection,
+        string $extensionClass,
+    ): string {
+        $extensionOfAttrs = $reflection->getAttributes(ExtensionOf::class);
+
+        if (count($extensionOfAttrs) === 0) {
+            throw EntityException::extensionMissingExtensionOf($extensionClass);
+        }
+
+        return $extensionOfAttrs[0]->newInstance()->entityClass;
+    }
+
+    /**
+     * Validate that the property does not declare a relationship attribute.
+     *
+     * @param class-string $extensionClass
+     *
+     * @throws EntityException
+     */
+    private function validateNoRelationship(
+        ReflectionProperty $property,
+        string $extensionClass,
+    ): void {
+        $hasRelationship = count($property->getAttributes(HasOne::class)) > 0
+            || count($property->getAttributes(HasMany::class)) > 0
+            || count($property->getAttributes(BelongsTo::class)) > 0
+            || count($property->getAttributes(BelongsToMany::class)) > 0;
+
+        if ($hasRelationship) {
+            throw EntityException::extensionDeclaresRelationship($extensionClass, $property->getName());
+        }
+    }
+
+    /**
+     * Convert a camelCase property name to snake_case for use as a column name.
+     */
+    private function camelToSnakeCase(string $name): string
+    {
+        $result = (string) preg_replace('/([a-z0-9])([A-Z])/', '$1_$2', $name);
+        $result = (string) preg_replace('/([A-Z]+)([A-Z][a-z])/', '$1_$2', $result);
+
+        return strtolower($result);
+    }
+
+    /**
+     * Infer the database type from a PHP type.
+     */
+    private function inferDatabaseType(string $phpType): string
+    {
+        return self::TYPE_MAP[$phpType] ?? 'varchar';
+    }
+}

--- a/packages/database/src/Entity/EntityExtensionRegistry.php
+++ b/packages/database/src/Entity/EntityExtensionRegistry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Entity;
+
+/**
+ * Maps entity class strings to their registered extension class strings.
+ */
+class EntityExtensionRegistry
+{
+    /** @var array<class-string<Entity>, list<class-string<EntityExtension>>> */
+    private array $extensions = [];
+
+    /**
+     * @param class-string<Entity> $entityClass
+     * @param class-string<EntityExtension> $extensionClass
+     */
+    public function register(string $entityClass, string $extensionClass): void
+    {
+        if (!isset($this->extensions[$entityClass])) {
+            $this->extensions[$entityClass] = [];
+        }
+
+        if (!in_array($extensionClass, $this->extensions[$entityClass], true)) {
+            $this->extensions[$entityClass][] = $extensionClass;
+        }
+    }
+
+    /**
+     * @param class-string<Entity> $entityClass
+     * @return array<class-string<EntityExtension>>
+     */
+    public function getExtensions(string $entityClass): array
+    {
+        return $this->extensions[$entityClass] ?? [];
+    }
+}

--- a/packages/database/src/Entity/EntityHydrator.php
+++ b/packages/database/src/Entity/EntityHydrator.php
@@ -8,6 +8,7 @@ use BackedEnum;
 use DateTimeImmutable;
 use JsonException;
 use Marko\Database\Exceptions\EntityException;
+use Marko\Database\Exceptions\RepositoryException;
 use ReflectionClass;
 use WeakMap;
 
@@ -35,6 +36,8 @@ class EntityHydrator
      * @param class-string<T> $entityClass
      * @param array<string, mixed> $row Database row with column names as keys
      * @return T
+     *
+     * @throws EntityException
      */
     public function hydrate(
         string $entityClass,
@@ -44,7 +47,6 @@ class EntityHydrator
         $reflection = new ReflectionClass($entityClass);
         $entity = $reflection->newInstanceWithoutConstructor();
 
-        $columnToProperty = $metadata->getColumnToPropertyMap();
         $originalValues = [];
 
         foreach ($metadata->properties as $propName => $propMeta) {
@@ -65,6 +67,41 @@ class EntityHydrator
 
         $this->originalValues[$entity] = $originalValues;
 
+        foreach ($metadata->extensions as $extensionMeta) {
+            $columnNames = array_map(
+                fn (PropertyMetadata $p) => $p->columnName,
+                $extensionMeta->properties,
+            );
+
+            $presentColumns = array_filter(
+                $columnNames,
+                fn (string $col) => array_key_exists($col, $row),
+            );
+
+            if (count($presentColumns) === 0) {
+                continue;
+            }
+
+            $extReflection = new ReflectionClass($extensionMeta->extensionClass);
+            $extensionInstance = $extReflection->newInstanceWithoutConstructor();
+
+            foreach ($extensionMeta->properties as $propName => $propMeta) {
+                $columnName = $propMeta->columnName;
+
+                if (!array_key_exists($columnName, $row)) {
+                    continue;
+                }
+
+                $dbValue = $row[$columnName];
+                $phpValue = $this->convertToPhpType($dbValue, $propMeta);
+
+                $property = $extReflection->getProperty($propName);
+                $property->setValue($extensionInstance, $phpValue);
+            }
+
+            $entity->setExtension($extensionInstance);
+        }
+
         return $entity;
     }
 
@@ -72,6 +109,8 @@ class EntityHydrator
      * Extract entity data to a row array for persistence.
      *
      * @return array<string, mixed> Column name => value
+     *
+     * @throws EntityException
      */
     public function extract(
         Entity $entity,
@@ -85,6 +124,55 @@ class EntityHydrator
             $value = $property->getValue($entity);
 
             $row[$propMeta->columnName] = $this->convertToDbValue($value, $propMeta);
+        }
+
+        return $row;
+    }
+
+    /**
+     * Extract extension column data from an entity for persistence.
+     *
+     * Applies the null/default/error policy when an extension is not attached:
+     * - Column nullable → use null
+     * - Column non-nullable AND PropertyMetadata::$default is not null → use that default
+     * - Column non-nullable AND no default → throw RepositoryException
+     *
+     * @return array<string, mixed> Column name => DB value for all extension columns
+     *
+     * @throws RepositoryException|EntityException
+     */
+    public function extractExtensions(
+        Entity $entity,
+        EntityMetadata $metadata,
+    ): array {
+        $row = [];
+
+        foreach ($metadata->extensions as $extensionClass => $extensionMeta) {
+            $extension = $entity->extension($extensionClass);
+
+            if ($extension !== null) {
+                $extReflection = new ReflectionClass($extension);
+
+                foreach ($extensionMeta->properties as $propName => $propMeta) {
+                    $property = $extReflection->getProperty($propName);
+                    $value = $property->isInitialized($extension) ? $property->getValue($extension) : null;
+                    $row[$propMeta->columnName] = $this->convertToDbValue($value, $propMeta);
+                }
+            } else {
+                foreach ($extensionMeta->properties as $propMeta) {
+                    if ($propMeta->nullable) {
+                        $row[$propMeta->columnName] = null;
+                    } elseif ($propMeta->default !== null) {
+                        $row[$propMeta->columnName] = $propMeta->default;
+                    } else {
+                        throw RepositoryException::extensionRequired(
+                            $metadata->entityClass,
+                            $extensionClass,
+                            $propMeta->columnName,
+                        );
+                    }
+                }
+            }
         }
 
         return $row;

--- a/packages/database/src/Entity/EntityMetadata.php
+++ b/packages/database/src/Entity/EntityMetadata.php
@@ -17,6 +17,7 @@ readonly class EntityMetadata
      * @param array<ColumnMetadata> $columns
      * @param array<IndexMetadata> $indexes
      * @param array<string, RelationshipMetadata> $relationships Property name => metadata
+     * @param array<class-string<EntityExtension>, ExtensionMetadata> $extensions Extension class => metadata
      */
     public function __construct(
         public string $entityClass,
@@ -26,6 +27,7 @@ readonly class EntityMetadata
         public array $columns = [],
         public array $indexes = [],
         public array $relationships = [],
+        public array $extensions = [],
     ) {}
 
     /**

--- a/packages/database/src/Entity/EntityMetadataFactory.php
+++ b/packages/database/src/Entity/EntityMetadataFactory.php
@@ -20,6 +20,11 @@ use ReflectionProperty;
 
 /**
  * Parses entity classes and extracts metadata from attributes.
+ *
+ * The $registry and $extensionMetadataFactory constructor parameters are nullable so that
+ * existing call-sites using `new EntityMetadataFactory()` without arguments continue to
+ * compile and pass. When null, no extension metadata is merged. The DI container injects
+ * real instances in production via autowiring.
  */
 class EntityMetadataFactory
 {
@@ -35,16 +40,25 @@ class EntityMetadataFactory
     ];
 
     /**
+     * Parsed metadata cache, keyed by entity class name.
+     * NOTE: This cache is not invalidated when extensions are added after first parse.
+     * Boot ordering ensures the registry is fully populated before any parse call.
+     *
      * @var array<class-string, EntityMetadata>
      */
     private array $cache = [];
+
+    public function __construct(
+        private readonly ?EntityExtensionRegistry $registry = null,
+        private readonly ?EntityExtensionMetadataFactory $extensionMetadataFactory = null,
+    ) {}
 
     /**
      * Parse an entity class and return its metadata.
      *
      * @param class-string $entityClass
      *
-     * @throws EntityException
+     * @throws EntityException|MissingPrimaryKeyException
      */
     public function parse(
         string $entityClass,
@@ -168,6 +182,8 @@ class EntityMetadataFactory
             );
         }
 
+        $extensions = $this->buildExtensions($entityClass, $properties, $columns);
+
         $metadata = new EntityMetadata(
             entityClass: $entityClass,
             tableName: $tableName,
@@ -176,6 +192,7 @@ class EntityMetadataFactory
             columns: $columns,
             indexes: $indexes,
             relationships: $relationships,
+            extensions: $extensions,
         );
 
         $this->cache[$entityClass] = $metadata;
@@ -189,6 +206,82 @@ class EntityMetadataFactory
     public function clearCache(): void
     {
         $this->cache = [];
+    }
+
+    /**
+     * Build the extension map for an entity, detecting column and property conflicts.
+     *
+     * @param class-string $entityClass
+     * @param array<string, PropertyMetadata> $baseProperties
+     * @param array<ColumnMetadata> $baseColumns
+     * @return array<class-string<EntityExtension>, ExtensionMetadata>
+     *
+     * @throws EntityException
+     */
+    private function buildExtensions(
+        string $entityClass,
+        array $baseProperties,
+        array $baseColumns,
+    ): array {
+        if ($this->registry === null || $this->extensionMetadataFactory === null) {
+            return [];
+        }
+
+        $extensionClasses = $this->registry->getExtensions($entityClass);
+
+        if (count($extensionClasses) === 0) {
+            return [];
+        }
+
+        // Build column name => source class map from base entity
+        $seenColumnNames = [];
+        foreach ($baseColumns as $col) {
+            $seenColumnNames[$col->name] = $entityClass;
+        }
+
+        // Build property name => source class map from base entity
+        $seenPropertyNames = [];
+        foreach (array_keys($baseProperties) as $propName) {
+            $seenPropertyNames[$propName] = $entityClass;
+        }
+
+        $extensions = [];
+
+        foreach ($extensionClasses as $extensionClass) {
+            $extMetadata = $this->extensionMetadataFactory->parse($extensionClass);
+
+            // Check property name conflicts
+            foreach (array_keys($extMetadata->properties) as $propName) {
+                if (isset($seenPropertyNames[$propName])) {
+                    throw EntityException::extensionPropertyConflict(
+                        $entityClass,
+                        $propName,
+                        $seenPropertyNames[$propName],
+                        $extensionClass,
+                    );
+                }
+
+                $seenPropertyNames[$propName] = $extensionClass;
+            }
+
+            // Check column name conflicts
+            foreach ($extMetadata->columns as $col) {
+                if (isset($seenColumnNames[$col->name])) {
+                    throw EntityException::extensionColumnConflict(
+                        $entityClass,
+                        $col->name,
+                        $seenColumnNames[$col->name],
+                        $extensionClass,
+                    );
+                }
+
+                $seenColumnNames[$col->name] = $extensionClass;
+            }
+
+            $extensions[$extensionClass] = $extMetadata;
+        }
+
+        return $extensions;
     }
 
     /**

--- a/packages/database/src/Entity/ExtensionMetadata.php
+++ b/packages/database/src/Entity/ExtensionMetadata.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Entity;
+
+/**
+ * Holds parsed metadata from an extension class attributes.
+ *
+ * @template T of EntityExtension
+ */
+readonly class ExtensionMetadata
+{
+    /**
+     * @param class-string<T> $extensionClass
+     * @param class-string<Entity> $entityClass
+     * @param array<string, PropertyMetadata> $properties Property name => metadata
+     * @param array<ColumnMetadata> $columns
+     */
+    public function __construct(
+        public string $extensionClass,
+        public string $entityClass,
+        public array $properties = [],
+        public array $columns = [],
+    ) {}
+
+    /**
+     * Get property metadata by property name.
+     */
+    public function getProperty(string $name): ?PropertyMetadata
+    {
+        return $this->properties[$name] ?? null;
+    }
+}

--- a/packages/database/src/Entity/SchemaBuilder.php
+++ b/packages/database/src/Entity/SchemaBuilder.php
@@ -21,9 +21,18 @@ class SchemaBuilder
     public function build(
         EntityMetadata $metadata,
     ): Table {
+        $extensionColumns = array_merge(
+            ...array_map(
+                fn (ExtensionMetadata $ext) => $ext->columns,
+                array_values($metadata->extensions),
+            ),
+        );
+
+        $allColumns = array_merge($metadata->columns, $extensionColumns);
+
         $columns = array_map(
             fn (ColumnMetadata $col) => $this->buildColumn($col),
-            $metadata->columns,
+            $allColumns,
         );
 
         $indexes = array_map(
@@ -31,7 +40,7 @@ class SchemaBuilder
             $metadata->indexes,
         );
 
-        $foreignKeys = $this->buildForeignKeys($metadata->tableName, $metadata->columns);
+        $foreignKeys = $this->buildForeignKeys($metadata->tableName, $allColumns);
 
         return new Table(
             name: $metadata->tableName,

--- a/packages/database/src/Exceptions/EntityException.php
+++ b/packages/database/src/Exceptions/EntityException.php
@@ -206,6 +206,133 @@ class EntityException extends MarkoException
     }
 
     /**
+     * @param class-string $extensionClass
+     */
+    public static function extensionHasNoColumns(string $extensionClass): self
+    {
+        return new self(
+            message: "Extension class '$extensionClass' must have at least one #[Column] property",
+            context: "Attempting to parse extension class '$extensionClass' for database schema",
+            suggestion: 'Add at least one public property with #[Column] attribute',
+        );
+    }
+
+    /**
+     * @param class-string $extensionClass
+     */
+    public static function extensionDeclaresPrimaryKey(
+        string $extensionClass,
+        string $propertyName,
+    ): self {
+        return new self(
+            message: "Extension class '$extensionClass' must not declare a primary key column (property '$propertyName')",
+            context: "Parsing extension class '$extensionClass'",
+            suggestion: 'Remove primaryKey: true from the #[Column] attribute — extensions add columns to an existing table without redefining the primary key',
+        );
+    }
+
+    /**
+     * @param class-string $extensionClass
+     */
+    public static function extensionDeclaresRelationship(
+        string $extensionClass,
+        string $propertyName,
+    ): self {
+        return new self(
+            message: "Extension class '$extensionClass' must not declare relationship attributes (property '$propertyName')",
+            context: "Parsing extension class '$extensionClass'",
+            suggestion: 'Remove relationship attributes (#[HasOne], #[HasMany], #[BelongsTo], #[BelongsToMany]) from extension classes — define relationships on the base entity instead',
+        );
+    }
+
+    /**
+     * @param class-string $extensionClass
+     */
+    public static function extensionDeclaresTableAttribute(string $extensionClass): self
+    {
+        return new self(
+            message: "Extension class '$extensionClass' must not declare #[Table] or #[Index] attributes",
+            context: "Parsing extension class '$extensionClass'",
+            suggestion: 'Remove #[Table] and #[Index] attributes from extension classes — they share the table defined on the base entity',
+        );
+    }
+
+    /**
+     * @param class-string $extensionClass
+     */
+    public static function extensionMissingExtensionOf(string $extensionClass): self
+    {
+        return new self(
+            message: "Extension class '$extensionClass' is missing #[ExtensionOf] attribute",
+            context: "Attempting to parse extension class '$extensionClass' for database schema",
+            suggestion: 'Add #[ExtensionOf(entityClass: YourEntity::class)] attribute to the extension class',
+        );
+    }
+
+    /**
+     * @param class-string $extensionClass
+     */
+    public static function notExtendsEntityExtension(string $extensionClass): self
+    {
+        return new self(
+            message: "Class '$extensionClass' must extend EntityExtension base class",
+            context: "Attempting to parse class '$extensionClass' as an entity extension",
+            suggestion: 'Extend Marko\\Database\\Entity\\EntityExtension in your extension class',
+        );
+    }
+
+    /**
+     * @param class-string $extensionClass
+     * @param class-string $targetClass
+     */
+    public static function extensionOfTargetNotEntity(
+        string $extensionClass,
+        string $targetClass,
+    ): self {
+        return new self(
+            message: "Extension class '$extensionClass' declares #[ExtensionOf('$targetClass')] but '$targetClass' does not extend Entity",
+            context: "Discovering extension class '$extensionClass'",
+            suggestion: "Ensure '$targetClass' extends Marko\\Database\\Entity\\Entity",
+        );
+    }
+
+    /**
+     * @param class-string $entityClass
+     * @param class-string $sourceA
+     * @param class-string $sourceB
+     */
+    public static function extensionColumnConflict(
+        string $entityClass,
+        string $columnName,
+        string $sourceA,
+        string $sourceB,
+    ): self {
+        return new self(
+            message: "Column name '$columnName' is declared by both '$sourceA' and '$sourceB' for entity '$entityClass'",
+            context: "Merging extension metadata for entity '$entityClass'",
+            suggestion: 'Rename the column in one of the sources to avoid the conflict',
+        );
+    }
+
+    /**
+     * @param class-string $entityClass
+     * @param class-string $sourceA
+     * @param class-string $sourceB
+     */
+    public static function extensionPropertyConflict(
+        string $entityClass,
+        string $propertyName,
+        string $sourceA,
+        string $sourceB,
+    ): self {
+        return new self(
+            message: "Property name '$propertyName' is declared by both '$sourceA' and '$sourceB' for entity '$entityClass'",
+            context: "Merging extension metadata for entity '$entityClass'",
+            suggestion: 'Rename the property in one of the sources to avoid the conflict',
+        );
+    }
+
+    /**
      * @param class-string $entityClass
      */
     public static function undefinedRelationship(

--- a/packages/database/src/Exceptions/RepositoryException.php
+++ b/packages/database/src/Exceptions/RepositoryException.php
@@ -96,4 +96,20 @@ class RepositoryException extends MarkoException
             suggestion: 'Check the entity class for #[HasOne], #[HasMany], or #[BelongsTo] attributes and use the correct property name',
         );
     }
+
+    /**
+     * @param class-string $entityClass
+     * @param class-string $extensionClass
+     */
+    public static function extensionRequired(
+        string $entityClass,
+        string $extensionClass,
+        string $columnName,
+    ): self {
+        return new self(
+            message: "Cannot persist '$entityClass': extension '$extensionClass' is required for column '$columnName' but is not attached",
+            context: "Persisting entity of class '$entityClass'",
+            suggestion: "Attach the '$extensionClass' extension to the entity before saving, or make column '$columnName' nullable or provide a default value",
+        );
+    }
 }

--- a/packages/database/src/Repository/Repository.php
+++ b/packages/database/src/Repository/Repository.php
@@ -22,6 +22,8 @@ use Marko\Database\Events\EntityDeleting;
 use Marko\Database\Events\EntityUpdated;
 use Marko\Database\Events\EntityUpdating;
 use Marko\Database\Exceptions\BatchInsertException;
+use Marko\Database\Exceptions\EntityException;
+use Marko\Database\Exceptions\MissingPrimaryKeyException;
 use Marko\Database\Exceptions\RepositoryException;
 use Marko\Database\Query\QueryBuilderFactoryInterface;
 use Marko\Database\Query\QueryBuilderInterface;
@@ -63,7 +65,7 @@ abstract class Repository implements RepositoryInterface
      * @param EventDispatcherInterface|null $eventDispatcher Optional event dispatcher for lifecycle events
      * @param RelationshipLoader|null $relationshipLoader Optional loader for eager-loading relationships
      *
-     * @throws RepositoryException
+     * @throws EntityException|MissingPrimaryKeyException|RepositoryException
      */
     public function __construct(
         protected readonly ConnectionInterface $connection,
@@ -108,6 +110,8 @@ abstract class Repository implements RepositoryInterface
      * Find an entity by its primary key.
      *
      * @return TEntity|null
+     *
+     * @throws EntityException
      */
     public function find(
         int|string $id,
@@ -141,7 +145,8 @@ abstract class Repository implements RepositoryInterface
      * Find an entity by its primary key or throw an exception.
      *
      * @return TEntity
-     * @throws RepositoryException When entity is not found
+     *
+     * @throws EntityException|RepositoryException When entity is not found
      */
     public function findOrFail(
         int|string $id,
@@ -159,6 +164,8 @@ abstract class Repository implements RepositoryInterface
      * Find all entities in the repository.
      *
      * @return EntityCollection<TEntity>
+     *
+     * @throws EntityException
      */
     public function findAll(): EntityCollection
     {
@@ -184,6 +191,8 @@ abstract class Repository implements RepositoryInterface
      *
      * @param array<string, mixed> $criteria Column-value pairs to match
      * @return EntityCollection<TEntity>
+     *
+     * @throws EntityException
      */
     public function findBy(
         array $criteria,
@@ -224,6 +233,8 @@ abstract class Repository implements RepositoryInterface
      * Find a single entity matching the given criteria.
      *
      * @return TEntity|null
+     *
+     * @throws EntityException
      */
     public function findOneBy(
         array $criteria,
@@ -234,7 +245,7 @@ abstract class Repository implements RepositoryInterface
     /**
      * Save an entity (insert or update).
      *
-     * @throws RepositoryException
+     * @throws EntityException|RepositoryException
      */
     public function save(
         Entity $entity,
@@ -256,7 +267,8 @@ abstract class Repository implements RepositoryInterface
      * Insert multiple entities in a single multi-row INSERT statement.
      *
      * @param array<Entity> $entities
-     * @throws BatchInsertException|RepositoryException
+     *
+     * @throws BatchInsertException|EntityException|RepositoryException
      */
     public function insertBatch(array $entities): void
     {
@@ -366,12 +378,17 @@ abstract class Repository implements RepositoryInterface
 
     /**
      * Extract row data for a single entity, excluding auto-increment PK if null.
+     * Includes all extension columns.
      *
      * @return array<string, mixed>
+     *
+     * @throws EntityException|RepositoryException
      */
     private function extractBatchRow(Entity $entity): array
     {
         $data = $this->hydrator->extract($entity, $this->metadata);
+        $extensionData = $this->hydrator->extractExtensions($entity, $this->metadata);
+        $data = array_merge($data, $extensionData);
 
         $pkProperty = $this->metadata->getPrimaryKeyProperty();
         if ($pkProperty?->isAutoIncrement === true) {
@@ -484,6 +501,8 @@ abstract class Repository implements RepositoryInterface
      * falls back to a raw SQL query. The raw-SQL path exists because Repository
      * can be constructed without a QueryBuilderFactory (e.g. in lightweight
      * contexts that only need find/save), and we must not break that contract.
+     *
+     * @throws RepositoryException
      */
     public function count(): int
     {
@@ -503,6 +522,8 @@ abstract class Repository implements RepositoryInterface
 
     /**
      * Check if an entity with the given ID exists.
+     *
+     * @throws EntityException
      */
     public function exists(
         int|string $id,
@@ -514,6 +535,8 @@ abstract class Repository implements RepositoryInterface
      * Check if any entity matches the given criteria.
      *
      * @param array<string, mixed> $criteria Column-value pairs to match
+     *
+     * @throws EntityException
      */
     public function existsBy(
         array $criteria,
@@ -549,11 +572,15 @@ abstract class Repository implements RepositoryInterface
 
     /**
      * Insert a new entity.
+     *
+     * @throws EntityException|RepositoryException
      */
     protected function insert(
         Entity $entity,
     ): void {
         $data = $this->hydrator->extract($entity, $this->metadata);
+        $extensionData = $this->hydrator->extractExtensions($entity, $this->metadata);
+        $data = array_merge($data, $extensionData);
 
         // Remove primary key if it's auto-increment and null
         $pkProperty = $this->metadata->getPrimaryKeyProperty();
@@ -589,7 +616,11 @@ abstract class Repository implements RepositoryInterface
     /**
      * Update an existing entity.
      *
-     * Only dirty (changed) fields are updated to minimize database operations.
+     * Only dirty (changed) base fields are included, but ALL extension columns are
+     * always written. Skips the UPDATE entirely only when both conditions hold:
+     * the base entity has no dirty properties AND no extensions are registered.
+     *
+     * @throws EntityException|RepositoryException
      */
     protected function update(
         Entity $entity,
@@ -600,8 +631,10 @@ abstract class Repository implements RepositoryInterface
         // Get the dirty properties
         $dirtyProperties = $this->hydrator->getDirtyProperties($entity, $this->metadata);
 
-        // If no fields are dirty, skip the update
-        if (count($dirtyProperties) === 0) {
+        $hasExtensions = count($this->metadata->extensions) > 0;
+
+        // Skip the UPDATE only when there are no dirty base properties AND no extensions
+        if (count($dirtyProperties) === 0 && !$hasExtensions) {
             return;
         }
 
@@ -616,6 +649,15 @@ abstract class Repository implements RepositoryInterface
 
             // Convert value to DB format
             $data[$columnName] = $this->convertToDbValue($value);
+        }
+
+        // Always include all extension columns in the UPDATE
+        $extensionData = $this->hydrator->extractExtensions($entity, $this->metadata);
+        $data = array_merge($data, $extensionData);
+
+        // If still nothing to update (dirty=0 and extensions produced no columns), skip
+        if (count($data) === 0) {
+            return;
         }
 
         // Get the primary key value for the WHERE clause
@@ -670,6 +712,8 @@ abstract class Repository implements RepositoryInterface
      * Supports dot-notation for nested eager loading (e.g. 'comments.author').
      *
      * @param Entity[] $entities
+     *
+     * @throws EntityException
      */
     private function eagerLoadRelationships(array $entities): void
     {
@@ -683,6 +727,8 @@ abstract class Repository implements RepositoryInterface
 
     /**
      * Validate that ENTITY_CLASS constant is defined.
+     *
+     * @throws RepositoryException
      */
     private function validateEntityClass(): void
     {
@@ -693,6 +739,8 @@ abstract class Repository implements RepositoryInterface
 
     /**
      * Validate that the entity is of the correct type.
+     *
+     * @throws RepositoryException
      */
     private function validateEntityType(
         Entity $entity,

--- a/packages/database/tests/Attributes/ExtensionOfAttributeTest.php
+++ b/packages/database/tests/Attributes/ExtensionOfAttributeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Tests\Attributes;
+
+use Attribute;
+use Marko\Database\Attributes\ExtensionOf;
+use Marko\Database\Entity\Entity;
+use Marko\Database\Entity\EntityExtension;
+use ReflectionClass;
+
+class UserEntityForExtension extends Entity {}
+
+#[ExtensionOf(UserEntityForExtension::class)]
+class UserEntityExtension extends EntityExtension {}
+
+it('stores the entity class in the attribute', function (): void {
+    $attribute = new ExtensionOf(UserEntityForExtension::class);
+
+    expect($attribute->entityClass)->toBe(UserEntityForExtension::class);
+});
+
+it('targets class-level application only', function (): void {
+    $reflection = new ReflectionClass(ExtensionOf::class);
+    $attributes = $reflection->getAttributes(Attribute::class);
+    $attributeMeta = $attributes[0]->newInstance();
+
+    expect($attributeMeta->flags)->toBe(Attribute::TARGET_CLASS);
+});
+
+it('has an ExtensionOf attribute that accepts an entity class string', function (): void {
+    $reflection = new ReflectionClass(UserEntityExtension::class);
+    $attributes = $reflection->getAttributes(ExtensionOf::class);
+    $extensionOfAttribute = $attributes[0]->newInstance();
+
+    expect($attributes)->toHaveCount(1)
+        ->and($extensionOfAttribute)->toBeInstanceOf(ExtensionOf::class)
+        ->and($extensionOfAttribute->entityClass)->toBe(UserEntityForExtension::class);
+});

--- a/packages/database/tests/Entity/EntityExtensionBagTest.php
+++ b/packages/database/tests/Entity/EntityExtensionBagTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Tests\Entity;
+
+use Marko\Database\Entity\Entity;
+use Marko\Database\Entity\EntityExtension;
+
+it('returns null for an extension that has not been set', function (): void {
+    $entity = new class () extends Entity {};
+
+    $extensionClass = new class () extends EntityExtension {};
+
+    expect($entity->extension($extensionClass::class))->toBeNull();
+});
+
+it('returns the extension instance after it is set', function (): void {
+    $entity = new class () extends Entity {};
+
+    $extension = new class () extends EntityExtension
+    {
+        public string $value = 'hello';
+    };
+
+    $entity->setExtension($extension);
+
+    expect($entity->extension($extension::class))->toBe($extension);
+});
+
+it('overwrites a previously set extension of the same class', function (): void {
+    $entity = new class () extends Entity {};
+
+    $extensionA = new class () extends EntityExtension
+    {
+        public string $value = 'first';
+    };
+
+    $extensionB = clone $extensionA;
+    $extensionB->value = 'second';
+
+    $entity->setExtension($extensionA);
+    $entity->setExtension($extensionB);
+
+    expect($entity->extension($extensionA::class))->toBe($extensionB);
+});
+
+it('stores multiple extensions independently by class', function (): void {
+    $entity = new class () extends Entity {};
+
+    $extensionOne = new class () extends EntityExtension
+    {
+        public string $label = 'one';
+    };
+
+    $extensionTwo = new class () extends EntityExtension
+    {
+        public string $label = 'two';
+    };
+
+    $entity->setExtension($extensionOne);
+    $entity->setExtension($extensionTwo);
+
+    expect($entity->extension($extensionOne::class))->toBe($extensionOne)
+        ->and($entity->extension($extensionTwo::class))->toBe($extensionTwo);
+});

--- a/packages/database/tests/Entity/EntityExtensionDiscoveryTest.php
+++ b/packages/database/tests/Entity/EntityExtensionDiscoveryTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Tests\Entity;
+
+use Marko\Core\Discovery\ClassFileParser;
+use Marko\Database\Entity\EntityExtensionDiscovery;
+use Marko\Database\Exceptions\EntityException;
+
+/**
+ * Helper to create a unique entity file for discovery tests.
+ */
+function createDiscoveryEntityFile(
+    string $path,
+    string $namespace,
+    string $className,
+    string $tableName,
+): void {
+    $dir = dirname($path);
+
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+
+    $content = <<<PHP
+<?php
+
+declare(strict_types=1);
+
+namespace $namespace;
+
+use Marko\Database\Attributes\Column;
+use Marko\Database\Attributes\Table;
+use Marko\Database\Entity\Entity;
+
+#[Table('$tableName')]
+class $className extends Entity
+{
+    #[Column(primaryKey: true)]
+    public int \$id;
+}
+PHP;
+
+    file_put_contents($path, $content);
+}
+
+/**
+ * Helper to create a unique extension file for discovery tests.
+ */
+function createDiscoveryExtensionFile(
+    string $path,
+    string $namespace,
+    string $className,
+    string $entityFqcn,
+): string {
+    $dir = dirname($path);
+
+    if (!is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+
+    $fullClassName = $namespace . '\\' . $className;
+
+    $content = <<<PHP
+<?php
+
+declare(strict_types=1);
+
+namespace $namespace;
+
+use Marko\Database\Attributes\Column;
+use Marko\Database\Attributes\ExtensionOf;
+use Marko\Database\Entity\EntityExtension;
+
+#[ExtensionOf(entityClass: \\$entityFqcn::class)]
+class $className extends EntityExtension
+{
+    #[Column]
+    public string \$extra;
+}
+PHP;
+
+    file_put_contents($path, $content);
+
+    return $fullClassName;
+}
+
+/**
+ * Helper to recursively delete directory.
+ */
+function cleanupDiscoveryDir(
+    string $path,
+): void {
+    if (!is_dir($path)) {
+        return;
+    }
+
+    $items = scandir($path);
+    if ($items === false) {
+        return;
+    }
+
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+
+        $itemPath = $path . '/' . $item;
+
+        if (is_dir($itemPath)) {
+            cleanupDiscoveryDir($itemPath);
+        } else {
+            unlink($itemPath);
+        }
+    }
+
+    rmdir($path);
+}
+
+beforeEach(function (): void {
+    $this->discovery = new EntityExtensionDiscovery(new ClassFileParser());
+    $this->uniqueId = bin2hex(random_bytes(8));
+    $this->tempDir = sys_get_temp_dir() . '/ext-discovery-' . $this->uniqueId;
+    mkdir($this->tempDir, 0777, true);
+});
+
+afterEach(function (): void {
+    cleanupDiscoveryDir($this->tempDir);
+});
+
+it('discovers extension classes in vendor src/EntityExtension directories', function (): void {
+    $entityNs = 'DiscVendor' . $this->uniqueId . '\Blog\Entity';
+    $entityClass = $entityNs . '\Post';
+    $entityFile = $this->tempDir . '/vendor/acme/blog/src/Entity/Post.php';
+    createDiscoveryEntityFile($entityFile, $entityNs, 'Post', 'posts');
+    require_once $entityFile;
+
+    $extNs = 'DiscVendor' . $this->uniqueId . '\Blog\EntityExtension';
+    $extClass = createDiscoveryExtensionFile(
+        $this->tempDir . '/vendor/acme/blog/src/EntityExtension/PostExtension.php',
+        $extNs,
+        'PostExtension',
+        $entityClass,
+    );
+
+    $result = $this->discovery->discoverInVendor($this->tempDir . '/vendor');
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0][0])->toBe($entityClass)
+        ->and($result[0][1])->toBe($extClass);
+});
+
+it('discovers extension classes in app EntityExtension directories', function (): void {
+    $entityNs = 'DiscApp' . $this->uniqueId . '\Blog\Entity';
+    $entityClass = $entityNs . '\Post';
+    $entityFile = $this->tempDir . '/app/blog/Entity/Post.php';
+    createDiscoveryEntityFile($entityFile, $entityNs, 'Post', 'posts');
+    require_once $entityFile;
+
+    $extNs = 'DiscApp' . $this->uniqueId . '\Blog\EntityExtension';
+    $extClass = createDiscoveryExtensionFile(
+        $this->tempDir . '/app/blog/EntityExtension/PostExtension.php',
+        $extNs,
+        'PostExtension',
+        $entityClass,
+    );
+
+    $result = $this->discovery->discoverInApp($this->tempDir . '/app');
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0][0])->toBe($entityClass)
+        ->and($result[0][1])->toBe($extClass);
+});
+
+it('skips classes that do not extend EntityExtension', function (): void {
+    $entityNs = 'DiscSkipNoExt' . $this->uniqueId . '\Entity';
+    $entityClass = $entityNs . '\Item';
+    $entityFile = $this->tempDir . '/app/shop/Entity/Item.php';
+    createDiscoveryEntityFile($entityFile, $entityNs, 'Item', 'items');
+    require_once $entityFile;
+
+    $extNs = 'DiscSkipNoExt' . $this->uniqueId . '\EntityExtension';
+    $dir = $this->tempDir . '/app/shop/EntityExtension';
+    mkdir($dir, 0777, true);
+    $path = $dir . '/NotAnExtension.php';
+    file_put_contents($path, <<<PHP
+<?php
+declare(strict_types=1);
+namespace $extNs;
+use Marko\Database\Attributes\Column;
+use Marko\Database\Attributes\ExtensionOf;
+use \\$entityClass;
+#[ExtensionOf(entityClass: Item::class)]
+class NotAnExtension {
+    #[Column]
+    public string \$extra;
+}
+PHP);
+
+    $result = $this->discovery->discoverInApp($this->tempDir . '/app');
+
+    expect($result)->toBeEmpty();
+});
+
+it('skips classes without ExtensionOf attribute', function (): void {
+    $ns = 'DiscSkipNoAttr' . $this->uniqueId;
+    $dir = $this->tempDir . '/app/blog/EntityExtension';
+    mkdir($dir, 0777, true);
+    $path = $dir . '/NoAttrExtension.php';
+    file_put_contents($path, <<<PHP
+<?php
+declare(strict_types=1);
+namespace $ns;
+use Marko\Database\Attributes\Column;
+use Marko\Database\Entity\EntityExtension;
+class NoAttrExtension extends EntityExtension {
+    #[Column]
+    public string \$extra;
+}
+PHP);
+
+    $result = $this->discovery->discoverInApp($this->tempDir . '/app');
+
+    expect($result)->toBeEmpty();
+});
+
+it('throws when ExtensionOf target class does not extend Entity', function (): void {
+    $notEntityNs = 'DiscThrows' . $this->uniqueId;
+    $notEntityClass = $notEntityNs . '\NotAnEntity';
+    $notEntityDir = $this->tempDir . '/app/bad/Other';
+    mkdir($notEntityDir, 0777, true);
+    $notEntityFile = $notEntityDir . '/NotAnEntity.php';
+    file_put_contents($notEntityFile, <<<PHP
+<?php
+declare(strict_types=1);
+namespace $notEntityNs;
+class NotAnEntity {}
+PHP);
+    require_once $notEntityFile;
+
+    $extNs = 'DiscThrows' . $this->uniqueId . '\EntityExtension';
+    $dir = $this->tempDir . '/app/bad/EntityExtension';
+    mkdir($dir, 0777, true);
+    $path = $dir . '/BadExtension.php';
+    file_put_contents($path, <<<PHP
+<?php
+declare(strict_types=1);
+namespace $extNs;
+use Marko\Database\Attributes\Column;
+use Marko\Database\Attributes\ExtensionOf;
+use Marko\Database\Entity\EntityExtension;
+use \\$notEntityClass;
+#[ExtensionOf(entityClass: NotAnEntity::class)]
+class BadExtension extends EntityExtension {
+    #[Column]
+    public string \$extra;
+}
+PHP);
+
+    $this->discovery->discoverInApp($this->tempDir . '/app');
+})->throws(EntityException::class, 'does not extend Entity');
+
+it('discovers extension classes in modules src/EntityExtension directories', function (): void {
+    $entityNs = 'DiscModules' . $this->uniqueId . '\Custom\Entity';
+    $entityClass = $entityNs . '\Widget';
+    $entityFile = $this->tempDir . '/modules/acme/custom/src/Entity/Widget.php';
+    createDiscoveryEntityFile($entityFile, $entityNs, 'Widget', 'widgets');
+    require_once $entityFile;
+
+    $extNs = 'DiscModules' . $this->uniqueId . '\Custom\EntityExtension';
+    $extClass = createDiscoveryExtensionFile(
+        $this->tempDir . '/modules/acme/custom/src/EntityExtension/WidgetExtension.php',
+        $extNs,
+        'WidgetExtension',
+        $entityClass,
+    );
+
+    $result = $this->discovery->discoverInModules($this->tempDir . '/modules');
+
+    expect($result)->toHaveCount(1)
+        ->and($result[0][0])->toBe($entityClass)
+        ->and($result[0][1])->toBe($extClass);
+});

--- a/packages/database/tests/Entity/EntityExtensionMetadataFactoryTest.php
+++ b/packages/database/tests/Entity/EntityExtensionMetadataFactoryTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Tests\Entity;
+
+use Marko\Database\Attributes\BelongsTo;
+use Marko\Database\Attributes\Column;
+use Marko\Database\Attributes\ExtensionOf;
+use Marko\Database\Attributes\HasOne;
+use Marko\Database\Attributes\Table;
+use Marko\Database\Entity\Entity;
+use Marko\Database\Entity\EntityExtension;
+use Marko\Database\Entity\EntityExtensionMetadataFactory;
+use Marko\Database\Entity\ExtensionMetadata;
+use Marko\Database\Exceptions\EntityException;
+
+// ── Fixture classes ────────────────────────────────────────────────────────────
+
+enum ExtensionTestStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}
+
+#[Table('ext_users')]
+class ExtFactoryUser extends Entity
+{
+    #[Column(primaryKey: true)]
+    public int $id;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryBasicExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $extraField;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryMultiColExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public int $intCol;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $strCol;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public float $floatCol;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public bool $boolCol;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryCamelCaseExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $firstName;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public int $userID;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $HTMLContent;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryExplicitNameExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(name: 'custom_name')]
+    public string $myProperty;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryNullableExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $required;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public ?string $optional;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryDefaultsExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $status = 'active';
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public int $count = 0;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public ?string $noDefault;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryEnumExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public ExtensionTestStatus $status = ExtensionTestStatus::Active;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryNoColumnsExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    public string $notAColumn;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryPrimaryKeyExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(primaryKey: true)]
+    public int $id;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $extra;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryRelationshipExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $extra;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[HasOne(entityClass: ExtFactoryUser::class, foreignKey: 'user_id')]
+    public ?ExtFactoryUser $related = null;
+}
+
+class ExtFactoryNoExtensionOfExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $extra;
+}
+
+class ExtFactoryNotExtendingEntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $extra;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryJsonMismatchExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(type: 'json')]
+    public string $badJsonProp;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryCacheExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $extra;
+}
+
+#[ExtensionOf(entityClass: ExtFactoryUser::class)]
+class ExtFactoryBelongsToExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $extra;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[BelongsTo(entityClass: ExtFactoryUser::class, foreignKey: 'user_id')]
+    public ?ExtFactoryUser $owner = null;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+beforeEach(function (): void {
+    $this->factory = new EntityExtensionMetadataFactory();
+});
+
+it('parses public Column-annotated properties into ExtensionMetadata', function (): void {
+    $metadata = $this->factory->parse(ExtFactoryBasicExtension::class);
+
+    expect($metadata)
+        ->toBeInstanceOf(ExtensionMetadata::class)
+        ->and($metadata->properties)->toHaveCount(1)
+        ->and($metadata->columns)->toHaveCount(1)
+        ->and($metadata->columns[0]->name)->toBe('extra_field');
+});
+
+it('stores the extension class and entity class on ExtensionMetadata', function (): void {
+    $metadata = $this->factory->parse(ExtFactoryBasicExtension::class);
+
+    expect($metadata->extensionClass)
+        ->toBe(ExtFactoryBasicExtension::class)
+        ->and($metadata->entityClass)->toBe(ExtFactoryUser::class);
+});
+
+it('throws when extension class has no Column-annotated properties', function (): void {
+    $this->factory->parse(ExtFactoryNoColumnsExtension::class);
+})->throws(EntityException::class, 'at least one #[Column]');
+
+it('throws when extension class declares a primary key column', function (): void {
+    $this->factory->parse(ExtFactoryPrimaryKeyExtension::class);
+})->throws(EntityException::class, 'must not declare a primary key');
+
+it('throws when extension class declares a relationship attribute', function (): void {
+    $this->factory->parse(ExtFactoryRelationshipExtension::class);
+})->throws(EntityException::class, 'must not declare relationship');
+
+it('throws when extension class is missing the ExtensionOf attribute', function (): void {
+    $this->factory->parse(ExtFactoryNoExtensionOfExtension::class);
+})->throws(EntityException::class, 'missing #[ExtensionOf]');
+
+it('infers database types from PHP scalar types', function (): void {
+    $metadata = $this->factory->parse(ExtFactoryMultiColExtension::class);
+
+    expect($metadata->columns[0]->type)
+        ->toBe('integer')
+        ->and($metadata->columns[1]->type)->toBe('varchar')
+        ->and($metadata->columns[2]->type)->toBe('decimal')
+        ->and($metadata->columns[3]->type)->toBe('boolean');
+});
+
+it('converts camelCase property names to snake_case column names', function (): void {
+    $metadata = $this->factory->parse(ExtFactoryCamelCaseExtension::class);
+
+    expect($metadata->columns[0]->name)
+        ->toBe('first_name')
+        ->and($metadata->columns[1]->name)->toBe('user_id')
+        ->and($metadata->columns[2]->name)->toBe('html_content');
+});
+
+it('uses explicit column name from Column attribute when provided', function (): void {
+    $metadata = $this->factory->parse(ExtFactoryExplicitNameExtension::class);
+
+    expect($metadata->columns[0]->name)->toBe('custom_name');
+});
+
+it('correctly marks nullable properties', function (): void {
+    $metadata = $this->factory->parse(ExtFactoryNullableExtension::class);
+
+    expect($metadata->columns[0]->nullable)
+        ->toBeFalse()
+        ->and($metadata->columns[1]->nullable)->toBeTrue();
+});
+
+it('captures declared default values', function (): void {
+    $metadata = $this->factory->parse(ExtFactoryDefaultsExtension::class);
+
+    expect($metadata->columns[0]->default)
+        ->toBe('active')
+        ->and($metadata->columns[1]->default)->toBe(0)
+        ->and($metadata->columns[2]->default)->toBeNull();
+});
+
+it('converts BackedEnum default values to their backing value', function (): void {
+    $metadata = $this->factory->parse(ExtFactoryEnumExtension::class);
+
+    expect($metadata->columns[0]->default)->toBe('active');
+});
+
+it('throws when extension class does not extend EntityExtension', function (): void {
+    $this->factory->parse(ExtFactoryNotExtendingEntityExtension::class);
+})->throws(EntityException::class, 'must extend EntityExtension');
+
+it('throws when a json column type does not match the PHP array type', function (): void {
+    $this->factory->parse(ExtFactoryJsonMismatchExtension::class);
+})->throws(EntityException::class, "type: 'json'");
+
+it('caches parsed metadata by class', function (): void {
+    $metadata1 = $this->factory->parse(ExtFactoryCacheExtension::class);
+    $metadata2 = $this->factory->parse(ExtFactoryCacheExtension::class);
+
+    expect($metadata1)->toBe($metadata2);
+});

--- a/packages/database/tests/Entity/EntityExtensionRegistryTest.php
+++ b/packages/database/tests/Entity/EntityExtensionRegistryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Tests\Entity;
+
+use Marko\Database\Entity\EntityExtensionRegistry;
+
+it('registers an extension class against its target entity class', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register('App\SomeEntity', 'App\SomeExtension');
+
+    expect($registry->getExtensions('App\SomeEntity'))->toBe(['App\SomeExtension']);
+});
+
+it('returns all registered extension classes for an entity', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register('App\SomeEntity', 'App\ExtensionA');
+    $registry->register('App\SomeEntity', 'App\ExtensionB');
+
+    expect($registry->getExtensions('App\SomeEntity'))->toBe(['App\ExtensionA', 'App\ExtensionB']);
+});
+
+it('returns empty array for entity with no registered extensions', function (): void {
+    $registry = new EntityExtensionRegistry();
+
+    expect($registry->getExtensions('App\SomeEntity'))->toBeEmpty();
+});
+
+it('is idempotent when registering the same pair twice', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register('App\SomeEntity', 'App\SomeExtension');
+    $registry->register('App\SomeEntity', 'App\SomeExtension');
+
+    expect($registry->getExtensions('App\SomeEntity'))->toBe(['App\SomeExtension']);
+});

--- a/packages/database/tests/Entity/EntityExtensionTest.php
+++ b/packages/database/tests/Entity/EntityExtensionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Tests\Entity;
+
+use Marko\Database\Entity\EntityExtension;
+use ReflectionClass;
+
+it('rejects direct instantiation as an abstract class', function (): void {
+    $reflection = new ReflectionClass(EntityExtension::class);
+
+    expect($reflection->isAbstract())->toBeTrue();
+});
+
+it('can be extended to create a concrete extension class', function (): void {
+    $extension = new class () extends EntityExtension
+    {
+        public string $extraField;
+    };
+
+    $extension->extraField = 'value';
+
+    expect($extension)->toBeInstanceOf(EntityExtension::class)
+        ->and($extension->extraField)->toBe('value');
+});

--- a/packages/database/tests/Entity/EntityHydratorTest.php
+++ b/packages/database/tests/Entity/EntityHydratorTest.php
@@ -9,8 +9,10 @@ use DateTimeImmutable;
 use Marko\Database\Attributes\Column;
 use Marko\Database\Attributes\Table;
 use Marko\Database\Entity\Entity;
+use Marko\Database\Entity\EntityExtension;
 use Marko\Database\Entity\EntityHydrator;
 use Marko\Database\Entity\EntityMetadata;
+use Marko\Database\Entity\ExtensionMetadata;
 use Marko\Database\Entity\PropertyMetadata;
 
 #[Table('users')]
@@ -35,9 +37,11 @@ class HydratorTestUser extends Entity
 #[Table('posts')]
 class HydratorTestPost extends Entity
 {
+    /** @noinspection PhpUnused - Entity property for structural definition */
     #[Column(primaryKey: true, autoIncrement: true)]
     public ?int $id = null;
 
+    /** @noinspection PhpUnused - Entity property for structural definition */
     #[Column]
     public string $title;
 
@@ -58,9 +62,11 @@ enum PostStatus: string
 #[Table('articles')]
 class HydratorTestArticle extends Entity
 {
+    /** @noinspection PhpUnused - Entity property for structural definition */
     #[Column(primaryKey: true, autoIncrement: true)]
     public ?int $id = null;
 
+    /** @noinspection PhpUnused - Entity property for structural definition */
     #[Column]
     public string $title;
 
@@ -74,6 +80,7 @@ class HydratorTestArticle extends Entity
 #[Table('items')]
 class HydratorSnakeCaseEntity extends Entity
 {
+    /** @noinspection PhpUnused - Entity property for structural definition */
     #[Column(primaryKey: true)]
     public int $id;
 
@@ -86,6 +93,46 @@ class HydratorSnakeCaseEntity extends Entity
     #[Column]
     public int $totalCount;
 }
+
+// ── Extension fixtures ─────────────────────────────────────────────────────────
+
+class HydratorExtProfile extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    public string $phone;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    public ?string $website = null;
+}
+
+class HydratorExtMetrics extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    public int $viewCount;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    public float $rating;
+}
+
+enum HydratorExtStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}
+
+class HydratorExtTyped extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    public ?string $nullableField = null;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    public array $jsonField;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    public HydratorExtStatus $statusField;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
 
 it('creates EntityHydrator class', function (): void {
     $hydrator = new EntityHydrator();
@@ -616,3 +663,366 @@ function createSnakeCaseMetadata(): EntityMetadata
         ],
     );
 }
+
+function createProfileExtensionMetadata(): ExtensionMetadata
+{
+    return new ExtensionMetadata(
+        extensionClass: HydratorExtProfile::class,
+        entityClass: HydratorTestUser::class,
+        properties: [
+            'phone' => new PropertyMetadata(
+                name: 'phone',
+                columnName: 'phone',
+                type: 'string',
+                nullable: false,
+            ),
+            'website' => new PropertyMetadata(
+                name: 'website',
+                columnName: 'website',
+                type: 'string',
+                nullable: true,
+            ),
+        ],
+    );
+}
+
+function createMetricsExtensionMetadata(): ExtensionMetadata
+{
+    return new ExtensionMetadata(
+        extensionClass: HydratorExtMetrics::class,
+        entityClass: HydratorTestUser::class,
+        properties: [
+            'viewCount' => new PropertyMetadata(
+                name: 'viewCount',
+                columnName: 'view_count',
+                type: 'int',
+                nullable: false,
+            ),
+            'rating' => new PropertyMetadata(
+                name: 'rating',
+                columnName: 'rating',
+                type: 'float',
+                nullable: false,
+            ),
+        ],
+    );
+}
+
+function createTypedExtensionMetadata(): ExtensionMetadata
+{
+    return new ExtensionMetadata(
+        extensionClass: HydratorExtTyped::class,
+        entityClass: HydratorTestUser::class,
+        properties: [
+            'nullableField' => new PropertyMetadata(
+                name: 'nullableField',
+                columnName: 'nullable_field',
+                type: 'string',
+                nullable: true,
+            ),
+            'jsonField' => new PropertyMetadata(
+                name: 'jsonField',
+                columnName: 'json_field',
+                type: 'array',
+                nullable: false,
+                columnType: 'json',
+            ),
+            'statusField' => new PropertyMetadata(
+                name: 'statusField',
+                columnName: 'status_field',
+                type: HydratorExtStatus::class,
+                nullable: false,
+                enumClass: HydratorExtStatus::class,
+            ),
+        ],
+    );
+}
+
+function createUserMetadataWithProfileExtension(): EntityMetadata
+{
+    $base = createUserMetadata();
+
+    return new EntityMetadata(
+        entityClass: $base->entityClass,
+        tableName: $base->tableName,
+        primaryKey: $base->primaryKey,
+        properties: $base->properties,
+        extensions: [
+            HydratorExtProfile::class => createProfileExtensionMetadata(),
+        ],
+    );
+}
+
+function createUserMetadataWithBothExtensions(): EntityMetadata
+{
+    $base = createUserMetadata();
+
+    return new EntityMetadata(
+        entityClass: $base->entityClass,
+        tableName: $base->tableName,
+        primaryKey: $base->primaryKey,
+        properties: $base->properties,
+        extensions: [
+            HydratorExtProfile::class => createProfileExtensionMetadata(),
+            HydratorExtMetrics::class => createMetricsExtensionMetadata(),
+        ],
+    );
+}
+
+function createUserMetadataWithTypedExtension(): EntityMetadata
+{
+    $base = createUserMetadata();
+
+    return new EntityMetadata(
+        entityClass: $base->entityClass,
+        tableName: $base->tableName,
+        primaryKey: $base->primaryKey,
+        properties: $base->properties,
+        extensions: [
+            HydratorExtTyped::class => createTypedExtensionMetadata(),
+        ],
+    );
+}
+
+// ── Extension hydration tests ──────────────────────────────────────────────────
+
+it('attaches a hydrated extension instance to the entity when its columns are in the row', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithProfileExtension();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        'phone' => '555-1234',
+        'website' => 'https://example.com',
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+
+    expect($entity->extension(HydratorExtProfile::class))->toBeInstanceOf(HydratorExtProfile::class);
+});
+
+it('hydrates extension property values from the DB row', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithProfileExtension();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        'phone' => '555-1234',
+        'website' => 'https://example.com',
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+    $profile = $entity->extension(HydratorExtProfile::class);
+
+    expect($profile->phone)->toBe('555-1234')
+        ->and($profile->website)->toBe('https://example.com');
+});
+
+it('skips attaching an extension when none of its columns are present in the row', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithProfileExtension();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        // no phone or website columns
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+
+    expect($entity->extension(HydratorExtProfile::class))->toBeNull();
+});
+
+it('partially hydrates an extension when only some of its columns are present in the row', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithProfileExtension();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        'phone' => '555-1234',
+        // website column is absent
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+    $profile = $entity->extension(HydratorExtProfile::class);
+
+    expect($profile)->toBeInstanceOf(HydratorExtProfile::class)
+        ->and($profile->phone)->toBe('555-1234');
+});
+
+it('hydrates multiple extensions from the same row independently', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithBothExtensions();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        'phone' => '555-1234',
+        'website' => 'https://example.com',
+        'view_count' => 42,
+        'rating' => 4.5,
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+    $profile = $entity->extension(HydratorExtProfile::class);
+    $metrics = $entity->extension(HydratorExtMetrics::class);
+
+    expect($profile)->toBeInstanceOf(HydratorExtProfile::class)
+        ->and($metrics)->toBeInstanceOf(HydratorExtMetrics::class)
+        ->and($profile->phone)->toBe('555-1234')
+        ->and($metrics->viewCount)->toBe(42);
+});
+
+it('converts extension column values to the correct PHP types', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithBothExtensions();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        'phone' => 555,
+        'website' => null,
+        'view_count' => '99',
+        'rating' => '3.7',
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+    $profile = $entity->extension(HydratorExtProfile::class);
+    $metrics = $entity->extension(HydratorExtMetrics::class);
+
+    expect($profile->phone)->toBe('555')
+        ->toBeString()
+        ->and($metrics->viewCount)->toBe(99)
+        ->toBeInt()
+        ->and($metrics->rating)->toBe(3.7)
+        ->toBeFloat();
+});
+
+it('converts nullable extension column values to null', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithProfileExtension();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        'phone' => '555-1234',
+        'website' => null,
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+    $profile = $entity->extension(HydratorExtProfile::class);
+
+    expect($profile->website)->toBeNull();
+});
+
+it('converts JSON extension column values to arrays', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithTypedExtension();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        'nullable_field' => 'hello',
+        'json_field' => '{"key":"value","count":3}',
+        'status_field' => 'active',
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+    $typed = $entity->extension(HydratorExtTyped::class);
+
+    expect($typed->jsonField)->toBe(['key' => 'value', 'count' => 3])
+        ->toBeArray();
+});
+
+it('converts BackedEnum extension column values via the enum class', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithTypedExtension();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        'nullable_field' => null,
+        'json_field' => '[]',
+        'status_field' => 'inactive',
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+    $typed = $entity->extension(HydratorExtTyped::class);
+
+    expect($typed->statusField)->toBe(HydratorExtStatus::Inactive)
+        ->toBeInstanceOf(BackedEnum::class);
+});
+
+it('does not affect base entity hydration when no extensions are registered', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadata();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => 'Developer',
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+
+    expect($entity->id)->toBe(1)
+        ->and($entity->name)->toBe('John Doe')
+        ->and($entity->email)->toBe('john@example.com')
+        ->and($entity->isActive)->toBeTrue()
+        ->and($entity->bio)->toBe('Developer')
+        ->and($entity->extension(HydratorExtProfile::class))->toBeNull();
+});
+
+it('does not include extension property values in the originalValues dirty-tracking map', function (): void {
+    $hydrator = new EntityHydrator();
+    $metadata = createUserMetadataWithProfileExtension();
+
+    $row = [
+        'id' => 1,
+        'name' => 'John Doe',
+        'email_address' => 'john@example.com',
+        'is_active' => 1,
+        'bio' => null,
+        'phone' => '555-1234',
+        'website' => 'https://example.com',
+    ];
+
+    $entity = $hydrator->hydrate(HydratorTestUser::class, $row, $metadata);
+    $originalValues = $hydrator->getOriginalValues($entity);
+
+    expect($originalValues)->toHaveKeys(['id', 'name', 'email', 'isActive', 'bio'])
+        ->not->toHaveKey('phone')
+        ->not->toHaveKey('website');
+});

--- a/packages/database/tests/Entity/EntityMetadataExtensionsTest.php
+++ b/packages/database/tests/Entity/EntityMetadataExtensionsTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\Tests\Entity;
+
+use Marko\Database\Attributes\Column;
+use Marko\Database\Attributes\ExtensionOf;
+use Marko\Database\Attributes\Table;
+use Marko\Database\Entity\Entity;
+use Marko\Database\Entity\EntityExtension;
+use Marko\Database\Entity\EntityExtensionMetadataFactory;
+use Marko\Database\Entity\EntityExtensionRegistry;
+use Marko\Database\Entity\EntityMetadata;
+use Marko\Database\Entity\EntityMetadataFactory;
+use Marko\Database\Entity\ExtensionMetadata;
+use Marko\Database\Exceptions\EntityException;
+
+// ── Fixture classes ────────────────────────────────────────────────────────────
+
+#[Table('ext_merge_users')]
+class ExtMergeUser extends Entity
+{
+    #[Column(primaryKey: true)]
+    public int $id;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $name;
+}
+
+#[ExtensionOf(entityClass: ExtMergeUser::class)]
+class ExtMergeExtensionA extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $extraA;
+}
+
+#[ExtensionOf(entityClass: ExtMergeUser::class)]
+class ExtMergeExtensionB extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $extraB;
+}
+
+#[ExtensionOf(entityClass: ExtMergeUser::class)]
+class ExtMergeColumnConflictExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(name: 'name')]
+    public string $conflictingColumn;
+}
+
+#[ExtensionOf(entityClass: ExtMergeUser::class)]
+class ExtMergeExtExtColumnConflictA extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(name: 'shared_col')]
+    public string $propA;
+}
+
+#[ExtensionOf(entityClass: ExtMergeUser::class)]
+class ExtMergeExtExtColumnConflictB extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(name: 'shared_col')]
+    public string $propB;
+}
+
+#[ExtensionOf(entityClass: ExtMergeUser::class)]
+class ExtMergePropertyConflictExtension extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $name;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+it('includes an empty extensions map by default on EntityMetadata', function (): void {
+    $metadata = new EntityMetadata(
+        entityClass: ExtMergeUser::class,
+        tableName: 'ext_merge_users',
+        primaryKey: 'id',
+    );
+
+    expect($metadata->extensions)->toBeEmpty();
+});
+
+it('constructs EntityMetadataFactory with null registry and factory for backward compatibility', function (): void {
+    $factory = new EntityMetadataFactory();
+
+    expect($factory)->toBeInstanceOf(EntityMetadataFactory::class);
+});
+
+it('populates extensions from the registry when parsing an entity with registered extensions', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register(ExtMergeUser::class, ExtMergeExtensionA::class);
+    $registry->register(ExtMergeUser::class, ExtMergeExtensionB::class);
+
+    $extensionMetadataFactory = new EntityExtensionMetadataFactory();
+    $factory = new EntityMetadataFactory($registry, $extensionMetadataFactory);
+
+    $metadata = $factory->parse(ExtMergeUser::class);
+
+    expect($metadata->extensions)
+        ->toHaveCount(2)
+        ->and($metadata->extensions)->toHaveKey(ExtMergeExtensionA::class)
+        ->and($metadata->extensions)->toHaveKey(ExtMergeExtensionB::class)
+        ->and($metadata->extensions[ExtMergeExtensionA::class])->toBeInstanceOf(ExtensionMetadata::class)
+        ->and($metadata->extensions[ExtMergeExtensionB::class])->toBeInstanceOf(ExtensionMetadata::class);
+});
+
+it('leaves extensions empty when no extensions are registered for the entity', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $extensionMetadataFactory = new EntityExtensionMetadataFactory();
+    $factory = new EntityMetadataFactory($registry, $extensionMetadataFactory);
+
+    $metadata = $factory->parse(ExtMergeUser::class);
+
+    expect($metadata->extensions)->toBeEmpty();
+});
+
+it('leaves extensions empty when constructed without a registry', function (): void {
+    $factory = new EntityMetadataFactory();
+
+    $metadata = $factory->parse(ExtMergeUser::class);
+
+    expect($metadata->extensions)->toBeEmpty();
+});
+
+it('throws when an extension column name collides with a base entity column name', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register(ExtMergeUser::class, ExtMergeColumnConflictExtension::class);
+
+    $extensionMetadataFactory = new EntityExtensionMetadataFactory();
+    $factory = new EntityMetadataFactory($registry, $extensionMetadataFactory);
+
+    $factory->parse(ExtMergeUser::class);
+})->throws(EntityException::class);
+
+it('throws when two extension column names collide with each other', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register(ExtMergeUser::class, ExtMergeExtExtColumnConflictA::class);
+    $registry->register(ExtMergeUser::class, ExtMergeExtExtColumnConflictB::class);
+
+    $extensionMetadataFactory = new EntityExtensionMetadataFactory();
+    $factory = new EntityMetadataFactory($registry, $extensionMetadataFactory);
+
+    $factory->parse(ExtMergeUser::class);
+})->throws(EntityException::class);
+
+it('throws when an extension property name collides with a base entity property name', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register(ExtMergeUser::class, ExtMergePropertyConflictExtension::class);
+
+    $extensionMetadataFactory = new EntityExtensionMetadataFactory();
+    $factory = new EntityMetadataFactory($registry, $extensionMetadataFactory);
+
+    $factory->parse(ExtMergeUser::class);
+})->throws(EntityException::class);
+
+it('caches entity metadata including extensions', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register(ExtMergeUser::class, ExtMergeExtensionA::class);
+
+    $extensionMetadataFactory = new EntityExtensionMetadataFactory();
+    $factory = new EntityMetadataFactory($registry, $extensionMetadataFactory);
+
+    $metadata1 = $factory->parse(ExtMergeUser::class);
+    $metadata2 = $factory->parse(ExtMergeUser::class);
+
+    expect($metadata1)->toBe($metadata2);
+});

--- a/packages/database/tests/Entity/SchemaBuilderTest.php
+++ b/packages/database/tests/Entity/SchemaBuilderTest.php
@@ -5,15 +5,59 @@ declare(strict_types=1);
 namespace Marko\Database\Tests\Entity;
 
 use Marko\Database\Attributes\Column;
+use Marko\Database\Attributes\ExtensionOf;
 use Marko\Database\Attributes\Index;
 use Marko\Database\Attributes\Table;
 use Marko\Database\Entity\Entity;
+use Marko\Database\Entity\EntityExtension;
+use Marko\Database\Entity\EntityExtensionMetadataFactory;
+use Marko\Database\Entity\EntityExtensionRegistry;
 use Marko\Database\Entity\EntityMetadataFactory;
 use Marko\Database\Entity\SchemaBuilder;
 use Marko\Database\Schema\Column as SchemaColumn;
 use Marko\Database\Schema\Index as SchemaIndex;
 use Marko\Database\Schema\IndexType;
 use Marko\Database\Schema\Table as SchemaTable;
+
+// ── Fixture classes ────────────────────────────────────────────────────────────
+
+#[Table('sb_products')]
+class SbProduct extends Entity
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(primaryKey: true, autoIncrement: true)]
+    public int $id;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(length: 255)]
+    public string $name;
+}
+
+#[ExtensionOf(entityClass: SbProduct::class)]
+class SbProductExtensionA extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(length: 100)]
+    public string $color;
+}
+
+#[ExtensionOf(entityClass: SbProduct::class)]
+class SbProductExtensionB extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public ?string $sku;
+}
+
+#[ExtensionOf(entityClass: SbProduct::class)]
+class SbProductExtensionWithFk extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(references: 'categories.id', onDelete: 'CASCADE')]
+    public int $categoryId;
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────────
 
 beforeEach(function (): void {
     $this->metadataFactory = new EntityMetadataFactory();
@@ -156,4 +200,78 @@ it('builds ForeignKey objects from column references', function (): void {
         ->and($table->foreignKeys[0]->referencedColumns)->toBe(['id'])
         ->and($table->foreignKeys[0]->onDelete)->toBe('CASCADE')
         ->and($table->foreignKeys[0]->onUpdate)->toBe('SET NULL');
+});
+
+it('includes columns from multiple extensions', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register(SbProduct::class, SbProductExtensionA::class);
+    $registry->register(SbProduct::class, SbProductExtensionB::class);
+
+    $factory = new EntityMetadataFactory($registry, new EntityExtensionMetadataFactory());
+    $metadata = $factory->parse(SbProduct::class);
+    $table = $this->schemaBuilder->build($metadata);
+
+    expect($table->columns)->toHaveCount(4)
+        ->and($table->columns[0]->name)->toBe('id')
+        ->and($table->columns[1]->name)->toBe('name')
+        ->and($table->columns[2]->name)->toBe('color')
+        ->and($table->columns[3]->name)->toBe('sku')
+        ->and($table->columns[3]->nullable)->toBeTrue();
+});
+
+it('produces the same Table as before when no extensions are registered', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $factory = new EntityMetadataFactory($registry, new EntityExtensionMetadataFactory());
+    $metadata = $factory->parse(SbProduct::class);
+    $table = $this->schemaBuilder->build($metadata);
+
+    expect($table->columns)->toHaveCount(2)
+        ->and($table->columns[0]->name)->toBe('id')
+        ->and($table->columns[1]->name)->toBe('name')
+        ->and($table->foreignKeys)->toHaveCount(0);
+});
+
+it('includes foreign key constraints from extension columns that reference other tables', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register(SbProduct::class, SbProductExtensionWithFk::class);
+
+    $factory = new EntityMetadataFactory($registry, new EntityExtensionMetadataFactory());
+    $metadata = $factory->parse(SbProduct::class);
+    $table = $this->schemaBuilder->build($metadata);
+
+    expect($table->foreignKeys)->toHaveCount(1)
+        ->and($table->foreignKeys[0]->name)->toBe('fk_sb_products_category_id')
+        ->and($table->foreignKeys[0]->columns)->toBe(['category_id'])
+        ->and($table->foreignKeys[0]->referencedTable)->toBe('categories')
+        ->and($table->foreignKeys[0]->referencedColumns)->toBe(['id'])
+        ->and($table->foreignKeys[0]->onDelete)->toBe('CASCADE');
+});
+
+it('builds correct column types for extension columns', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register(SbProduct::class, SbProductExtensionA::class);
+
+    $factory = new EntityMetadataFactory($registry, new EntityExtensionMetadataFactory());
+    $metadata = $factory->parse(SbProduct::class);
+    $table = $this->schemaBuilder->build($metadata);
+
+    expect($table->columns[2])->toBeInstanceOf(SchemaColumn::class)
+        ->and($table->columns[2]->name)->toBe('color')
+        ->and($table->columns[2]->type)->toBe('varchar')
+        ->and($table->columns[2]->length)->toBe(100)
+        ->and($table->columns[2]->nullable)->toBeFalse();
+});
+
+it('includes extension columns in the built Table schema', function (): void {
+    $registry = new EntityExtensionRegistry();
+    $registry->register(SbProduct::class, SbProductExtensionA::class);
+
+    $factory = new EntityMetadataFactory($registry, new EntityExtensionMetadataFactory());
+    $metadata = $factory->parse(SbProduct::class);
+    $table = $this->schemaBuilder->build($metadata);
+
+    expect($table->columns)->toHaveCount(3)
+        ->and($table->columns[0]->name)->toBe('id')
+        ->and($table->columns[1]->name)->toBe('name')
+        ->and($table->columns[2]->name)->toBe('color');
 });

--- a/packages/database/tests/PackageScaffoldingTest.php
+++ b/packages/database/tests/PackageScaffoldingTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Marko\Database\Entity\EntityExtensionRegistry;
+
 describe('Package Scaffolding', function (): void {
     it('creates marko/database package with valid composer.json', function (): void {
         $composerPath = dirname(__DIR__) . '/composer.json';
@@ -152,5 +154,29 @@ describe('Package Scaffolding', function (): void {
             ->and($content)->toContain('DB_PASSWORD')
             // Driver-specific notes
             ->and($content)->toContain('PostgreSQL');
+    });
+
+    it('has a README that documents entity extensions', function (): void {
+        $readmePath = dirname(__DIR__) . '/README.md';
+
+        expect(file_exists($readmePath))->toBeTrue()
+            ->and(file_get_contents($readmePath))->toContain('EntityExtension');
+    });
+
+    it('registers EntityExtensionRegistry as a singleton in the container', function (): void {
+        $module = require dirname(__DIR__) . '/module.php';
+
+        expect($module)->toBeArray()
+            ->and($module)->toHaveKey('singletons')
+            ->and($module['singletons'])->toHaveKey(EntityExtensionRegistry::class)
+            ->and($module['singletons'][EntityExtensionRegistry::class])->toBe(EntityExtensionRegistry::class);
+    });
+
+    it('declares a boot callback in module.php that populates the registry from discovery', function (): void {
+        $module = require dirname(__DIR__) . '/module.php';
+
+        expect($module)->toBeArray()
+            ->and($module)->toHaveKey('boot')
+            ->and($module['boot'])->toBeCallable();
     });
 });

--- a/packages/database/tests/Repository/RepositoryTest.php
+++ b/packages/database/tests/Repository/RepositoryTest.php
@@ -1442,6 +1442,7 @@ function createSpyConnection(array &$sqlLog, array $queryResults = []): Connecti
 #[Table('orders')]
 class OrderWithCustomPk extends Entity
 {
+    /** @noinspection PhpUnused - Entity property for structural definition */
     #[Column(primaryKey: true, autoIncrement: true, name: 'order_uuid')]
     public ?int $orderUuid = null;
 
@@ -1602,4 +1603,349 @@ it('Repository::count() delegates to the builder without duplicating logic', fun
     expect($builderCountCalled)->toBeTrue()
         ->and($rawQueryCalled)->toBeFalse()
         ->and($result)->toBe(7);
+});
+
+// ── Extension INSERT/UPDATE tests ───────────────────────────────────────────────
+
+use DateTimeImmutable;
+use Marko\Database\Attributes\ExtensionOf;
+use Marko\Database\Entity\EntityExtension;
+use Marko\Database\Entity\EntityExtensionMetadataFactory;
+use Marko\Database\Entity\EntityExtensionRegistry;
+
+#[Table('ext_users')]
+class ExtUser extends Entity
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column(primaryKey: true, autoIncrement: true)]
+    public ?int $id = null;
+
+    #[Column]
+    public string $name = '';
+}
+
+#[ExtensionOf(entityClass: ExtUser::class)]
+class ExtUserProfile extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $phone = '';
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public ?string $website = null;
+}
+
+#[ExtensionOf(entityClass: ExtUser::class)]
+class ExtUserMetrics extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public int $viewCount = 0;
+}
+
+enum ExtUserStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}
+
+#[ExtensionOf(entityClass: ExtUser::class)]
+class ExtUserRequired extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public string $requiredField;
+}
+
+#[ExtensionOf(entityClass: ExtUser::class)]
+class ExtUserTyped extends EntityExtension
+{
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public ExtUserStatus $status = ExtUserStatus::Active;
+
+    /** @noinspection PhpUnused - Entity property for structural definition */
+    #[Column]
+    public ?DateTimeImmutable $activatedAt = null;
+}
+
+class ExtUserRepository extends Repository
+{
+    protected const string ENTITY_CLASS = ExtUser::class;
+}
+
+/**
+ * Build an EntityMetadataFactory with the given extension classes registered for ExtUser.
+ *
+ * @param class-string<EntityExtension> ...$extensionClasses
+ */
+function makeExtMetadataFactory(string ...$extensionClasses): EntityMetadataFactory
+{
+    $registry = new EntityExtensionRegistry();
+    foreach ($extensionClasses as $extensionClass) {
+        $registry->register(ExtUser::class, $extensionClass);
+    }
+
+    return new EntityMetadataFactory($registry, new EntityExtensionMetadataFactory());
+}
+
+it('includes extension columns in the INSERT statement when extension is attached', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserProfile::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    $user = new ExtUser();
+    $user->name = 'Alice';
+
+    $profile = new ExtUserProfile();
+    $profile->phone = '555-0001';
+    $profile->website = 'https://alice.example.com';
+    $user->setExtension($profile);
+
+    $repository->save($user);
+
+    $insertEntry = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'INSERT')))[0];
+    expect($insertEntry['sql'])->toContain('phone')
+        ->and($insertEntry['sql'])->toContain('website')
+        ->and($insertEntry['bindings'])->toContain('555-0001')
+        ->and($insertEntry['bindings'])->toContain('https://alice.example.com');
+});
+
+it('uses null for nullable extension columns when extension is not attached', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserProfile::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    $user = new ExtUser();
+    $user->name = 'Bob';
+    // No extension attached — website is nullable, phone is non-nullable but has a default ''
+
+    $repository->save($user);
+
+    $insertEntry = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'INSERT')))[0];
+    expect($insertEntry['sql'])->toContain('website')
+        ->and($insertEntry['bindings'])->toContain(null);
+});
+
+it('uses declared default for non-nullable extension columns when extension is not attached', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserMetrics::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    $user = new ExtUser();
+    $user->name = 'Carol';
+    // No extension attached — viewCount is non-nullable but has default 0
+
+    $repository->save($user);
+
+    $insertEntry = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'INSERT')))[0];
+    expect($insertEntry['sql'])->toContain('view_count')
+        ->and($insertEntry['bindings'])->toContain(0);
+});
+
+it('throws when a non-nullable extension column has no default and no extension is attached', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserRequired::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    $user = new ExtUser();
+    $user->name = 'Dave';
+    // No extension attached — requiredField is non-nullable with no default
+
+    $repository->save($user);
+})->throws(RepositoryException::class, 'extension');
+
+it('includes extension columns in the UPDATE statement', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog, [
+        [['id' => 1, 'name' => 'Alice']],
+    ]);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserProfile::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    // Hydrate entity to make it non-new
+    $user = $repository->find(1);
+    $user->name = 'Alice Updated';
+
+    $profile = new ExtUserProfile();
+    $profile->phone = '555-9999';
+    $profile->website = null;
+    $user->setExtension($profile);
+
+    $repository->save($user);
+
+    $updateEntry = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'UPDATE')))[0];
+    expect($updateEntry['sql'])->toContain('phone')
+        ->and($updateEntry['sql'])->toContain('website')
+        ->and($updateEntry['bindings'])->toContain('555-9999');
+});
+
+it('still issues an UPDATE for extension columns when no base entity properties are dirty', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog, [
+        [['id' => 1, 'name' => 'Alice']],
+    ]);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserProfile::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    // Hydrate entity — no changes to base properties (no dirty)
+    $user = $repository->find(1);
+
+    // Attach extension
+    $profile = new ExtUserProfile();
+    $profile->phone = '555-8888';
+    $profile->website = 'https://example.com';
+    $user->setExtension($profile);
+
+    $repository->save($user);
+
+    $updateEntries = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'UPDATE')));
+    expect($updateEntries)->toHaveCount(1)
+        ->and($updateEntries[0]['sql'])->toContain('phone')
+        ->and($updateEntries[0]['bindings'])->toContain('555-8888');
+});
+
+it('does not issue an UPDATE when there are no dirty base properties and no extensions registered', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog, [
+        [['id' => 1, 'name' => 'Alice', 'email_address' => 'alice@example.com', 'is_active' => 1]],
+    ]);
+
+    // UserRepository has NO extensions registered
+    $metadataFactory = new EntityMetadataFactory();
+    $hydrator = new EntityHydrator();
+    $repository = new UserRepository($connection, $metadataFactory, $hydrator);
+
+    // Hydrate entity — no changes made (no dirty)
+    $user = $repository->find(1);
+
+    $repository->save($user);
+
+    $updateEntries = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'UPDATE')));
+    expect($updateEntries)->toHaveCount(0);
+});
+
+it('includes extension columns in batch insert', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserProfile::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    $user1 = new ExtUser();
+    $user1->name = 'Alice';
+    $profile1 = new ExtUserProfile();
+    $profile1->phone = '555-0001';
+    $profile1->website = 'https://alice.example.com';
+    $user1->setExtension($profile1);
+
+    $user2 = new ExtUser();
+    $user2->name = 'Bob';
+    $profile2 = new ExtUserProfile();
+    $profile2->phone = '555-0002';
+    $profile2->website = null;
+    $user2->setExtension($profile2);
+
+    $repository->insertBatch([$user1, $user2]);
+
+    $insertEntry = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'INSERT')))[0];
+    expect($insertEntry['sql'])->toContain('phone')
+        ->and($insertEntry['sql'])->toContain('website')
+        ->and($insertEntry['bindings'])->toContain('555-0001')
+        ->and($insertEntry['bindings'])->toContain('555-0002');
+});
+
+it('writes correct extension values for multiple extensions on the same entity', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserProfile::class, ExtUserMetrics::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    $user = new ExtUser();
+    $user->name = 'Alice';
+
+    $profile = new ExtUserProfile();
+    $profile->phone = '555-1111';
+    $profile->website = 'https://alice.example.com';
+    $user->setExtension($profile);
+
+    $metrics = new ExtUserMetrics();
+    $metrics->viewCount = 42;
+    $user->setExtension($metrics);
+
+    $repository->save($user);
+
+    $insertEntry = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'INSERT')))[0];
+    expect($insertEntry['sql'])->toContain('phone')
+        ->and($insertEntry['sql'])->toContain('view_count')
+        ->and($insertEntry['bindings'])->toContain('555-1111')
+        ->and($insertEntry['bindings'])->toContain(42);
+});
+
+it('converts BackedEnum extension property values to backing values before persisting', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserTyped::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    $user = new ExtUser();
+    $user->name = 'Alice';
+
+    $typed = new ExtUserTyped();
+    $typed->status = ExtUserStatus::Inactive;
+    $typed->activatedAt = null;
+    $user->setExtension($typed);
+
+    $repository->save($user);
+
+    $insertEntry = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'INSERT')))[0];
+    expect($insertEntry['sql'])->toContain('status')
+        ->and($insertEntry['bindings'])->toContain('inactive')
+        ->and($insertEntry['bindings'])->not->toContain(ExtUserStatus::Inactive);
+});
+
+it('converts DateTimeImmutable extension property values to formatted strings before persisting', function (): void {
+    $sqlLog = [];
+    $connection = createSpyConnection($sqlLog);
+
+    $metadataFactory = makeExtMetadataFactory(ExtUserTyped::class);
+    $hydrator = new EntityHydrator();
+    $repository = new ExtUserRepository($connection, $metadataFactory, $hydrator);
+
+    $user = new ExtUser();
+    $user->name = 'Alice';
+
+    $typed = new ExtUserTyped();
+    $typed->status = ExtUserStatus::Active;
+    $typed->activatedAt = new DateTimeImmutable('2025-01-15 12:30:00');
+    $user->setExtension($typed);
+
+    $repository->save($user);
+
+    $insertEntry = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'INSERT')))[0];
+    expect($insertEntry['sql'])->toContain('activated_at')
+        ->and($insertEntry['bindings'])->toContain('2025-01-15 12:30:00')
+        ->and($insertEntry['bindings'])->not->toContain($typed->activatedAt);
 });


### PR DESCRIPTION
## Summary

- Any module can now add columns to an existing entity's table without touching the original entity class
- Extensions are auto-discovered from `src/EntityExtension/` directories across vendor/modules/app at boot
- Hydrated transparently from the same DB row; accessed via `$entity->extension(MyExtension::class)` with full IDE type inference via `@template`

## What was built

- **`EntityExtension`** abstract base class + **`#[ExtensionOf]`** attribute to declare which entity a class extends
- **`EntityExtensionRegistry`** singleton + **`EntityExtensionDiscovery`** scanner — registered and populated in `module.php` boot
- **`ExtensionMetadata`** + **`EntityExtensionMetadataFactory`** — parses extension classes; validates no `#[Table]`, no primary key, no relationships
- **`EntityMetadata::$extensions`** field (backward-compatible last param) — `EntityMetadataFactory` merges extensions and detects column/property name conflicts loud at boot
- **`Entity::extension()` / `setExtension()`** — typed accessor with `@template T of EntityExtension` for IDE inference
- **`EntityHydrator`** — hydrates extension objects from the same DB row; silently skips extensions whose columns are absent (safe during rolling deploys)
- **`Repository`** — INSERT/UPDATE/batch include extension columns; null/default/loud-error policy enforced at save time
- **`SchemaBuilder`** — extension columns included in table schema for migration diffs
- **`packages/database/README.md`** updated with full developer workflow

## Test plan

- [x] 47 new tests added across 10 new/modified test files
- [x] Full suite: 4956 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)