### PR TITLE
fix(database): use SchemaRegistry in DiffCommand and MigrateCommand for extender merge

### DIFF
--- a/packages/database/src/Command/DiffCommand.php
+++ b/packages/database/src/Command/DiffCommand.php
@@ -13,10 +13,9 @@ use Marko\Database\Diff\DiffCalculator;
 use Marko\Database\Diff\SchemaDiff;
 use Marko\Database\Diff\TableDiff;
 use Marko\Database\Entity\EntityDiscovery;
-use Marko\Database\Entity\EntityMetadataFactory;
-use Marko\Database\Entity\SchemaBuilder;
 use Marko\Database\Exceptions\EntityException;
 use Marko\Database\Introspection\IntrospectorInterface;
+use Marko\Database\Schema\SchemaRegistry;
 use Marko\Database\Schema\Table;
 
 /** @noinspection PhpUnused */
@@ -26,8 +25,7 @@ readonly class DiffCommand implements CommandInterface
     public function __construct(
         private EntityDiscovery $discovery,
         private IntrospectorInterface $introspector,
-        private EntityMetadataFactory $metadataFactory,
-        private SchemaBuilder $schemaBuilder,
+        private SchemaRegistry $schemaRegistry,
         private DiffCalculator $diffCalculator,
         private ProjectPaths $paths,
     ) {}
@@ -77,15 +75,10 @@ readonly class DiffCommand implements CommandInterface
     private function buildEntitySchema(
         array $entityClasses,
     ): array {
-        $schema = [];
+        $this->schemaRegistry->clear();
+        $this->schemaRegistry->registerEntities($entityClasses);
 
-        foreach ($entityClasses as $entityClass) {
-            $metadata = $this->metadataFactory->parse($entityClass);
-            $table = $this->schemaBuilder->build($metadata);
-            $schema[$table->name] = $table;
-        }
-
-        return $schema;
+        return $this->schemaRegistry->getTables();
     }
 
     /**

--- a/packages/database/src/Command/MigrateCommand.php
+++ b/packages/database/src/Command/MigrateCommand.php
@@ -13,14 +13,13 @@ use Marko\Database\Diff\DiffCalculator;
 use Marko\Database\Diff\SchemaDiff;
 use Marko\Database\Diff\SqlGeneratorInterface;
 use Marko\Database\Entity\EntityDiscovery;
-use Marko\Database\Entity\EntityMetadataFactory;
-use Marko\Database\Entity\SchemaBuilder;
 use Marko\Database\Exceptions\EntityException;
 use Marko\Database\Exceptions\MigrationException;
 use Marko\Database\Introspection\IntrospectorInterface;
 use Marko\Database\Migration\DataMigrator;
 use Marko\Database\Migration\MigrationGenerator;
 use Marko\Database\Migration\Migrator;
+use Marko\Database\Schema\SchemaRegistry;
 use Marko\Database\Schema\Table;
 
 /** @noinspection PhpUnused */
@@ -33,8 +32,7 @@ readonly class MigrateCommand implements CommandInterface
         private MigrationGenerator $migrationGenerator,
         private EntityDiscovery $entityDiscovery,
         private IntrospectorInterface $introspector,
-        private EntityMetadataFactory $metadataFactory,
-        private SchemaBuilder $schemaBuilder,
+        private SchemaRegistry $schemaRegistry,
         private DiffCalculator $diffCalculator,
         private SqlGeneratorInterface $sqlGenerator,
         private ProjectPaths $paths,
