### PR TITLE
fix: auto-create missing split repos and cancel superseded runs

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: split-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 env:
   SPLIT_ORG: marko-php
@@ -19,6 +19,10 @@ jobs:
       packages: ${{ steps.list.outputs.packages }}
     steps:
       - uses: actions/checkout@v6
+      - name: Create missing split repos
+        env:
+          GH_TOKEN: ${{ secrets.SPLIT_TOKEN }}
+        run: ./bin/create-split-repos.sh
       - name: List packages
         id: list
         run: |


### PR DESCRIPTION
## Summary

- **Auto-create missing split repos** before the matrix fans out, so a plain merge to `develop` that introduces a new package doesn't fail at the git push step with "Repository not found" (as just happened for the three page-cache packages in [run 25739254101](https://github.com/marko-php/marko/actions/runs/25739254101)). Previously, repo auto-creation only ran during `bin/release.sh`.
- **Cancel superseded branch runs.** `cancel-in-progress` was hard-coded to `false`, so rapid pushes to `develop` queued and each run repeated the full 80-package split. Now branch pushes cancel older runs; tag pushes (release artifacts) never cancel.

The auto-create step calls the existing idempotent `bin/create-split-repos.sh` (~1s when no repos are missing, single batched `gh repo list` call).

## Token scope note

`SPLIT_TOKEN` must be able to create repos under `marko-php`:
- Classic PAT: `repo` scope
- Fine-grained PAT: `Administration: write` + `Contents: write` on the org

If the current token only has push rights, the new step will fail and the token needs to be rotated/broadened.

## Test plan

- [ ] Verify `SPLIT_TOKEN` has repo-creation permission on `marko-php` (or rotate it)
- [ ] Merge PR and confirm Split Packages workflow's `setup` job runs `create-split-repos.sh` successfully (no-op since all current repos exist)
- [ ] Confirm the matrix split still completes for all packages
- [ ] On next package add, confirm the missing repo is auto-created without manual intervention
- [ ] Push twice in rapid succession to a feature merge → confirm the older run is canceled

🤖 Generated with [Claude Code](https://claude.com/claude-code)