### PR TITLE
fix(database-pgsql): JSON-encode array bindings before passing to PDO

### DIFF
--- a/packages/database-pgsql/src/Connection/PgSqlConnection.php
+++ b/packages/database-pgsql/src/Connection/PgSqlConnection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Marko\Database\PgSql\Connection;
 
+use JsonException;
 use Marko\Database\Config\DatabaseConfig;
 use Marko\Database\Connection\ConnectionInterface;
 use Marko\Database\Connection\StatementInterface;
@@ -180,6 +181,8 @@ class PgSqlConnection implements ConnectionInterface, TransactionInterface
 
     /**
      * @param array<int|string, mixed> $bindings
+     *
+     * @throws ConnectionException
      */
     private function bindValues(
         PDOStatement $statement,
@@ -189,7 +192,14 @@ class PgSqlConnection implements ConnectionInterface, TransactionInterface
             $param = is_int($key) ? $key + 1 : $key;
 
             if (is_array($value)) {
-                $statement->bindValue($param, json_encode($value), PDO::PARAM_STR);
+                try {
+                    $encoded = json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+                } catch (JsonException $e) {
+                    throw ConnectionException::invalidArrayBinding($param, $e);
+                }
+
+                $statement->bindValue($param, $encoded, PDO::PARAM_STR);
+
                 continue;
             }
 

--- a/packages/database-pgsql/src/Connection/PgSqlConnection.php
+++ b/packages/database-pgsql/src/Connection/PgSqlConnection.php
@@ -187,6 +187,12 @@ class PgSqlConnection implements ConnectionInterface, TransactionInterface
     ): void {
         foreach ($bindings as $key => $value) {
             $param = is_int($key) ? $key + 1 : $key;
+
+            if (is_array($value)) {
+                $statement->bindValue($param, json_encode($value), PDO::PARAM_STR);
+                continue;
+            }
+
             $type = match (true) {
                 is_bool($value) => PDO::PARAM_BOOL,
                 is_null($value) => PDO::PARAM_NULL,

--- a/packages/database-pgsql/src/Exceptions/ConnectionException.php
+++ b/packages/database-pgsql/src/Exceptions/ConnectionException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Marko\Database\PgSql\Exceptions;
 
+use JsonException;
 use Marko\Core\Exceptions\MarkoException;
 use PDOException;
 
@@ -22,6 +23,18 @@ class ConnectionException extends MarkoException
             message: "Failed to connect to PostgreSQL database '$database' on $host:$port",
             context: $previous->getMessage(),
             suggestion: 'Verify the database server is running, credentials are correct, and the database exists',
+            previous: $previous,
+        );
+    }
+
+    public static function invalidArrayBinding(
+        int|string $parameter,
+        JsonException $previous,
+    ): self {
+        return new self(
+            message: "Failed to JSON-encode array bound to parameter '$parameter'",
+            context: $previous->getMessage(),
+            suggestion: 'Ensure array values are JSON-encodable (no resources, recursive references, NAN, or INF)',
             previous: $previous,
         );
     }

--- a/packages/database-pgsql/tests/Connection/PgSqlConnectionTest.php
+++ b/packages/database-pgsql/tests/Connection/PgSqlConnectionTest.php
@@ -714,4 +714,27 @@ describe('PgSqlConnection', function (): void {
             ->toBe('{"key":"value","nested":[1,2,3]}')
             ->not->toBe('Array');
     });
+
+    it('throws ConnectionException when an array binding is not JSON-encodable', function (): void {
+        $config = createTestPgSqlConfig();
+        $connection = new class ($config) extends PgSqlConnection
+        {
+            protected function createPdo(
+                string $dsn,
+                string $username,
+                string $password,
+                array $options,
+            ): PDO {
+                $pdo = createSqliteMockPdo($options);
+                $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, metadata TEXT)');
+
+                return $pdo;
+            }
+        };
+
+        expect(fn () => $connection->execute(
+            'INSERT INTO items (metadata) VALUES (?)',
+            [[NAN]],
+        ))->toThrow(ConnectionException::class, "Failed to JSON-encode array bound to parameter '1'");
+    });
 });

--- a/packages/database-pgsql/tests/Connection/PgSqlConnectionTest.php
+++ b/packages/database-pgsql/tests/Connection/PgSqlConnectionTest.php
@@ -685,4 +685,33 @@ describe('PgSqlConnection', function (): void {
         expect(fn () => $connection->beginTransaction())
             ->toThrow(TransactionException::class, 'Nested transactions are not supported');
     });
+
+    it('JSON-encodes array bindings instead of casting them to the string "Array"', function (): void {
+        $config = createTestPgSqlConfig();
+        $connection = new class ($config) extends PgSqlConnection
+        {
+            protected function createPdo(
+                string $dsn,
+                string $username,
+                string $password,
+                array $options,
+            ): PDO {
+                $pdo = createSqliteMockPdo($options);
+                $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, metadata TEXT)');
+
+                return $pdo;
+            }
+        };
+
+        $connection->execute(
+            'INSERT INTO items (metadata) VALUES (?)',
+            [['key' => 'value', 'nested' => [1, 2, 3]]],
+        );
+
+        $rows = $connection->query('SELECT metadata FROM items');
+
+        expect($rows[0]['metadata'])
+            ->toBe('{"key":"value","nested":[1,2,3]}')
+            ->not->toBe('Array');
+    });
 });


### PR DESCRIPTION
Fixes #71

## Summary

- Detect array values in `PgSqlConnection::bindValues()` and call `json_encode()` before binding, so `json`/`jsonb` columns receive a valid JSON string instead of the literal `"Array"`
- Add a regression test covering the array binding path

## Test plan

- [ ] `./vendor/bin/pest packages/database-pgsql/tests/Connection/PgSqlConnectionTest.php` — all 29 tests pass including the new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)