### PR TITLE
fix: point split workflow at MARKO_BUILD_PAT secret

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Create missing split repos
         env:
-          GH_TOKEN: ${{ secrets.SPLIT_TOKEN }}
+          GH_TOKEN: ${{ secrets.MARKO_BUILD_PAT }}
         run: ./bin/create-split-repos.sh
       - name: List packages
         id: list
@@ -54,9 +54,9 @@ jobs:
 
       - name: Split and push
         env:
-          SPLIT_TOKEN: ${{ secrets.SPLIT_TOKEN }}
+          MARKO_BUILD_PAT: ${{ secrets.MARKO_BUILD_PAT }}
         run: |
-          REPO="https://x-access-token:${SPLIT_TOKEN}@github.com/${SPLIT_ORG}/marko-${{ matrix.package }}.git"
+          REPO="https://x-access-token:${MARKO_BUILD_PAT}@github.com/${SPLIT_ORG}/marko-${{ matrix.package }}.git"
           SHA=$(splitsh-lite --prefix="packages/${{ matrix.package }}")
 
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then


### PR DESCRIPTION
## Summary
- The `Split Packages` workflow referenced `secrets.SPLIT_TOKEN`, which no longer exists in the repo.
- The current PAT is stored as `MARKO_BUILD_PAT`, so `GH_TOKEN` resolved to empty and `gh auth status` failed the `Create missing split repos` step.
- Updates both references plus the internal env var name for consistency.

## Test plan
- [ ] Re-run the `Split Packages` workflow on `develop` and confirm `Create missing split repos` passes.
- [ ] Confirm the `Split and push` matrix jobs still authenticate against the split repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)