### PR TITLE
fix(database): link entity extenders at boot so companions hydrate during HTTP requests

### DIFF
--- a/packages/database/module.php
+++ b/packages/database/module.php
@@ -5,11 +5,28 @@ declare(strict_types=1);
 use Marko\Core\Container\ContainerInterface;
 use Marko\Core\Path\ProjectPaths;
 use Marko\Database\Connection\TransactionInterface;
+use Marko\Database\Entity\EntityDiscovery;
+use Marko\Database\Entity\EntityMetadataFactory;
 use Marko\Database\Seed\SeederDiscovery;
 use Marko\Database\Seed\SeederDiscoveryInterface;
 use Marko\Database\Seed\SeederRunner;
 
 return [
+    'singletons' => [
+        EntityMetadataFactory::class,
+    ],
+    'boot' => function (
+        EntityDiscovery $discovery,
+        EntityMetadataFactory $metadataFactory,
+        ProjectPaths $paths,
+    ): void {
+        $entityClasses = array_merge(
+            $discovery->discoverInVendor($paths->vendor),
+            $discovery->discoverInModules($paths->modules),
+            $discovery->discoverInApp($paths->app),
+        );
+        $metadataFactory->linkExtendersFrom($entityClasses);
+    },
     'bindings' => [
         SeederDiscoveryInterface::class => SeederDiscovery::class,
         SeederRunner::class => function (ContainerInterface $container): SeederRunner {

--- a/packages/database/src/Entity/EntityMetadataFactory.php
+++ b/packages/database/src/Entity/EntityMetadataFactory.php
@@ -216,6 +216,33 @@ class EntityMetadataFactory
     }
 
     /**
+     * Scan a list of entity classes and link any extenders to their parent metadata.
+     *
+     * @param array<class-string> $entityClasses
+     */
+    public function linkExtendersFrom(array $entityClasses): void
+    {
+        $extenders = [];
+        foreach ($entityClasses as $entityClass) {
+            $reflection = new ReflectionClass($entityClass);
+            $tableAttrs = $reflection->getAttributes(Table::class);
+            if (count($tableAttrs) === 0) {
+                continue;
+            }
+            $tableAttr = $tableAttrs[0]->newInstance();
+            if ($tableAttr->extends !== null) {
+                $extenders[$tableAttr->extends][] = $entityClass;
+            }
+        }
+        foreach ($extenders as $parentClass => $extenderClasses) {
+            if (!class_exists($parentClass, true)) {
+                throw EntityException::extenderParentClassNotFound($extenderClasses[0], $parentClass);
+            }
+            $this->linkExtenders($parentClass, $extenderClasses);
+        }
+    }
+
+    /**
      * Clear the metadata cache.
      */
     public function clearCache(): void

--- a/packages/database/src/Entity/EntityMetadataFactory.php
+++ b/packages/database/src/Entity/EntityMetadataFactory.php
@@ -15,6 +15,7 @@ use Marko\Database\Attributes\Table;
 use Marko\Database\Exceptions\EntityException;
 use Marko\Database\Exceptions\MissingPrimaryKeyException;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionNamedType;
 use ReflectionProperty;
 
@@ -219,25 +220,34 @@ class EntityMetadataFactory
      * Scan a list of entity classes and link any extenders to their parent metadata.
      *
      * @param array<class-string> $entityClasses
+     *
+     * @throws EntityException|MissingPrimaryKeyException|ReflectionException
      */
-    public function linkExtendersFrom(array $entityClasses): void
-    {
+    public function linkExtendersFrom(
+        array $entityClasses,
+    ): void {
         $extenders = [];
+
         foreach ($entityClasses as $entityClass) {
             $reflection = new ReflectionClass($entityClass);
             $tableAttrs = $reflection->getAttributes(Table::class);
-            if (count($tableAttrs) === 0) {
+
+            if ($tableAttrs === []) {
                 continue;
             }
+
             $tableAttr = $tableAttrs[0]->newInstance();
+
             if ($tableAttr->extends !== null) {
                 $extenders[$tableAttr->extends][] = $entityClass;
             }
         }
+
         foreach ($extenders as $parentClass => $extenderClasses) {
             if (!class_exists($parentClass, true)) {
                 throw EntityException::extenderParentClassNotFound($extenderClasses[0], $parentClass);
             }
+
             $this->linkExtenders($parentClass, $extenderClasses);
         }
     }

--- a/packages/database/tests/Entity/EntityMetadataFactoryTest.php
+++ b/packages/database/tests/Entity/EntityMetadataFactoryTest.php
@@ -531,6 +531,30 @@ it('produces a chained-extension error message that names both the extender and 
         ->toThrow(EntityException::class, "Chained extension is not supported. $extender's parent $parent is itself an extender. Extend the root entity directly.");
 });
 
+it('linkExtendersFrom scans entity classes and links extenders to their parents', function (): void {
+    $this->factory->linkExtendersFrom([
+        ExtenderParentEntity::class,
+        BasicExtenderEntity::class,
+    ]);
+
+    $parentMetadata = $this->factory->parse(ExtenderParentEntity::class);
+
+    expect($parentMetadata->extenders)->toBe([BasicExtenderEntity::class]);
+});
+
+it('linkExtendersFrom ignores entities without extends', function (): void {
+    $this->factory->linkExtendersFrom([ExtenderParentEntity::class]);
+
+    $parentMetadata = $this->factory->parse(ExtenderParentEntity::class);
+
+    expect($parentMetadata->extenders)->toBe([]);
+});
+
+it('linkExtendersFrom throws when an extender references a parent class that cannot be autoloaded', function (): void {
+    expect(fn () => $this->factory->linkExtendersFrom([ExtenderWithMissingParentEntity::class]))
+        ->toThrow(EntityException::class, 'does not exist');
+});
+
 it('clears cached metadata', function (): void {
     $entity = new #[Table('test')] class () extends Entity
     {

--- a/packages/database/tests/Entity/EntityMetadataFactoryTest.php
+++ b/packages/database/tests/Entity/EntityMetadataFactoryTest.php
@@ -403,18 +403,21 @@ it('converts camelCase property names to snake_case column names automatically',
         ->and($metadata->columns[3]->name)->toBe('is_active');
 });
 
-it('throws MissingPrimaryKeyException at metadata parse time when entity has no primary key attribute', function (): void {
-    $entity = new #[Table('no_pk')] class () extends Entity
-    {
-        #[Column]
-        public int $userId;
+it(
+    'throws MissingPrimaryKeyException at metadata parse time when entity has no primary key attribute',
+    function (): void {
+        $entity = new #[Table('no_pk')] class () extends Entity
+        {
+            #[Column]
+            public int $userId;
 
-        #[Column]
-        public string $name;
-    };
+            #[Column]
+            public string $name;
+        };
 
-    $this->factory->parse($entity::class);
-})->throws(MissingPrimaryKeyException::class);
+        $this->factory->parse($entity::class);
+    },
+)->throws(MissingPrimaryKeyException::class);
 
 it('includes the entity class name in the exception message', function (): void {
     $entity = new #[Table('no_pk')] class () extends Entity
@@ -523,13 +526,19 @@ it('linkExtenders returns metadata where isExtended is true', function (): void 
     expect($result->isExtended())->toBeTrue();
 });
 
-it('produces a chained-extension error message that names both the extender and its extender-parent and tells the user to extend the root', function (): void {
-    $extender = ChainedExtenderEntity::class;
-    $parent = BasicExtenderEntity::class;
+it(
+    'produces a chained-extension error message that names both the extender and its extender-parent and tells the user to extend the root',
+    function (): void {
+        $extender = ChainedExtenderEntity::class;
+        $parent = BasicExtenderEntity::class;
 
-    expect(fn () => $this->factory->parse($extender))
-        ->toThrow(EntityException::class, "Chained extension is not supported. $extender's parent $parent is itself an extender. Extend the root entity directly.");
-});
+        expect(fn () => $this->factory->parse($extender))
+            ->toThrow(
+                EntityException::class,
+                "Chained extension is not supported. $extender's parent $parent is itself an extender. Extend the root entity directly.",
+            );
+    },
+);
 
 it('linkExtendersFrom scans entity classes and links extenders to their parents', function (): void {
     $this->factory->linkExtendersFrom([


### PR DESCRIPTION
## Summary

- `EntityMetadataFactory` was not registered as a singleton — every resolution created a fresh instance with an empty cache
- `linkExtenders()` was only called from `SchemaRegistry::registerEntities()`, which is invoked exclusively by CLI migration commands (`DiffCommand`, `MigrateCommand`)
- During HTTP requests, `$metadata->extenders` was always `[]`, so `EntityHydrator` never attached companion entities

## Fix

- Register `EntityMetadataFactory` as a singleton in `module.php`
- Add a `boot` callback that discovers all entity classes across vendor, modules, and app, then calls `linkExtendersFrom()` to populate the extender map once at startup
- `linkExtendersFrom()` throws a loud `EntityException` if an extender references a parent class that cannot be autoloaded, rather than silently ignoring the misconfiguration

## Test plan

- [ ] `linkExtendersFrom` scans entity classes and links extenders to their parents
- [ ] `linkExtendersFrom` ignores entities without `extends`
- [ ] `linkExtendersFrom` throws `EntityException` when an extender's parent class cannot be autoloaded
- [ ] Full test suite passes: `composer test`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)