### PR TITLE
feat(routing): memoize RouteMatcher and share one instance with Router

### DIFF
--- a/packages/routing/src/RouteMatcher.php
+++ b/packages/routing/src/RouteMatcher.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Marko\Routing;
 
-readonly class RouteMatcher implements RouteMatcherInterface
+class RouteMatcher implements RouteMatcherInterface
 {
+    /** @var array<string, ?MatchedRoute> */
+    private array $cache = [];
+
     public function __construct(
-        private RouteCollection $routes,
+        private readonly RouteCollection $routes,
     ) {}
 
     public function match(
@@ -15,19 +18,24 @@ readonly class RouteMatcher implements RouteMatcherInterface
         string $path,
     ): ?MatchedRoute {
         $normalizedPath = $this->normalizePath($path);
+        $cacheKey = $method . ':' . $normalizedPath;
+
+        if (array_key_exists($cacheKey, $this->cache)) {
+            return $this->cache[$cacheKey];
+        }
 
         foreach ($this->routes->byMethod($method) as $route) {
             if (preg_match($route->regex, $normalizedPath, $matches)) {
                 $parameters = $this->extractParameters($route, $matches);
 
-                return new MatchedRoute(
+                return $this->cache[$cacheKey] = new MatchedRoute(
                     route: $route,
                     parameters: $parameters,
                 );
             }
         }
 
-        return null;
+        return $this->cache[$cacheKey] = null;
     }
 
     private function normalizePath(

--- a/packages/routing/src/Router.php
+++ b/packages/routing/src/Router.php
@@ -18,19 +18,16 @@ use ReflectionType;
 
 readonly class Router
 {
-    private RouteMatcher $matcher;
-
     private MiddlewarePipeline $pipeline;
 
     /**
      * @param array<class-string<MiddlewareInterface>> $globalMiddleware
      */
     public function __construct(
-        private RouteCollection $routes,
+        private RouteMatcherInterface $matcher,
         private ContainerInterface $container,
         private array $globalMiddleware = [],
     ) {
-        $this->matcher = new RouteMatcher($routes);
         $this->pipeline = new MiddlewarePipeline($container);
     }
 

--- a/packages/routing/src/RoutingBootstrapper.php
+++ b/packages/routing/src/RoutingBootstrapper.php
@@ -57,11 +57,13 @@ class RoutingBootstrapper
         // Register RouteCollection as singleton instance
         $this->container->instance(RouteCollection::class, $this->routes);
 
-        // Register RouteMatcher with the same RouteCollection
-        $this->container->instance(RouteMatcherInterface::class, new RouteMatcher($this->routes));
+        // Register a single RouteMatcher so the Router and any middleware that
+        // inspects routes (e.g. PageCacheMiddleware) share one memoized instance.
+        $matcher = new RouteMatcher($this->routes);
+        $this->container->instance(RouteMatcherInterface::class, $matcher);
 
         // Create and register Router
-        $router = new Router($this->routes, $this->container, $globalMiddleware);
+        $router = new Router($matcher, $this->container, $globalMiddleware);
         $this->container->instance(Router::class, $router);
 
         return $router;

--- a/packages/routing/tests/Integration/DemoRoutingTest.php
+++ b/packages/routing/tests/Integration/DemoRoutingTest.php
@@ -8,6 +8,7 @@ use Marko\Routing\Http\Request;
 use Marko\Routing\Http\Response;
 use Marko\Routing\RouteCollection;
 use Marko\Routing\RouteDefinition;
+use Marko\Routing\RouteMatcher;
 use Marko\Routing\Router;
 
 /**
@@ -51,7 +52,7 @@ it('demo index.php routes request through Router', function (): void {
     $container->instance($controller::class, $controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -96,7 +97,7 @@ it('demo index.php returns 404 for unmatched routes', function (): void {
     $container = new Container($preferenceRegistry);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 

--- a/packages/routing/tests/RouteMatcherTest.php
+++ b/packages/routing/tests/RouteMatcherTest.php
@@ -210,3 +210,65 @@ it('matches root path /', function () {
         ->and($result->route)->toBe($route)
         ->and($result->parameters)->toBe([]);
 });
+
+it('memoizes match() results per (method, path)', function () {
+    $collection = new RouteCollection();
+    $collection->add(new RouteDefinition(
+        method: 'GET',
+        path: '/products/{id}',
+        controller: 'ProductController',
+        action: 'show',
+    ));
+
+    $matcher = new RouteMatcher($collection);
+
+    $first = $matcher->match('GET', '/products/42');
+    $second = $matcher->match('GET', '/products/42');
+
+    // Same input must return the identical MatchedRoute object (memoized)
+    expect($second)->toBe($first);
+});
+
+it('memoizes null results for unmatched (method, path) pairs', function () {
+    $collection = new RouteCollection();
+    $collection->add(new RouteDefinition(
+        method: 'GET',
+        path: '/products',
+        controller: 'ProductController',
+        action: 'index',
+    ));
+
+    $matcher = new RouteMatcher($collection);
+
+    expect($matcher->match('GET', '/missing'))->toBeNull()
+        ->and($matcher->match('GET', '/missing'))->toBeNull();
+});
+
+it('distinguishes cached entries by method and by path', function () {
+    $collection = new RouteCollection();
+    $getRoute = new RouteDefinition(
+        method: 'GET',
+        path: '/orders/{id}',
+        controller: 'OrderController',
+        action: 'show',
+    );
+    $postRoute = new RouteDefinition(
+        method: 'POST',
+        path: '/orders/{id}',
+        controller: 'OrderController',
+        action: 'update',
+    );
+    $collection->add($getRoute);
+    $collection->add($postRoute);
+
+    $matcher = new RouteMatcher($collection);
+
+    $getMatch = $matcher->match('GET', '/orders/1');
+    $postMatch = $matcher->match('POST', '/orders/1');
+    $otherPath = $matcher->match('GET', '/orders/2');
+
+    expect($getMatch->route)->toBe($getRoute)
+        ->and($postMatch->route)->toBe($postRoute)
+        ->and($otherPath)->not->toBe($getMatch)
+        ->and($otherPath->route)->toBe($getRoute);
+});

--- a/packages/routing/tests/RouterTest.php
+++ b/packages/routing/tests/RouterTest.php
@@ -8,14 +8,15 @@ use Marko\Routing\Http\Response;
 use Marko\Routing\Middleware\MiddlewareInterface;
 use Marko\Routing\RouteCollection;
 use Marko\Routing\RouteDefinition;
+use Marko\Routing\RouteMatcher;
 use Marko\Routing\Router;
 
-it('accepts RouteCollection in constructor', function (): void {
+it('accepts a RouteMatcher in constructor', function (): void {
     $routes = new RouteCollection();
     $container = $this->createMock(ContainerInterface::class);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -44,7 +45,7 @@ it('matches request to route', function (): void {
         ->willReturn($controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -65,7 +66,7 @@ it('returns 404 response when no route matches', function (): void {
     $container = $this->createMock(ContainerInterface::class);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -104,7 +105,7 @@ it('resolves controller through container', function (): void {
         ->willReturn($controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -148,7 +149,7 @@ it('invokes controller method', function (): void {
         ->willReturn($controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -192,7 +193,7 @@ it('passes route parameters to controller method', function (): void {
         ->willReturn($controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -251,7 +252,7 @@ it('executes middleware pipeline', function (): void {
         });
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -292,7 +293,7 @@ it('returns response from controller', function (): void {
         ->willReturn($controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -354,7 +355,7 @@ it('returns response from middleware short-circuit', function (): void {
         });
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -392,7 +393,7 @@ it('handles controller returning Response object', function (): void {
         ->willReturn($controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -430,7 +431,7 @@ it('wraps string return in Response object', function (): void {
         ->willReturn($controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -471,7 +472,7 @@ it('wraps array return in JSON Response', function (): void {
         ->willReturn($controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -518,7 +519,7 @@ it('injects Request into controller method parameter', function (): void {
         ->willReturn($controller);
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
     );
 
@@ -576,7 +577,7 @@ it('executes global middleware on every request', function (): void {
         });
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
         globalMiddleware: ['App\\Middleware\\GlobalMiddleware'],
     );
@@ -653,7 +654,7 @@ it('runs global middleware before route middleware', function (): void {
         });
 
     $router = new Router(
-        routes: $routes,
+        matcher: new RouteMatcher($routes),
         container: $container,
         globalMiddleware: ['App\\Middleware\\GlobalMiddleware'],
     );

--- a/packages/routing/tests/RoutingBootstrapperTest.php
+++ b/packages/routing/tests/RoutingBootstrapperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Marko\Core\Application;
 use Marko\Routing\Exceptions\RouteConflictException;
 use Marko\Routing\RouteCollection;
+use Marko\Routing\RouteMatcherInterface;
 use Marko\Routing\Router;
 
 // Helper function for recursive directory cleanup
@@ -306,6 +307,36 @@ it('returns Router as singleton in container', function (): void {
     $router2 = $container->get(Router::class);
 
     expect($router1)->toBe($router2);
+
+    routingTestCleanupDirectory($baseDir);
+});
+
+it('shares one RouteMatcher between the container and the Router', function (): void {
+    $uniqueId = bin2hex(random_bytes(8));
+    $baseDir = sys_get_temp_dir() . '/marko-routing-test-' . $uniqueId;
+    $vendorDir = $baseDir . '/vendor';
+
+    routingTestCreateModule($vendorDir . '/acme/core', 'acme/core');
+
+    $app = new Application(
+        vendorPath: $vendorDir,
+        modulesPath: '',
+        appPath: '',
+    );
+
+    $app->initialize();
+
+    $container = $app->container;
+    $containerMatcher = $container->get(RouteMatcherInterface::class);
+
+    // Reflect Router's private $matcher to confirm it is the same instance the
+    // container hands out — required so middleware that calls match() shares
+    // the Router's memoization cache.
+    $router = $container->get(Router::class);
+    $reflection = new ReflectionProperty($router, 'matcher');
+    $routerMatcher = $reflection->getValue($router);
+
+    expect($routerMatcher)->toBe($containerMatcher);
 
     routingTestCleanupDirectory($baseDir);
 });


### PR DESCRIPTION
## Summary

Closes #61.

Eliminates the duplicate route match per request that any global middleware inspecting the upcoming route would trigger (the original surfacing example was `PageCacheMiddleware` reading `#[Cacheable]`).

- **Memoize `RouteMatcher::match()` by `(method, path)`** — both hit and miss results are cached, so repeated calls within a request are O(1). Class is no longer `readonly` since the cache mutates; the `$routes` field stays `readonly`.
- **Share one matcher between container and `Router`** — `Router` now takes `RouteMatcherInterface` via constructor instead of constructing a private `RouteMatcher`. `RoutingBootstrapper` creates a single matcher, binds it to the container, and passes the same instance to `Router`. The `RouteCollection $routes` parameter is removed from `Router` (it only existed to construct the now-removed private matcher).

Net effect: a cacheable request still resolves the route exactly once. The middleware's `match()` populates the cache; the router's later `match()` is the cache hit.

## Test plan

- [x] Added 3 `RouteMatcher` memoization tests: per-`(method, path)` identity, null caching, and key disambiguation by method and by path.
- [x] Added a `RoutingBootstrapper` test that reflects into the registered `Router` and asserts its private `$matcher` is the same instance the container hands out for `RouteMatcherInterface`.
- [x] Updated `RouterTest` (15 sites) and `DemoRoutingTest` (2 sites) constructors from `routes: $routes` to `matcher: new RouteMatcher($routes)`.
- [x] `composer test` — 5042 passed / 0 failed
- [x] `phpcs` + `php-cs-fixer` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)