### PR TITLE
fix(database-mysql): JSON-encode array bindings before passing to PDO

### DIFF
--- a/packages/database-mysql/src/Connection/MySqlConnection.php
+++ b/packages/database-mysql/src/Connection/MySqlConnection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Marko\Database\MySql\Connection;
 
+use JsonException;
 use Marko\Database\Config\DatabaseConfig;
 use Marko\Database\Connection\ConnectionInterface;
 use Marko\Database\Connection\StatementInterface;
@@ -125,7 +126,7 @@ class MySqlConnection implements ConnectionInterface, TransactionInterface
         $this->ensureConnected();
 
         $statement = $this->pdo->prepare($sql);
-        $statement->execute($bindings);
+        $statement->execute($this->prepareBindings($bindings));
 
         return $statement->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -140,9 +141,36 @@ class MySqlConnection implements ConnectionInterface, TransactionInterface
         $this->ensureConnected();
 
         $statement = $this->pdo->prepare($sql);
-        $statement->execute($bindings);
+        $statement->execute($this->prepareBindings($bindings));
 
         return $statement->rowCount();
+    }
+
+    /**
+     * JSON-encode any array values so PDO does not silently cast them to the literal string "Array".
+     *
+     * @param array<int|string, mixed> $bindings
+     *
+     * @return array<int|string, mixed>
+     *
+     * @throws ConnectionException
+     */
+    private function prepareBindings(
+        array $bindings,
+    ): array {
+        foreach ($bindings as $key => $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+
+            try {
+                $bindings[$key] = json_encode($value, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+            } catch (JsonException $e) {
+                throw ConnectionException::invalidArrayBinding($key, $e);
+            }
+        }
+
+        return $bindings;
     }
 
     /**

--- a/packages/database-mysql/src/Exceptions/ConnectionException.php
+++ b/packages/database-mysql/src/Exceptions/ConnectionException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Marko\Database\MySql\Exceptions;
 
+use JsonException;
 use Marko\Core\Exceptions\MarkoException;
 use PDOException;
 
@@ -19,6 +20,18 @@ class ConnectionException extends MarkoException
             message: "Failed to connect to MySQL database '$database' at $host:$port",
             context: "While establishing database connection: {$previous->getMessage()}",
             suggestion: 'Verify MySQL is running and credentials are correct. Check host, port, database name, username, and password.',
+            previous: $previous,
+        );
+    }
+
+    public static function invalidArrayBinding(
+        int|string $parameter,
+        JsonException $previous,
+    ): self {
+        return new self(
+            message: "Failed to JSON-encode array bound to parameter '$parameter'",
+            context: $previous->getMessage(),
+            suggestion: 'Ensure array values are JSON-encodable (no resources, recursive references, NAN, or INF)',
             previous: $previous,
         );
     }

--- a/packages/database-mysql/tests/Connection/MySqlConnectionTest.php
+++ b/packages/database-mysql/tests/Connection/MySqlConnectionTest.php
@@ -667,4 +667,56 @@ describe('MySqlConnection', function (): void {
         expect(fn () => $connection->beginTransaction())
             ->toThrow(TransactionException::class, 'Nested transactions are not supported');
     });
+
+    it('JSON-encodes array bindings instead of casting them to the string "Array"', function (): void {
+        $config = createTestDatabaseConfig();
+        $connection = new class ($config) extends MySqlConnection
+        {
+            protected function createPdo(
+                string $dsn,
+                string $username,
+                string $password,
+                array $options,
+            ): PDO {
+                $pdo = new PDO('sqlite::memory:', options: $options);
+                $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, metadata TEXT)');
+
+                return $pdo;
+            }
+        };
+
+        $connection->execute(
+            'INSERT INTO items (metadata) VALUES (?)',
+            [['key' => 'value', 'nested' => [1, 2, 3]]],
+        );
+
+        $rows = $connection->query('SELECT metadata FROM items');
+
+        expect($rows[0]['metadata'])
+            ->toBe('{"key":"value","nested":[1,2,3]}')
+            ->not->toBe('Array');
+    });
+
+    it('throws ConnectionException when an array binding is not JSON-encodable', function (): void {
+        $config = createTestDatabaseConfig();
+        $connection = new class ($config) extends MySqlConnection
+        {
+            protected function createPdo(
+                string $dsn,
+                string $username,
+                string $password,
+                array $options,
+            ): PDO {
+                $pdo = new PDO('sqlite::memory:', options: $options);
+                $pdo->exec('CREATE TABLE items (id INTEGER PRIMARY KEY, metadata TEXT)');
+
+                return $pdo;
+            }
+        };
+
+        expect(fn () => $connection->execute(
+            'INSERT INTO items (metadata) VALUES (?)',
+            [[NAN]],
+        ))->toThrow(ConnectionException::class, "Failed to JSON-encode array bound to parameter '0'");
+    });
 });


### PR DESCRIPTION
Closes #81

## Summary

PDO silently casts PHP arrays to the string `"Array"` when bound as query parameters. For JSON-typed columns this either fails the JSON parse or stores the literal string `"Array"` depending on column type and SQL mode — the same root cause as #71 / #72, but in the MySQL driver.

## Fix

Mirrors the `database-pgsql` approach:

- Added `prepareBindings()` helper to `MySqlConnection` that walks the bindings array and JSON-encodes any array values with `JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE`.
- `JsonException` is caught and converted to a domain `ConnectionException::invalidArrayBinding($parameter, $previous)` with a clear message identifying the offending parameter.
- `MySqlConnection::query()` and `MySqlConnection::execute()` now route through `prepareBindings()` before calling `$statement->execute()`.

## Tests

- `it JSON-encodes array bindings instead of casting them to the string "Array"` — happy path, end-to-end via an SQLite-backed `MySqlConnection`.
- `it throws ConnectionException when an array binding is not JSON-encodable` — failure path using `NAN` as an array value.

Full suite green: 5147 passing.

## Test plan

- [x] `./vendor/bin/pest packages/database-mysql/tests/ --parallel`
- [x] `./vendor/bin/phpcs` clean on touched files
- [x] `./vendor/bin/php-cs-fixer fix --dry-run` clean on touched files
- [x] `composer test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)