@@ -251,15 +249,10 @@ readonly class MigrateCommand implements CommandInterface
     private function buildEntitySchema(
         array $entityClasses,
     ): array {
-        $schema = [];
+        $this->schemaRegistry->clear();
+        $this->schemaRegistry->registerEntities($entityClasses);
 
-        foreach ($entityClasses as $entityClass) {
-            $metadata = $this->metadataFactory->parse($entityClass);
-            $table = $this->schemaBuilder->build($metadata);
-            $schema[$table->name] = $table;
-        }
-
-        return $schema;
+        return $this->schemaRegistry->getTables();
     }
 
     /**

--- a/packages/database/tests/Command/DiffCommandTest.php
+++ b/packages/database/tests/Command/DiffCommandTest.php
@@ -8,11 +8,16 @@ use Marko\Database\Command\DiffCommand;
 use Marko\Database\Diff\DiffCalculator;
 use Marko\Database\Diff\SchemaDiff;
 use Marko\Database\Diff\TableDiff;
+use Marko\Database\Entity\EntityMetadataFactory;
+use Marko\Database\Entity\SchemaBuilder;
 use Marko\Database\Schema\Column;
 use Marko\Database\Schema\Index;
 use Marko\Database\Schema\IndexType;
+use Marko\Database\Schema\SchemaRegistry;
 use Marko\Database\Schema\Table;
 use Marko\Database\Tests\Command\Helpers;
+use Marko\Database\Tests\Entity\Fixtures\ExtenderFactory\BasicExtenderEntity;
+use Marko\Database\Tests\Entity\Fixtures\ExtenderFactory\ExtenderParentEntity;
 
 it('registers as db:diff command via #[Command] attribute', function (): void {
     $reflection = new ReflectionClass(DiffCommand::class);
@@ -348,4 +353,30 @@ it('returns 0 when no changes, 1 when changes exist', function (): void {
     ['exitCode' => $exitCode2] = Helpers::executeDiffCommand($commandWithChanges);
 
     expect($exitCode2)->toBe(1);
+});
+
+it('merges extender columns into parent table schema (regression for #66)', function (): void {
+    // Build the expected merged schema via the real SchemaRegistry so the
+    // introspector stub mirrors exactly what DiffCommand will compute. If
+    // DiffCommand bypasses the extender merge, the entity-side schema will
+    // be missing the extender's `extra` column and DiffCalculator will
+    // report it as a destructive drop.
+    $registry = new SchemaRegistry(
+        new EntityMetadataFactory(),
+        new SchemaBuilder(),
+    );
+    $registry->registerEntities([ExtenderParentEntity::class, BasicExtenderEntity::class]);
+    $mergedTables = $registry->getTables();
+
+    expect($mergedTables['users']->columns)->toHaveCount(2);
+
+    $command = Helpers::createDiffCommand(
+        tables: $mergedTables,
+        entities: [ExtenderParentEntity::class, BasicExtenderEntity::class],
+    );
+
+    ['output' => $output, 'exitCode' => $exitCode] = Helpers::executeDiffCommand($command);
+
+    expect($output)->toContain('No changes detected')
+        ->and($exitCode)->toBe(0);
 });

--- a/packages/database/tests/Command/Helpers.php
+++ b/packages/database/tests/Command/Helpers.php
@@ -14,8 +14,8 @@ use Marko\Database\Diff\DiffCalculator;
 use Marko\Database\Entity\EntityDiscovery;
 use Marko\Database\Entity\EntityMetadataFactory;
 use Marko\Database\Entity\SchemaBuilder;
-use Marko\Database\Schema\SchemaRegistry;
 use Marko\Database\Introspection\IntrospectorInterface;
+use Marko\Database\Schema\SchemaRegistry;
 use Marko\Database\Schema\Table;
 
 /**
@@ -222,13 +222,15 @@ final class Helpers
      * Helper to create a DiffCommand with standard dependencies.
      *
      * @param array<string, Table> $tables Tables for introspector
+     * @param array<class-string>  $entities Entity classes for discovery
      */
     public static function createDiffCommand(
         ?DiffCalculator $diffCalculator = null,
         array $tables = [],
+        array $entities = [],
     ): DiffCommand {
         return new DiffCommand(
-            discovery: self::createStubEntityDiscovery(),
+            discovery: self::createStubEntityDiscovery($entities),
             introspector: self::createStubIntrospector($tables),
             schemaRegistry: new SchemaRegistry(new EntityMetadataFactory(), new SchemaBuilder()),
             diffCalculator: $diffCalculator ?? new DiffCalculator(),

--- a/packages/database/tests/Command/Helpers.php
+++ b/packages/database/tests/Command/Helpers.php
@@ -14,6 +14,7 @@ use Marko\Database\Diff\DiffCalculator;
 use Marko\Database\Entity\EntityDiscovery;
 use Marko\Database\Entity\EntityMetadataFactory;
 use Marko\Database\Entity\SchemaBuilder;
+use Marko\Database\Schema\SchemaRegistry;
 use Marko\Database\Introspection\IntrospectorInterface;
 use Marko\Database\Schema\Table;
 
@@ -229,8 +230,7 @@ final class Helpers
         return new DiffCommand(
             discovery: self::createStubEntityDiscovery(),
             introspector: self::createStubIntrospector($tables),
-            metadataFactory: new EntityMetadataFactory(),
-            schemaBuilder: new SchemaBuilder(),
+            schemaRegistry: new SchemaRegistry(new EntityMetadataFactory(), new SchemaBuilder()),
             diffCalculator: $diffCalculator ?? new DiffCalculator(),
             paths: new ProjectPaths('/test'),
         );

--- a/packages/database/tests/Command/MigrateCommandTest.php
+++ b/packages/database/tests/Command/MigrateCommandTest.php
@@ -12,6 +12,7 @@ use Marko\Database\Diff\SchemaDiff;
 use Marko\Database\Diff\SqlGeneratorInterface;
 use Marko\Database\Entity\EntityMetadataFactory;
 use Marko\Database\Entity\SchemaBuilder;
+use Marko\Database\Schema\SchemaRegistry;
 use Marko\Database\Exceptions\MigrationException;
 use Marko\Database\Migration\DataMigrator;
 use Marko\Database\Migration\MigrationGenerator;
@@ -304,8 +305,7 @@ function createMigrateCommand(
         migrationGenerator: $generator ?? createMigrationGeneratorStub(),
         entityDiscovery: Helpers::createStubEntityDiscovery(),
         introspector: Helpers::createStubIntrospector(),
-        metadataFactory: new EntityMetadataFactory(),
-        schemaBuilder: new SchemaBuilder(),
+        schemaRegistry: new SchemaRegistry(new EntityMetadataFactory(), new SchemaBuilder()),
         diffCalculator: createMigrateDiffCalculator($diff ?? new SchemaDiff()),
         sqlGenerator: $sqlGenerator ?? createMigrateSqlGenerator(),
         paths: new ProjectPaths('/test'),
@@ -684,8 +684,7 @@ it('excludes migrations table from diff calculation', function (): void {
         migrationGenerator: $generator,
         entityDiscovery: Helpers::createStubEntityDiscovery(),
         introspector: $introspector,
-        metadataFactory: new EntityMetadataFactory(),
-        schemaBuilder: new SchemaBuilder(),
+        schemaRegistry: new SchemaRegistry(new EntityMetadataFactory(), new SchemaBuilder()),
         diffCalculator: new DiffCalculator(),
         sqlGenerator: createMigrateSqlGenerator(),
         paths: new ProjectPaths('/test'),

--- a/packages/database/tests/Command/MigrateCommandTest.php
+++ b/packages/database/tests/Command/MigrateCommandTest.php
@@ -12,7 +12,6 @@ use Marko\Database\Diff\SchemaDiff;
 use Marko\Database\Diff\SqlGeneratorInterface;
 use Marko\Database\Entity\EntityMetadataFactory;
 use Marko\Database\Entity\SchemaBuilder;
-use Marko\Database\Schema\SchemaRegistry;
 use Marko\Database\Exceptions\MigrationException;
 use Marko\Database\Migration\DataMigrator;
 use Marko\Database\Migration\MigrationGenerator;
@@ -20,8 +19,11 @@ use Marko\Database\Migration\Migrator;
 use Marko\Database\Schema\Column;
 use Marko\Database\Schema\ForeignKey;
 use Marko\Database\Schema\Index;
+use Marko\Database\Schema\SchemaRegistry;
 use Marko\Database\Schema\Table;
 use Marko\Database\Tests\Command\Helpers;
+use Marko\Database\Tests\Entity\Fixtures\ExtenderFactory\BasicExtenderEntity;
+use Marko\Database\Tests\Entity\Fixtures\ExtenderFactory\ExtenderParentEntity;
 
 /**
  * Create a stub Migrator for testing.
@@ -696,4 +698,54 @@ it('excludes migrations table from diff calculation', function (): void {
     // Should NOT generate a migration to drop migrations table
     expect($output)->toContain('Nothing to migrate')
         ->and($generator->generateCalled)->toBeFalse();
+});
+
+it('merges extender columns into parent table schema before computing diff (regression for #66)', function (): void {
+    // Capture the entitySchema passed to DiffCalculator so we can prove the
+    // extender's `extra` column was merged into the parent `users` table
+    // before the diff was computed. Pre-fix the command bypassed
+    // SchemaRegistry's extender merge and the extender column would be
+    // absent from $entitySchema['users'].
+    /** @var array<string, Table>|null $captured */
+    $captured = null;
+
+    $capturingCalculator = new class ($captured) extends DiffCalculator
+    {
+        public function __construct(
+            /** @noinspection PhpPropertyOnlyWrittenInspection - Reference property captures schema for assertion */
+            private ?array &$captured,
+        ) {}
+
+        public function calculate(
+            array $entitySchema,
+            array $databaseSchema,
+        ): SchemaDiff {
+            $this->captured = $entitySchema;
+
+            return new SchemaDiff();
+        }
+    };
+
+    $command = new MigrateCommand(
+        migrator: createMigratorStub(),
+        dataMigrator: createDataMigratorStub(),
+        migrationGenerator: createMigrationGeneratorStub(),
+        entityDiscovery: Helpers::createStubEntityDiscovery([ExtenderParentEntity::class, BasicExtenderEntity::class]),
+        introspector: Helpers::createStubIntrospector(),
+        schemaRegistry: new SchemaRegistry(new EntityMetadataFactory(), new SchemaBuilder()),
+        diffCalculator: $capturingCalculator,
+        sqlGenerator: createMigrateSqlGenerator(),
+        paths: new ProjectPaths('/test'),
+        isProduction: false,
+    );
+
+    executeMigrateCommand($command);
+
+    expect($captured)->toHaveKey('users')
+        ->and($captured['users']->columns)->toHaveCount(2);
+
+    $columnNames = array_map(fn (Column $c): string => $c->name, $captured['users']->columns);
+
+    expect($columnNames)->toContain('id')
+        ->and($columnNames)->toContain('extra');
 });


### PR DESCRIPTION
## Summary

- `DiffCommand` and `MigrateCommand` used a single-pass loop (`metadataFactory->parse` + `schemaBuilder->build` per entity) to build the entity schema, bypassing the two-pass extender merge in `SchemaRegistry::registerEntities()`
- Replaced the loop with `SchemaRegistry::registerEntities()` in both commands
- Removed the now-unused `EntityMetadataFactory` and `SchemaBuilder` constructor dependencies; updated test helpers accordingly

Closes #66

## Steps to reproduce (before fix)

1. Define a parent entity with `#[Table(name: 'products')]`
2. Define an extender entity with `#[Table(extends: Product::class)]` that adds a column
3. Run `db:migrate` — extender column is never added to the table
4. If the column already exists in the DB, run `db:diff` — reports `[DESTRUCTIVE] Drop column`

## Expected behavior

- `db:migrate` generates and applies an `ADD COLUMN` migration for the extender column
- `db:diff` reports no changes once the column exists in the database

## Test plan

- [ ] Run `pest tests/Command/DiffCommandTest.php` — all green
- [ ] Run `pest tests/Command/MigrateCommandTest.php` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)