### PR TITLE
fix(database-pgsql): normalise jsonb → json in introspector type map

### DIFF
--- a/packages/database-pgsql/src/Introspection/PgSqlIntrospector.php
+++ b/packages/database-pgsql/src/Introspection/PgSqlIntrospector.php
@@ -51,7 +51,7 @@ readonly class PgSqlIntrospector implements IntrospectorInterface
         'double precision' => 'double',
         'float8' => 'double',
         'json' => 'json',
-        'jsonb' => 'jsonb',
+        'jsonb' => 'json',
         'uuid' => 'uuid',
         'bytea' => 'blob',
     ];

--- a/packages/database-pgsql/tests/Introspection/PgSqlIntrospectorTest.php
+++ b/packages/database-pgsql/tests/Introspection/PgSqlIntrospectorTest.php
@@ -6,6 +6,7 @@ namespace Marko\Database\PgSql\Tests\Introspection;
 
 use Marko\Database\Connection\ConnectionInterface;
 use Marko\Database\Connection\StatementInterface;
+use Marko\Database\Diff\DiffCalculator;
 use Marko\Database\Introspection\IntrospectorInterface;
 use Marko\Database\PgSql\Introspection\PgSqlIntrospector;
 use Marko\Database\Schema\Column;
@@ -152,11 +153,55 @@ describe('PgSqlIntrospector', function (): void {
             ->and($columns[11]->type)->toBe('date')
             ->and($columns[12]->type)->toBe('time')
             ->and($columns[13]->type)->toBe('json')
-            ->and($columns[14]->type)->toBe('jsonb')
+            ->and($columns[14]->type)->toBe('json')
             ->and($columns[15]->type)->toBe('uuid')
             ->and($columns[16]->type)->toBe('char')
             ->and($columns[16]->length)->toBe(10)
             ->and($columns[17]->type)->toBe('blob');
+    });
+
+    it('normalises jsonb to json so introspected columns match entity-declared type', function (): void {
+        $connection = createTestConnection(function (string $sql): array {
+            if (str_contains($sql, 'information_schema.columns')) {
+                return [
+                    ['column_name' => 'data', 'data_type' => 'jsonb', 'character_maximum_length' => null, 'is_nullable' => 'NO', 'column_default' => null, 'is_identity' => 'NO', 'identity_generation' => null],
+                ];
+            }
+
+            return [];
+        });
+
+        $introspector = new PgSqlIntrospector($connection);
+        $columns = $introspector->getColumns('products');
+
+        expect($columns[0]->type)->toBe('json');
+    });
+
+    it('produces no diff when entity declares json and database stores jsonb', function (): void {
+        $entitySchema = [
+            'products' => new Table(
+                name: 'products',
+                columns: [new Column(name: 'data', type: 'json')],
+                indexes: [],
+            ),
+        ];
+
+        $connection = createTestConnection(function (string $sql): array {
+            if (str_contains($sql, 'information_schema.columns')) {
+                return [
+                    ['column_name' => 'data', 'data_type' => 'jsonb', 'character_maximum_length' => null, 'is_nullable' => 'NO', 'column_default' => null, 'is_identity' => 'NO', 'identity_generation' => null],
+                ];
+            }
+
+            return [];
+        });
+
+        $introspector = new PgSqlIntrospector($connection);
+        $databaseSchema = ['products' => $introspector->getTable('products')];
+
+        $diff = (new DiffCalculator())->calculate($entitySchema, $databaseSchema);
+
+        expect($diff->isEmpty())->toBeTrue();
     });
 
     it('detects nullable columns', function (): void {


### PR DESCRIPTION
## Summary

- `PgSqlGenerator` maps entity type `json` → `JSONB` in DDL (correct — JSONB is preferred in PostgreSQL)
- `PgSqlIntrospector` read the column back as `jsonb`, while the entity schema held `json`
- No alias existed in `Column::typeEquals()` for this pair, so the diff calculator reported a spurious `Modify` on every `json` column indefinitely
- Fixed by mapping `'jsonb' => 'json'` in `PgSqlIntrospector::TYPE_MAP`, normalising the round-trip at the driver level

Closes #68

## Steps to reproduce (before fix)

1. Define an entity with `#[Column(type: 'json')]`
2. Run `db:migrate` — column is created as `JSONB` in PostgreSQL
3. Run `db:diff` — reports `Modify column` despite no changes

## Expected behavior

`db:diff` reports no changes after the column has been created.

## Test plan

- [ ] `it normalises jsonb to json so introspected columns match entity-declared type`
- [ ] `it produces no diff when entity declares json and database stores jsonb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)