### PR TITLE
feat: add Twig template engine driver as sibling to Latte

### DIFF
--- a/.claude/plans/view-twig/001-refactor-view-remove-extension-default.md
+++ b/.claude/plans/view-twig/001-refactor-view-remove-extension-default.md
@@ -1,0 +1,49 @@
+# Task 001: Refactor marko/view — remove extension and strict_types defaults from config
+
+**Status**: pending
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+The shared `marko/view` interface package currently hardcodes `extension => '.latte'` and `strict_types => true` in its `config/view.php`. Both are driver-specific (extension is Latte-flavored; strict_types is a Latte-only feature flag) and bias the interface package toward Latte, violating Marko's interface/driver separation.
+
+Remove both keys from `marko/view`'s config so it ships only truly driver-neutral defaults (`cache_directory`, `auto_refresh`). Each driver package will ship its own defaults via its own config file (task 002 for view-latte; task 008 for view-twig).
+
+Additionally remove the `strictTypes()` accessor from `ViewConfig` entirely — it is Latte-specific and does not belong in the shared interface package. Task 002 introduces a new `LatteViewConfig` class in view-latte to host this Latte-only accessor.
+
+The `extension()` accessor on `ViewConfig` MUST stay, because `ModuleTemplateResolver` (in `marko/view`) calls it during path resolution. The accessor remains; only the default value moves to driver packages. With no driver installed, calling `extension()` will throw `ConfigNotFoundException` — which is the correct loud-error behavior.
+
+## Context
+- Related files:
+  - `packages/view/config/view.php` (remove `extension` and `strict_types` keys; keep `cache_directory` and `auto_refresh`)
+  - `packages/view/src/ViewConfig.php` (remove `strictTypes()` method; keep `extension()`, `cacheDirectory()`, `autoRefresh()`)
+  - `packages/view/tests/ViewConfigTest.php` (update — see Tests To Update below)
+- The `extension()` method on `ViewConfig` must keep working because `ModuleTemplateResolver` calls it. The accessor stays; only the default value moves to driver packages.
+- App-level config still wins via Marko's override priority (vendor < modules < app).
+
+## Tests To Update
+The current `ViewConfigTest.php` has the following assertions that will break and must be updated:
+- The `createDefaultViewConfigRepository()` helper currently seeds `view.extension => '.latte'` and `view.strict_types => true` — remove those from the helper's defaults.
+- `it('ViewConfig has strict types property', ...)` — delete this test entirely (accessor is being removed).
+- `it('ViewConfig loads all properties from config repository', ...)` — drop the `strictTypes()` assertion.
+- `it('ViewConfig uses default config values', ...)` — drop the `.latte` extension expectation and the `strictTypes()` assertion. This test should now only assert the two remaining shared defaults (`cache_directory`, `auto_refresh`).
+- `it('uses FakeConfigRepository in ViewConfigTest', ...)` — drop `view.extension` and `view.strict_types` from the seed array.
+
+## Requirements (Test Descriptions)
+- [ ] `it does not include an extension default in the shipped view config`
+- [ ] `it does not include a strict_types default in the shipped view config`
+- [ ] `it keeps cache_directory as a shipped default`
+- [ ] `it keeps auto_refresh as a shipped default`
+- [ ] `ViewConfig::extension() throws ConfigNotFoundException when no driver has set view.extension`
+- [ ] `ViewConfig::extension() returns the value when a driver config sets view.extension`
+- [ ] `ViewConfig no longer exposes a strictTypes() accessor`
+
+## Acceptance Criteria
+- `packages/view/config/view.php` contains exactly two keys: `cache_directory` and `auto_refresh`
+- `ViewConfig::extension()` still exists and reads from `view.extension` — no signature change
+- `ViewConfig::strictTypes()` no longer exists
+- All existing `marko/view` tests still pass (per the Tests To Update list above)
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/002-refactor-view-latte-ship-own-config.md
+++ b/.claude/plans/view-twig/002-refactor-view-latte-ship-own-config.md
@@ -1,0 +1,55 @@
+# Task 002: Refactor marko/view-latte — ship own config + LatteViewConfig + conflict declaration
+
+**Status**: pending
+**Depends on**: 001
+**Retry count**: 0
+
+## Description
+After task 001 removes the `extension` default (and the `strictTypes()` accessor) from `marko/view`, view-latte must:
+
+1. **Ship its own `config/view.php`** so existing apps continue to work with no behavior change. This file contributes Latte-specific keys to the `view.*` config namespace.
+2. **Introduce a new `LatteViewConfig` readonly class** that mirrors the pattern of `TwigViewConfig` (task 004). This class hosts the Latte-only `strictTypes()` accessor that was removed from shared `ViewConfig` in task 001. This is the architectural symmetry the plan requires: every driver hosts its driver-specific config accessors in its own package.
+3. **Refactor `LatteEngineFactory`** to accept `LatteViewConfig` (for `strictTypes()`) alongside the shared `ViewConfig` (for `cacheDirectory()` and `autoRefresh()`). Update the constructor and `create()` method accordingly.
+4. **Add a Composer `conflict` declaration** so view-latte and view-twig cannot be installed simultaneously — enforcing mutual exclusion at install time rather than runtime.
+
+## Context
+- Related files:
+  - `packages/view-latte/config/view.php` (new file — does not currently exist; view-latte has no `config/` directory)
+  - `packages/view-latte/src/LatteViewConfig.php` (new — readonly class with `strictTypes(): bool` accessor)
+  - `packages/view-latte/src/LatteEngineFactory.php` (modify constructor to take `LatteViewConfig`; replace `$viewConfig->strictTypes()` with `$latteViewConfig->strictTypes()`)
+  - `packages/view-latte/composer.json` (add `conflict` block)
+  - `packages/view-latte/tests/LatteEngineFactoryTest.php` (update mocks: add LatteViewConfig mock alongside ViewConfig mock)
+  - `packages/view-latte/tests/LatteViewConfigTest.php` (new — verifies the typed accessor)
+  - `packages/view-latte/tests/ViewConfigDefaultsTest.php` (new — verifies the shipped config/view.php has expected keys)
+- The new `config/view.php` keys:
+  - `extension => '.latte'`
+  - `strict_types => true`
+  - (Do NOT duplicate `cache_directory` or `auto_refresh` here — those live in `marko/view`'s shared config since they're driver-neutral.)
+- `LatteViewConfig` follows the same pattern as `ViewConfig`: readonly class, constructor takes `ConfigRepositoryInterface`, accessor uses `getBool('view.strict_types')` — no PHP-level defaults.
+- The `conflict` value should be `*` (any version) to prevent mixing regardless of versions.
+- The container will autowire `LatteViewConfig` (single `ConfigRepositoryInterface` constructor dep). No explicit binding needed in `module.php`.
+
+## Requirements (Test Descriptions)
+- [ ] `it ships a config/view.php file in the view-latte package`
+- [ ] `it sets extension to .latte by default`
+- [ ] `it sets strict_types to true by default`
+- [ ] `it does not redeclare cache_directory (lives in marko/view shared config)`
+- [ ] `it does not redeclare auto_refresh (lives in marko/view shared config)`
+- [ ] `it declares a Composer conflict with marko/view-twig in composer.json`
+- [ ] `LatteViewConfig::strictTypes() returns the configured bool value`
+- [ ] `LatteViewConfig::strictTypes() throws ConfigNotFoundException when view.strict_types is missing`
+- [ ] `LatteEngineFactory takes both ViewConfig and LatteViewConfig in its constructor`
+- [ ] `LatteEngineFactory sets Latte strict types from LatteViewConfig`
+- [ ] `LatteEngineFactory continues to set cache directory and auto refresh from ViewConfig`
+
+## Acceptance Criteria
+- `packages/view-latte/config/view.php` exists and contains exactly `extension` and `strict_types` keys
+- `packages/view-latte/src/LatteViewConfig.php` exists as a readonly class with `strictTypes(): bool`
+- `packages/view-latte/src/LatteEngineFactory.php` constructor: `__construct(ViewConfig $viewConfig, LatteViewConfig $latteViewConfig)`
+- `packages/view-latte/composer.json` includes `"conflict": {"marko/view-twig": "*"}`
+- All existing view-latte tests pass after updating mocks to include `LatteViewConfig`
+- App-level config overrides still win
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/003-scaffold-view-twig-package.md
+++ b/.claude/plans/view-twig/003-scaffold-view-twig-package.md
@@ -1,0 +1,43 @@
+# Task 003: Scaffold marko/view-twig package structure + composer.json
+
+**Status**: pending
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+Create the directory structure and Composer metadata for the new `marko/view-twig` package. Mirror the shape of `packages/view-latte/`. This task only scaffolds; subsequent tasks fill in the PHP code.
+
+## Context
+- Related files (to mirror):
+  - `packages/view-latte/composer.json`
+  - `packages/view-latte/.gitattributes`
+  - `packages/view-latte/LICENSE`
+- New directory: `packages/view-twig/` with subdirectories `src/`, `tests/`, `config/`
+- Package name: `marko/view-twig`
+- Namespace: `Marko\View\Twig\` → `src/`
+- Test namespace: `Marko\View\Twig\Tests\` → `tests/`
+- Twig library: `twig/twig ^3.0`
+- Add `"conflict": {"marko/view-latte": "*"}` to enforce mutual exclusion
+- Add `extra.marko.module = true` (per `view-latte` pattern)
+
+## Requirements (Test Descriptions)
+- [ ] `it ships a composer.json with name marko/view-twig`
+- [ ] `it requires php ^8.5`
+- [ ] `it requires marko/view at self.version`
+- [ ] `it requires twig/twig ^3.0`
+- [ ] `it declares a Composer conflict with marko/view-latte`
+- [ ] `it autoloads Marko\\View\\Twig namespace from src/`
+- [ ] `it autoloads Marko\\View\\Twig\\Tests namespace from tests/`
+- [ ] `it marks the package as a Marko module via extra.marko.module`
+
+## Acceptance Criteria
+- `packages/view-twig/composer.json` exists with correct schema
+- `packages/view-twig/LICENSE` exists (MIT, matching the repo)
+- `packages/view-twig/.gitattributes` exists (matching `view-latte`'s)
+- `packages/view-twig/src/` and `packages/view-twig/tests/` and `packages/view-twig/config/` directories exist (use a `.gitkeep` file in each so empty dirs are committed before later tasks add real files)
+- Composer can resolve the package (valid JSON, valid schema)
+- Do NOT create `module.php`, `src/*.php`, or `config/view.php` in this task — those are created by tasks 004–009
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/004-implement-twig-view-config.md
+++ b/.claude/plans/view-twig/004-implement-twig-view-config.md
@@ -1,0 +1,43 @@
+# Task 004: Implement TwigViewConfig with typed accessors
+
+**Status**: pending
+**Depends on**: 003
+**Retry count**: 0
+
+## Description
+Create `TwigViewConfig` — a readonly class with typed accessors for all Twig-specific settings plus the shared view settings the engine factory needs. Lives in the `marko/view-twig` package because these settings are Twig-specific and shouldn't pollute the shared `ViewConfig` in `marko/view`.
+
+## Context
+- Related files:
+  - `packages/view-twig/src/TwigViewConfig.php` (new)
+  - `packages/view-twig/tests/TwigViewConfigTest.php` (new)
+  - `packages/view/src/ViewConfig.php` (reference pattern — readonly, takes `ConfigRepositoryInterface`)
+- All accessors must use the strongly-typed `ConfigRepositoryInterface` getters (`getString`, `getBool`) which throw `ConfigNotFoundException` on missing keys — no silent fallbacks
+- Accessors needed:
+  - `cacheDirectory(): string` — reads `view.cache_directory`
+  - `extension(): string` — reads `view.extension`
+  - `autoRefresh(): bool` — reads `view.auto_refresh`
+  - `strictVariables(): bool` — reads `view.strict_variables`
+  - `autoescape(): string` — reads `view.autoescape`
+  - `debug(): bool` — reads `view.debug`
+  - `charset(): string` — reads `view.charset`
+
+## Requirements (Test Descriptions)
+- [ ] `it returns cache_directory from config`
+- [ ] `it returns extension from config`
+- [ ] `it returns auto_refresh as bool from config`
+- [ ] `it returns strict_variables as bool from config`
+- [ ] `it returns autoescape from config`
+- [ ] `it returns debug as bool from config`
+- [ ] `it returns charset from config`
+- [ ] `it throws ConfigNotFoundException when a required key is missing`
+
+## Acceptance Criteria
+- `TwigViewConfig` is a readonly class with constructor property promotion
+- Constructor takes `ConfigRepositoryInterface` as its only parameter
+- All accessors typed (return types declared)
+- All values resolved via `ConfigRepositoryInterface` — no PHP-level defaults
+- Code follows code standards (strict_types, no magic methods, no traits)
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/005-implement-twig-engine-factory.md
+++ b/.claude/plans/view-twig/005-implement-twig-engine-factory.md
@@ -1,0 +1,48 @@
+# Task 005: Implement TwigEngineFactory
+
+**Status**: pending
+**Depends on**: 004
+**Retry count**: 0
+
+## Description
+Create `TwigEngineFactory` that builds a configured `Twig\Environment` instance from `TwigViewConfig`. Mirrors the shape of `LatteEngineFactory` but uses Twig's API. The loader is set separately when `TwigView` is constructed (so the factory doesn't need the resolver).
+
+## Context
+- Related files:
+  - `packages/view-twig/src/TwigEngineFactory.php` (new)
+  - `packages/view-twig/tests/TwigEngineFactoryTest.php` (new)
+  - `packages/view-latte/src/LatteEngineFactory.php` (reference pattern)
+- Twig\Environment construction:
+  ```php
+  $loader = new \Twig\Loader\ArrayLoader();  // placeholder, replaced by TwigView with ModuleLoader
+  $environment = new \Twig\Environment($loader, [
+      'cache' => $config->cacheDirectory(),
+      'auto_reload' => $config->autoRefresh(),
+      'strict_variables' => $config->strictVariables(),
+      'autoescape' => $config->autoescape(),
+      'debug' => $config->debug(),
+      'charset' => $config->charset(),
+  ]);
+  ```
+- The factory creates and returns the `Environment`; `TwigView`'s constructor sets the real loader
+- Readonly class, constructor property promotion
+
+## Requirements (Test Descriptions)
+- [ ] `it returns a Twig Environment instance`
+- [ ] `it sets the cache directory from config`
+- [ ] `it sets auto_reload from auto_refresh config`
+- [ ] `it sets strict_variables from config`
+- [ ] `it sets autoescape from config`
+- [ ] `it sets debug from config`
+- [ ] `it sets charset from config`
+
+## Acceptance Criteria
+- `TwigEngineFactory` is a readonly class with constructor property promotion
+- Constructor takes `TwigViewConfig` (autowired by the container — `TwigViewConfig` itself autowires from `ConfigRepositoryInterface`)
+- `create(): \Twig\Environment` method returns a fresh environment per call
+- All Environment options sourced from `TwigViewConfig` — no inline defaults
+- Cache directory passed to Twig's `cache` option must be a non-empty string (Twig accepts `false` to disable caching, but our `TwigViewConfig::cacheDirectory()` returns a required string per the loud-errors principle)
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/006-implement-twig-module-loader.md
+++ b/.claude/plans/view-twig/006-implement-twig-module-loader.md
@@ -1,0 +1,51 @@
+# Task 006: Implement ModuleLoader for Twig
+
+**Status**: pending
+**Depends on**: 003
+**Retry count**: 0
+
+## Description
+Create `ModuleLoader` implementing `Twig\Loader\LoaderInterface`. Resolves module-namespaced templates (`module::path/to/template`) via the shared `TemplateResolverInterface`. Mirrors the responsibility of view-latte's `ModuleLoader` but adapts to Twig's loader contract.
+
+## Context
+- Related files:
+  - `packages/view-twig/src/ModuleLoader.php` (new)
+  - `packages/view-twig/tests/ModuleLoaderTest.php` (new)
+  - `packages/view-latte/src/ModuleLoader.php` (reference pattern, but Latte's interface differs)
+- `Twig\Loader\LoaderInterface` requires:
+  - `getSourceContext(string $name): \Twig\Source` — returns the template source wrapped in `Twig\Source($code, $name, $path)`
+  - `getCacheKey(string $name): string` — return the resolved absolute path (unique per template)
+  - `isFresh(string $name, int $time): bool` — return `filemtime($path) <= $time`
+  - `exists(string $name): bool` — return true if `TemplateResolverInterface::resolve($name)` returns a path that file_exists, false otherwise (must NOT throw)
+- Path resolution delegates to `TemplateResolverInterface::resolve($name)` (same approach as view-latte's loader)
+- For `exists()`: the resolver throws `TemplateNotFoundException` when the template isn't found. Catch it and return false — Twig's `exists()` must be non-throwing per its contract.
+- **Format enforcement (relative-include rejection):** Unlike Latte's `Loader`, Twig's `LoaderInterface` has no `getReferredName()` hook for normalizing include names — Twig passes include names verbatim to the loader. Enforce the `module::path` format at the entry of `getSourceContext()`, `getCacheKey()`, and `exists()`:
+  - In `getSourceContext()` and `getCacheKey()`: if `!str_contains($name, '::')`, throw a clear `\Twig\Error\LoaderError` ("Template includes must use module namespace format (e.g., 'blog::post/list/item'). Got '$name'.") — this surfaces at compile/render time with the offending name.
+  - In `exists()`: if `!str_contains($name, '::')`, return false (do not throw — keeps the contract intact). This is consistent with how `exists()` handles unknown templates.
+- **File read errors:** When `getSourceContext()` resolves a path, the file should exist (resolver checks via `file_exists`). But guard against race conditions: if `file_get_contents()` returns `false`, throw a `\Twig\Error\LoaderError` with the path included.
+- Extract a private `resolvePath(string $name): string` helper that calls `$this->resolver->resolve($name)` — mirrors view-latte's loader shape.
+
+## Requirements (Test Descriptions)
+- [ ] `it returns Twig Source containing the template content when getSourceContext is called`
+- [ ] `it returns the resolved absolute path as the cache key`
+- [ ] `it returns true from isFresh when file modification time is older than the given time`
+- [ ] `it returns false from isFresh when file modification time is newer than the given time`
+- [ ] `it returns true from exists when the resolver finds the template`
+- [ ] `it returns false from exists when the resolver cannot find the template`
+- [ ] `it does not throw from exists when the resolver throws TemplateNotFoundException`
+- [ ] `it returns false from exists when the name lacks module-namespaced format`
+- [ ] `it throws LoaderError from getSourceContext when the name lacks module-namespaced format`
+- [ ] `it throws LoaderError from getCacheKey when the name lacks module-namespaced format`
+- [ ] `it throws LoaderError from getSourceContext when the resolved file cannot be read`
+
+## Acceptance Criteria
+- `ModuleLoader` implements `\Twig\Loader\LoaderInterface`
+- Constructor takes `TemplateResolverInterface` via constructor injection
+- All four interface methods implemented correctly
+- `exists()` is non-throwing per Twig's contract (returns false for unknown templates and for names lacking `::`)
+- Relative includes / bare names (no `::`) produce a loud, actionable `\Twig\Error\LoaderError` from `getSourceContext()` and `getCacheKey()`
+- File read failures in `getSourceContext()` surface as `\Twig\Error\LoaderError` with the offending path
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/007-implement-twig-view.md
+++ b/.claude/plans/view-twig/007-implement-twig-view.md
@@ -1,0 +1,45 @@
+# Task 007: Implement TwigView
+
+**Status**: pending
+**Depends on**: 005, 006
+**Retry count**: 0
+
+## Description
+Create `TwigView` implementing `ViewInterface`. Wraps `Twig\Environment`, sets the `ModuleLoader` on construction so includes use module resolution, and exposes both `render()` (returns HTTP `Response`) and `renderToString()` (returns string). Mirrors the contract and behavior of `LatteView`.
+
+## Context
+- Related files:
+  - `packages/view-twig/src/TwigView.php` (new)
+  - `packages/view-twig/tests/TwigViewTest.php` (new)
+  - `packages/view-latte/src/LatteView.php` (reference pattern)
+  - `packages/view/src/ViewInterface.php` (contract)
+  - `packages/routing/src/Http/Response.php` (for `Response::html()`)
+- Constructor signature: `__construct(Twig\Environment $engine, TemplateResolverInterface $resolver)`
+- Constructor body: call `$this->engine->setLoader(new ModuleLoader($resolver))` so includes resolve correctly (mirrors view-latte pattern). `Twig\Environment::setLoader(LoaderInterface)` is a public method in Twig 3.
+- `render(string $template, array $data = []): Response` — render to string, return `Response::html($html)`
+- `renderToString(string $template, array $data = []): string` — call `$engine->render($template, $data)` and return result
+
+## Test Setup Notes
+- Tests that need a real `Twig\Environment` should construct one with `new \Twig\Environment(new \Twig\Loader\ArrayLoader([]), [...])` — `TwigView`'s constructor will immediately replace the loader. Make sure to pass `strict_variables => true` and `autoescape => 'html'` in the options so behavioral tests reflect production defaults.
+- The "auto-escapes HTML by default" test should render a template containing `{{ value }}` with a value of `'<script>'` and assert the output contains `&lt;script&gt;`.
+- The "throws on undefined variable" test should render a template referencing `{{ undefined_var }}` and assert a `\Twig\Error\RuntimeError` is thrown (Twig 3's strict_variables error type).
+- The "resolves module-namespaced includes" test should mirror view-latte's pattern: define a parent template that does `{% include 'blog::post/list/item' %}` and verify the include is resolved via the injected `TemplateResolverInterface`.
+
+## Requirements (Test Descriptions)
+- [ ] `it renders a template and returns an HTML Response`
+- [ ] `it renders a template to a string`
+- [ ] `it passes data variables to the template`
+- [ ] `it resolves module-namespaced template includes via the resolver`
+- [ ] `it auto-escapes HTML output by default`
+- [ ] `it throws a Twig error when an undefined variable is used and strict_variables is true`
+
+## Acceptance Criteria
+- `TwigView` implements `Marko\View\ViewInterface`
+- Constructor takes `Twig\Environment` and `TemplateResolverInterface`
+- Constructor sets `ModuleLoader` on the engine so includes use module resolution
+- `render()` returns a `Response::html()` instance
+- `renderToString()` returns the rendered string directly
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/008-ship-view-twig-config.md
+++ b/.claude/plans/view-twig/008-ship-view-twig-config.md
@@ -1,0 +1,42 @@
+# Task 008: Ship view-twig config/view.php with defaults
+
+**Status**: pending
+**Depends on**: 003
+**Retry count**: 0
+
+## Description
+Create `packages/view-twig/config/view.php` shipping all default values that `TwigViewConfig` reads. This is the single source of truth for Twig driver defaults; per Marko's "no silent fallbacks" principle, every value `TwigViewConfig` accesses must be present here.
+
+## Context
+- Related files:
+  - `packages/view-twig/config/view.php` (new)
+  - `packages/view-twig/tests/ViewConfigDefaultsTest.php` (new — verifies all keys are present)
+- Required keys and recommended defaults:
+  - `extension: '.twig'` — Twig's standard extension
+  - `strict_variables: true` — aligns with Marko's "loud errors" premise (undefined variables throw)
+  - `autoescape: 'html'` — safe default for web apps
+  - `debug: false` — production-safe default
+  - `charset: 'UTF-8'`
+- **Do NOT redeclare `cache_directory` or `auto_refresh`** — these are shared keys that live in `marko/view`'s `config/view.php` (the interface package ships them once for all drivers). Marko's `ConfigDiscovery` merges all `config/view.php` files from installed modules into a single `view.*` namespace, so values from `marko/view` and `marko/view-twig` combine cleanly.
+- The file returns a flat array (no nested `view` key — Marko's config loader prefixes by file name)
+
+## Requirements (Test Descriptions)
+- [ ] `it ships a config/view.php file`
+- [ ] `it defines extension as .twig`
+- [ ] `it defines strict_variables as true`
+- [ ] `it defines autoescape as html`
+- [ ] `it defines debug as false`
+- [ ] `it defines charset as UTF-8`
+- [ ] `it does not redeclare cache_directory (inherited from marko/view shared config)`
+- [ ] `it does not redeclare auto_refresh (inherited from marko/view shared config)`
+- [ ] `it returns a flat array (not nested under a view key)`
+
+## Acceptance Criteria
+- `packages/view-twig/config/view.php` exists
+- All five Twig-specific keys are present with the specified defaults
+- The file does NOT contain `cache_directory` or `auto_refresh` (those come from `marko/view`'s shipped config)
+- File uses `declare(strict_types=1)` and returns an array
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/009-wire-view-twig-module-php.md
+++ b/.claude/plans/view-twig/009-wire-view-twig-module-php.md
@@ -1,0 +1,44 @@
+# Task 009: Wire view-twig module.php bindings
+
+**Status**: pending
+**Depends on**: 007, 008
+**Retry count**: 0
+
+## Description
+Create `packages/view-twig/module.php` registering DI bindings so that `ViewInterface` resolves to a fully-wired `TwigView`. Mirrors the closure-based binding pattern in `view-latte/module.php`.
+
+## Context
+- Related files:
+  - `packages/view-twig/module.php` (new)
+  - `packages/view-twig/tests/ModuleTest.php` (new — verifies bindings resolve correctly)
+  - `packages/view-latte/module.php` (reference pattern)
+- Required binding:
+  ```php
+  return [
+      'bindings' => [
+          ViewInterface::class => function (ContainerInterface $container): ViewInterface {
+              $engine = $container->get(TwigEngineFactory::class)->create();
+              $resolver = $container->get(TemplateResolverInterface::class);
+              return new TwigView($engine, $resolver);
+          },
+      ],
+  ];
+  ```
+- The `TwigEngineFactory` and `TwigViewConfig` resolve via autowiring — `TwigEngineFactory` takes a `TwigViewConfig`, which takes a `ConfigRepositoryInterface` (a singleton already registered by `marko/config`)
+- `ModuleTest.php` should mirror `packages/view-latte/tests/ModuleTest.php`: assert `module.php` exists, returns an array with a `bindings` key, the binding for `ViewInterface::class` is a `Closure`, and calling the closure with a mock container that returns mocked `TwigEngineFactory` and `TemplateResolverInterface` produces a `TwigView` instance
+
+## Requirements (Test Descriptions)
+- [ ] `it registers a ViewInterface binding`
+- [ ] `it resolves ViewInterface to a TwigView instance`
+- [ ] `it injects a configured Twig Environment into TwigView`
+- [ ] `it injects the shared TemplateResolverInterface into TwigView`
+
+## Acceptance Criteria
+- `module.php` exists with a `bindings` array
+- `ViewInterface::class` binding is a closure that returns a wired `TwigView`
+- File uses `declare(strict_types=1)`
+- All referenced classes have proper `use` imports
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/010-add-twig-syntax-highlighting-docs.md
+++ b/.claude/plans/view-twig/010-add-twig-syntax-highlighting-docs.md
@@ -1,0 +1,43 @@
+# Task 010: Add Twig syntax highlighting to docs site
+
+**Status**: pending
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+Register `twig` as a Shiki language in the docs site's Astro Starlight config so Twig code blocks in `.md`/`.mdx` files render with syntax highlighting. Twig is bundled with Shiki natively, so this is a one-line addition to the `langs` array — no custom grammar JSON required (unlike the existing Latte support).
+
+## Context
+- Related files:
+  - `docs/astro.config.mjs` (modify — add `'twig'` to `shiki.langs`)
+- Current state of relevant lines:
+  ```js
+  shiki: {
+      langs: [latteGrammar, 'dotenv'],
+      langAlias: { ... },
+  },
+  ```
+- After change:
+  ```js
+  shiki: {
+      langs: [latteGrammar, 'twig', 'dotenv'],
+      langAlias: { ... },
+  },
+  ```
+- No new grammar file needed — Shiki ships Twig support (it's one of Shiki's bundled languages, identified by the string `'twig'`)
+- Verification step: after the edit, build the docs site (`cd docs && npm run build`) and confirm there are no warnings about the `twig` language being unknown. If Shiki rejects the string, fall back to importing the grammar from `shiki/langs/twig.mjs` and pushing the imported value into `langs` (same pattern as `latteGrammar`).
+- This task does not write Twig documentation content (that's doc-updater's job in the post-implementation pipeline)
+
+## Requirements (Test Descriptions)
+- [ ] `it registers twig as a Shiki language in astro.config.mjs`
+- [ ] `it keeps the existing latte grammar registration`
+- [ ] `it keeps the existing dotenv language registration`
+
+## Acceptance Criteria
+- `docs/astro.config.mjs` includes `'twig'` in the `shiki.langs` array
+- No regressions to existing Latte highlighting
+- Docs site builds successfully (`cd docs && npm run build`)
+- Twig code fences in any `.md` file render with syntax highlighting
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/011-update-skeleton-suggest-block.md
+++ b/.claude/plans/view-twig/011-update-skeleton-suggest-block.md
@@ -1,0 +1,37 @@
+# Task 011: Update skeleton composer.json suggest block
+
+**Status**: pending
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+Add both `marko/view-twig` and `marko/view-latte` to the `marko/skeleton` composer.json `suggest` block so users creating new projects see both engine options. List Twig first (broader recognition in the PHP ecosystem). The skeleton stays driver-agnostic — neither is a hard dependency.
+
+## Context
+- Related files:
+  - `packages/skeleton/composer.json` (modify — add `suggest` block if missing, or add to existing)
+- The skeleton has no `suggest` block today, so the entire block needs to be added
+- Format (alphabetical inside suggest is conventional, but here we deliberately order by recommendation — Twig first for visibility):
+  ```json
+  "suggest": {
+      "marko/view-twig": "Twig template engine driver (recommended for broader ecosystem familiarity)",
+      "marko/view-latte": "Latte template engine driver (compile-time safety, n:attribute syntax)"
+  }
+  ```
+- Do NOT add either to `require` — keep skeleton engine-agnostic
+
+## Requirements (Test Descriptions)
+- [ ] `it lists marko/view-twig in the skeleton composer suggest block`
+- [ ] `it lists marko/view-latte in the skeleton composer suggest block`
+- [ ] `it does not add marko/view-twig to require`
+- [ ] `it does not add marko/view-latte to require`
+- [ ] `it keeps the suggest entries valid JSON`
+
+## Acceptance Criteria
+- `packages/skeleton/composer.json` contains a `suggest` block with both entries
+- Neither view driver appears in `require` or `require-dev`
+- Composer can validate the file (`composer validate`)
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/012-add-twig-to-no-driver-exception.md
+++ b/.claude/plans/view-twig/012-add-twig-to-no-driver-exception.md
@@ -1,0 +1,39 @@
+# Task 012: Add marko/view-twig to NoDriverException driver package list
+
+**Status**: pending
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+`marko/view` already defines `NoDriverException` with a `DRIVER_PACKAGES` const that lists every install candidate when no view driver is bound. The message follows the same pattern as `marko/database`'s `NoDriverException`. After adding `marko/view-twig` as a sibling driver, the const must include it so the exception's suggestion lists every available driver:
+
+```
+Install a view driver:
+- `composer require marko/view-latte`
+- `composer require marko/view-twig`
+```
+
+This is a one-line addition to the const array.
+
+## Context
+- Related files:
+  - `packages/view/src/Exceptions/NoDriverException.php` (modify — add `'marko/view-twig'` to `DRIVER_PACKAGES` const)
+  - `packages/view/tests/Exceptions/NoDriverExceptionTest.php` (update — assert both drivers appear in the suggestion text)
+- Reference pattern: `packages/database/src/Exceptions/NoDriverException.php` lists both `marko/database-mysql` and `marko/database-pgsql` in its `DRIVER_PACKAGES` const — same shape this task produces for view
+- Keep alphabetical order in the const (`marko/view-latte` before `marko/view-twig`)
+- Out of scope: actually wiring the exception to be thrown by the container — that is a pre-existing gap in both `marko/view` and `marko/database` (neither currently throws this exception from a fallback binding). Tracked separately; not blocking this plan.
+
+## Requirements (Test Descriptions)
+- [ ] `it lists marko/view-latte as an installable driver`
+- [ ] `it lists marko/view-twig as an installable driver`
+- [ ] `it formats each driver as a composer require command in the suggestion`
+- [ ] `it keeps DRIVER_PACKAGES alphabetically ordered`
+
+## Acceptance Criteria
+- `NoDriverException::DRIVER_PACKAGES` contains both `'marko/view-latte'` and `'marko/view-twig'` in alphabetical order
+- The exception's `suggestion` text includes both `composer require` commands
+- Existing `NoDriverExceptionTest` assertions updated to cover the new entry
+- Code follows code standards
+
+## Implementation Notes
+(Left blank — filled in by programmer during implementation)

--- a/.claude/plans/view-twig/_plan.md
+++ b/.claude/plans/view-twig/_plan.md
@@ -1,0 +1,135 @@
+# Plan: marko/view-twig — Twig template engine driver
+
+## Created
+2026-05-26
+
+## Status
+completed
+
+## Objective
+Create a new `marko/view-twig` driver package as a sibling to `marko/view-latte`, giving users a second template engine choice. Refactor the shared `marko/view` config so it no longer biases toward a specific driver, ensuring true interface/driver separation.
+
+## Related Issues
+none
+
+## Discovery Notes
+
+**Existing view ecosystem:**
+- `marko/view` (interface package) defines `ViewInterface`, `TemplateResolverInterface`, `ModuleTemplateResolver`, `ViewConfig`, and exceptions
+- `marko/view-latte` is the only existing driver. Its shape: `LatteView` (implements `ViewInterface`), `LatteEngineFactory` (builds `Latte\Engine` from `ViewConfig`), `ModuleLoader` (implements `Latte\Loader` to resolve `module::path` templates via `TemplateResolverInterface`), `Extensions/SlotExtension` (custom `{slot}` tag)
+- `view/config/view.php` currently hardcodes `extension => '.latte'` — this biases the interface package toward Latte, violating the interface/driver split
+
+**Engine-specific config approach (resolved during clarification):**
+- All defaults live in driver-package config files (no PHP-level fallbacks — per Marko's "config files are the single source of truth" and "no silent fallbacks" principles)
+- Driver-specific accessors live in driver packages — `TwigViewConfig` in `view-twig`, not in shared `ViewConfig`
+- `marko/view` config keeps only truly shared keys (`cache_directory`, `auto_refresh`); each driver ships its own `config/view.php` adding the keys it needs
+- Mutual exclusion enforced via Composer `conflict` declaration (loud at install time, not just runtime)
+
+**Native Twig features (resolved):**
+- No SlotExtension port — Twig has native `{% block %}`, `{% extends %}`, `{% embed %}`, `{% use %}`, `{% macro %}` that cover slot use cases
+- Expose full native Twig; don't reimplement what Twig already provides
+
+**Cross-cutting impact:**
+- `marko/admin-panel` ships 5 `.latte` template files in `resources/views/`. A user installing `view-twig` instead of `view-latte` would have admin-panel break. **Scoped to a follow-up plan** (engine-specific sibling packages: `marko/admin-panel-latte`, `marko/admin-panel-twig`).
+- Docs site has custom Latte syntax highlighting grammar. Twig is built into Shiki — adding `'twig'` to `langs` in `docs/astro.config.mjs` covers highlighting.
+- `marko/skeleton` and `marko/framework` are already engine-agnostic (no view driver in `require`). Skeleton gets both options in `suggest` block.
+
+**Scaling pattern (documented for future):**
+- For UI packages that ship reusable templates: extract templates into engine-specific siblings (`marko/{package}-{engine}`)
+- For application/custom modules: hard-dep on whichever engine the team chose — multi-engine support is only worth the cost for shipped reusable UI
+
+**Core engine adoption policy (deferred to follow-up plan):**
+- Adopting a template engine under the `marko/*` namespace commits Marko to maintaining template parity for that engine across all `marko/*` UI modules
+- A `CrossEngineTemplateParityTest` will live in `marko/view`'s test suite (not `marko/framework`'s) — the test only runs when `marko/view` is installed, which is the correct gate (no view = no parity invariant)
+- The test walks `marko/*` packages, finds every template under `resources/views/`, and asserts a sibling exists for every registered core engine
+- This commitment implicitly limits how many engines Marko can adopt in core (the maintenance math caps it at 2–3 realistically). Community engines outside the `marko/*` namespace have no parity obligation.
+- **Scoped to the follow-up admin-panel plan**, where the test will be meaningful (added alongside the actual admin-panel sibling-package extraction)
+
+## Scope
+
+### In Scope
+- New package `marko/view-twig` at `packages/view-twig/`
+- `TwigView` implementing `ViewInterface`
+- `TwigEngineFactory` building `Twig\Environment` from typed config
+- `ModuleLoader` implementing `Twig\Loader\LoaderInterface` (resolves `module::path` templates via shared `TemplateResolverInterface`)
+- `TwigViewConfig` exposing Twig-specific settings: `extension`, `strict_variables`, `autoescape`, `debug`, `charset`, plus the shared `cache_directory` and `auto_refresh`
+- `view-twig/config/view.php` shipping all default values (`extension: '.twig'`, `strict_variables: true`, `autoescape: 'html'`, `debug: false`, `charset: 'UTF-8'`, `cache_directory: '/tmp/views'`, `auto_refresh: true`)
+- `view-twig/module.php` binding `ViewInterface => TwigView` via closure
+- Composer `conflict` declaration between `view-twig` and `view-latte` (mutual exclusion at install time)
+- Refactor `marko/view`: remove `extension` default from `view/config/view.php` (driver-neutral interface package)
+- Refactor `marko/view-latte`: add own `config/view.php` shipping `extension => '.latte'` and other Latte-relevant defaults; add `conflict` declaration mirroring view-twig's
+- Update `marko/skeleton` composer.json `suggest` block to list both `view-twig` and `view-latte` (Twig first for broader recognition)
+- Docs site: register `twig` as a Shiki language in `docs/astro.config.mjs`
+- Full test parity with `view-latte` test suite (PackageTest, ModuleTest, TwigEngineFactoryTest, TwigViewTest, ModuleLoaderTest)
+
+### Out of Scope
+- `marko/admin-panel` template extraction into engine siblings — separate follow-up plan
+- Other UI packages (none currently ship templates, so no work needed)
+- Interactive engine selection in `composer create-project`
+- README files and docs site content pages (handled by `doc-updater` agent in post-implementation pipeline per project conventions)
+- SlotExtension port (Twig has native blocks/embed)
+- Twig extensions beyond the engine defaults (users can add their own via DI or follow-up plans)
+
+## Success Criteria
+- [ ] `composer require marko/view-twig` installs cleanly into a Marko app
+- [ ] `composer require marko/view-twig` is rejected by Composer when `marko/view-latte` is already installed (and vice versa)
+- [ ] `ViewInterface` resolves to `TwigView` when view-twig is the installed driver
+- [ ] Module-namespaced templates (`module::path/to/template`) render correctly with Twig
+- [ ] Undefined template variables throw a Twig error (strict_variables enabled by default)
+- [ ] HTML output is auto-escaped by default
+- [ ] All defaults overridable via app-level `config/view.php`
+- [ ] `marko/view` config no longer presumes Latte
+- [ ] `marko/view-latte` continues to work with no behavior change after refactor
+- [ ] Twig code blocks in docs site are syntax-highlighted
+- [ ] All tests passing (`composer test`)
+- [ ] Code follows project standards (php-cs-fixer, phpcs)
+
+## Task Overview
+| Task | Description | Depends On | Status |
+|------|-------------|------------|--------|
+| 001 | Refactor marko/view: remove extension + strict_types defaults from config; remove strictTypes() accessor | - | pending |
+| 002 | Refactor marko/view-latte: ship own config + add LatteViewConfig + conflict declaration | 001 | pending |
+| 003 | Scaffold marko/view-twig package structure + composer.json | - | pending |
+| 004 | Implement TwigViewConfig with typed accessors | 003 | pending |
+| 005 | Implement TwigEngineFactory | 004 | pending |
+| 006 | Implement ModuleLoader for Twig | 003 | pending |
+| 007 | Implement TwigView | 005, 006 | pending |
+| 008 | Ship view-twig config/view.php with defaults | 003 | pending |
+| 009 | Wire view-twig module.php bindings | 007, 008 | pending |
+| 010 | Add Twig syntax highlighting to docs site | - | pending |
+| 011 | Update skeleton composer.json suggest block | - | pending |
+| 012 | Add marko/view-twig to NoDriverException driver package list | - | pending |
+
+## Architecture Notes
+
+**Interface/driver split is the load-bearing principle here.** The whole point of this plan is making `marko/view` genuinely driver-neutral. After the refactor:
+- `marko/view`: defines interface, resolver, and config keys *shared by all drivers* (cache_directory, auto_refresh). `ViewConfig` keeps `cacheDirectory()`, `autoRefresh()`, and `extension()` (the extension accessor is used by `ModuleTemplateResolver` which lives in this package; the default value moves to drivers but the accessor stays).
+- `marko/view-latte`: ships its own `config/view.php` with `extension => '.latte'` and `strict_types => true`. Introduces a new `LatteViewConfig` class hosting the Latte-only `strictTypes()` accessor (previously on shared `ViewConfig`). `LatteEngineFactory` now takes both `ViewConfig` and `LatteViewConfig`.
+- `marko/view-twig`: ships its own `config/view.php` with `extension => '.twig'` plus Twig-specific keys. Provides `TwigViewConfig` with all Twig-specific accessors.
+
+This symmetry — each driver hosting its own driver-specific config accessor class — is non-negotiable after the refactor. Otherwise Latte-specific concerns leak into the shared interface package, defeating the plan's stated goal.
+
+**Config layering:** Marko's module discovery loads config files in priority order (vendor → modules → app). A user's `app/config/view.php` overrides whatever the driver package ships. This is the user override mechanism — no special API needed.
+
+**No PHP-level defaults:** Every value `TwigViewConfig` exposes goes through `ConfigRepositoryInterface::getString()` / `getBool()` etc., which throw `ConfigNotFoundException` on missing keys. All defaults live in `view-twig/config/view.php`. This is non-negotiable per Marko's "loud errors / no silent fallbacks" principle.
+
+**Twig Loader interface differs from Latte's.** `Twig\Loader\LoaderInterface` requires `getSourceContext(string $name): Source`, `getCacheKey(string $name): string`, `isFresh(string $name, int $time): bool`, `exists(string $name): bool`. The `ModuleLoader` implementation delegates path resolution to the shared `TemplateResolverInterface` (same as view-latte does), then adapts to Twig's interface.
+
+**Composer conflict for mutual exclusion:** Adding `"conflict": {"marko/view-latte": "*"}` to view-twig's composer.json (and mirroring in view-latte) means Composer refuses to install both — fails loudly at install time rather than silently letting one bind win. Aligned with "loud errors" principle.
+
+## Risks & Mitigations
+
+- **Risk:** Refactoring `marko/view-latte` to add its own config could break apps that override `view.extension` at the app level.
+  **Mitigation:** App-level config has highest priority (overrides modules and vendor). App overrides continue to win. Driver-shipped config only fills in defaults — users who already set `view.extension` see no change.
+
+- **Risk:** Composer `conflict` declaration could surprise existing view-latte users when they try the new package.
+  **Mitigation:** The error message is loud and actionable ("remove marko/view-latte before installing marko/view-twig"). This is the correct UX — mixing two `ViewInterface` bindings was never supported and would have caused `BindingConflictException` at runtime anyway. Failing at `composer install` time is strictly better.
+
+- **Risk:** Twig autoescape defaults differ between Twig 2 and Twig 3. Twig 3 defaults to HTML autoescape from `{% autoescape %}` tags, but `Environment` constructor takes an `autoescape` option.
+  **Mitigation:** Explicitly set `autoescape => 'html'` in our default config and pass it through `TwigEngineFactory`. Don't rely on Twig's internal defaults.
+
+- **Risk:** admin-panel users who switch to view-twig will hit runtime template-not-found errors.
+  **Mitigation:** Out of scope for this plan — handled by the follow-up admin-panel-sibling-package plan. Document the limitation in skeleton README (handled by doc-updater).
+
+- **Risk:** Test parity with view-latte might miss Twig-specific edge cases (strict_variables behavior, autoescape behavior).
+  **Mitigation:** Add Twig-specific tests beyond direct parity: verify undefined-variable error is raised, verify HTML escaping is active by default, verify users can disable autoescape via config.

--- a/composer.json
+++ b/composer.json
@@ -428,7 +428,8 @@
         "predis/predis": "^2.0",
         "rector/rector": "^2.3",
         "slevomat/coding-standard": "^8.26",
-        "squizlabs/php_codesniffer": "^4.0"
+        "squizlabs/php_codesniffer": "^4.0",
+        "twig/twig": "^3.0"
     },
     "scripts": {
         "test": "pest -c phpunit.xml --parallel --exclude-group=integration-destructive",
@@ -529,6 +530,8 @@
             "Marko\\Validation\\Tests\\": "packages/validation/tests/",
             "Marko\\View\\Tests\\": "packages/view/tests/",
             "Marko\\View\\Latte\\Tests\\": "packages/view-latte/tests/",
+            "Marko\\View\\Twig\\": "packages/view-twig/src/",
+            "Marko\\View\\Twig\\Tests\\": "packages/view-twig/tests/",
             "Marko\\Vite\\Tests\\": "packages/vite/tests/",
             "Marko\\Webhook\\Tests\\": "packages/webhook/tests/"
         }

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -25,7 +25,7 @@ export default defineConfig({
 			expressiveCode: {
 				themes: [arcadeDark],
 				shiki: {
-					langs: [latteGrammar, 'dotenv'],
+					langs: [latteGrammar, 'twig', 'dotenv'],
 					langAlias: {
 						env: 'dotenv',
 					},

--- a/docs/src/content/docs/packages/view-latte.md
+++ b/docs/src/content/docs/packages/view-latte.md
@@ -11,17 +11,17 @@ Latte templating driver for the Marko Framework. Implements `ViewInterface` from
 composer require marko/view-latte
 ```
 
-This automatically installs `marko/view`.
+This automatically installs `marko/view`. Note: `marko/view-latte` conflicts with `marko/view-twig` --- install only one view driver per project.
 
 ## Configuration
 
-Configure via the `view` config key:
+Configure via the `view` config key. Settings from `marko/view` (`cache_directory`, `auto_refresh`) apply to all drivers. The following are Latte-specific defaults:
 
 ```php title="config/view.php"
 return [
     'cache_directory' => '/path/to/cache',
-    'extension' => '.latte',
     'auto_refresh' => true,  // Set false in production
+    'extension' => '.latte',
     'strict_types' => true,
 ];
 ```
@@ -147,7 +147,7 @@ views/
 
 | Option | Type | Description |
 |---|---|---|
-| `cache_directory` | `string` | Directory for compiled template cache |
+| `cache_directory` | `string` | Directory for compiled template cache (from `marko/view`) |
+| `auto_refresh` | `bool` | Recompile templates when source changes --- set `false` in production (from `marko/view`) |
 | `extension` | `string` | Template file extension (default `.latte`) |
-| `auto_refresh` | `bool` | Recompile templates when source changes --- set `false` in production |
-| `strict_types` | `bool` | Enable strict type checking in templates |
+| `strict_types` | `bool` | Enable strict type checking in templates (default `true`) |

--- a/docs/src/content/docs/packages/view-twig.md
+++ b/docs/src/content/docs/packages/view-twig.md
@@ -1,0 +1,159 @@
+---
+title: marko/view-twig
+description: Twig templating driver for the Marko Framework --- renders module-namespaced templates with automatic caching and configurable escaping.
+---
+
+Twig templating driver for the Marko Framework. Implements `ViewInterface` from [`marko/view`](/docs/packages/view/) using the [Twig](https://twig.symfony.com/) engine, with module-namespaced template resolution and automatic caching.
+
+## Installation
+
+```bash
+composer require marko/view-twig
+```
+
+This automatically installs `marko/view`. Note: `marko/view-twig` conflicts with `marko/view-latte` --- install only one view driver per project.
+
+## Configuration
+
+Configure via the `view` config key. Settings from `marko/view` (`cache_directory`, `auto_refresh`) apply to all drivers. The following are Twig-specific defaults:
+
+```php title="config/view.php"
+return [
+    'cache_directory' => '/path/to/cache',
+    'auto_refresh' => true,  // Set false in production
+    'extension' => '.twig',
+    'strict_variables' => true,
+    'autoescape' => 'html',
+    'debug' => false,
+    'charset' => 'UTF-8',
+];
+```
+
+## Usage
+
+### Rendering Templates
+
+Templates are rendered using the module namespace syntax:
+
+```php
+use Marko\View\ViewInterface;
+
+$view->render('blog::post/index', ['posts' => $posts]);
+```
+
+The format is `module::path/to/template` where:
+- `module` is the module name (e.g., `blog`, `admin`)
+- `path/to/template` is the path within `resources/views/`
+
+The `render()` method returns an HTTP `Response` object. Use `renderToString()` when you need the raw HTML --- for example, when rendering email bodies:
+
+```php
+use Marko\View\ViewInterface;
+
+$html = $view->renderToString('blog::email/comment-verification/html', $data);
+$text = $view->renderToString('blog::email/comment-verification/text', $data);
+```
+
+### Template Includes
+
+All template includes use the same namespaced syntax:
+
+```twig
+{% include 'blog::post/list/item' with { post: post } %}
+{% include 'blog::pagination/index' with { pagination: posts } %}
+```
+
+Relative paths are not supported. This ensures:
+- Consistent syntax throughout templates
+- Templates can include from any module
+- No fragile relative path dependencies
+
+### Passing Data to Includes
+
+Pass variables to included templates as named parameters:
+
+```twig
+{% include 'blog::post/list/item' with { post: post, showAuthor: true } %}
+```
+
+Default values in the included template:
+
+```twig title="resources/views/post/list/item.twig"
+{# post/list/item.twig #}
+{% set showAuthor = showAuthor ?? true %}
+{% set linkAuthor = linkAuthor ?? true %}
+
+<li class="post-item">
+    <h2><a href="/blog/{{ post.slug }}">{{ post.title }}</a></h2>
+    {% if showAuthor %}
+        <span>By {{ post.author.name }}</span>
+    {% endif %}
+</li>
+```
+
+### Template Organization
+
+All templates must live within at least one directory. No top-level template files.
+
+#### Standard Structure
+
+```
+views/
+  post/
+    index.twig         # Post listing
+    show.twig          # Single post
+    list/
+      item.twig        # Reusable list item
+  category/
+    show.twig
+  tag/
+    index.twig
+  author/
+    show.twig
+  search/
+    index.twig
+    bar.twig           # Search input
+  comment/
+    form.twig
+    thread.twig
+  pagination/
+    index.twig
+```
+
+#### Email Templates
+
+Email templates group HTML and plain text versions together:
+
+```
+views/
+  email/
+    comment-verification/
+      html.twig        # HTML version
+      text.twig        # Plain text version
+    welcome/
+      html.twig
+      text.twig
+```
+
+## API Reference
+
+`TwigView` implements `ViewInterface` from [`marko/view`](/docs/packages/view/).
+
+### Key Methods
+
+| Method | Description |
+|---|---|
+| `render(string $template, array $data = []): Response` | Render a template and return an HTTP response |
+| `renderToString(string $template, array $data = []): string` | Render a template and return the raw HTML string |
+
+### Configuration Options
+
+| Option | Type | Description |
+|---|---|---|
+| `cache_directory` | `string` | Directory for compiled template cache (from `marko/view`) |
+| `auto_refresh` | `bool` | Recompile templates when source changes --- set `false` in production (from `marko/view`) |
+| `extension` | `string` | Template file extension (default `.twig`) |
+| `strict_variables` | `bool` | Throw an error for undefined variables (default `true`) |
+| `autoescape` | `string` | Auto-escaping strategy: `html`, `js`, `css`, `url`, `name`, or `false` (default `html`) |
+| `debug` | `bool` | Enable Twig debug mode (default `false`) |
+| `charset` | `string` | Template charset (default `UTF-8`) |

--- a/docs/src/content/docs/packages/view.md
+++ b/docs/src/content/docs/packages/view.md
@@ -11,7 +11,7 @@ View and template rendering interface --- defines how controllers render templat
 composer require marko/view
 ```
 
-Note: You also need a view driver. Install `marko/view-latte` for Latte template support.
+Note: You also need a view driver. Install `marko/view-latte` for Latte template support or `marko/view-twig` for Twig template support.
 
 ## Usage
 
@@ -56,7 +56,7 @@ Templates follow the `module::path` pattern:
 - `blog::post/show` --- resolves to the `blog` module's `resources/views/post/show` template
 - `admin-panel::dashboard/index` --- resolves to the `admin-panel` module's dashboard view
 
-The file extension is configured via `view.extension` in config (e.g., `.latte`).
+The file extension is configured by the installed driver (e.g., `.latte` for `marko/view-latte`, `.twig` for `marko/view-twig`).
 
 ### Template File Location
 
@@ -67,10 +67,12 @@ mymodule/
   resources/
     views/
       post/
-        index.latte
-        show.latte
-      layout.latte
+        index.{ext}
+        show.{ext}
+      layout.{ext}
 ```
+
+The file extension depends on the installed driver (`.latte` for `marko/view-latte`, `.twig` for `marko/view-twig`).
 
 ### Resolving Template Paths
 
@@ -89,7 +91,7 @@ readonly class TemplateFinder
         string $template,
     ): string {
         return $this->templateResolver->resolve($template);
-        // Returns: /path/to/blog/resources/views/post/show.latte
+        // Returns: /path/to/blog/resources/views/post/show.latte (or .twig, etc.)
     }
 }
 ```
@@ -111,10 +113,8 @@ class MyService
 
     public function setup(): void
     {
-        $extension = $this->viewConfig->extension();
         $cacheDir = $this->viewConfig->cacheDirectory();
         $autoRefresh = $this->viewConfig->autoRefresh();
-        $strictTypes = $this->viewConfig->strictTypes();
     }
 }
 ```
@@ -165,10 +165,8 @@ public function getSearchedPaths(string $template): array;
 ```php
 use Marko\View\ViewConfig;
 
-public function extension(): string;
 public function cacheDirectory(): string;
 public function autoRefresh(): bool;
-public function strictTypes(): bool;
 ```
 
 ### Exceptions
@@ -177,4 +175,9 @@ public function strictTypes(): bool;
 |-----------|-------------|
 | `ViewException` | Base exception for all view errors --- extends `MarkoException` |
 | `TemplateNotFoundException` | Thrown when a template cannot be found --- includes all searched paths |
-| `NoDriverException` | Thrown when no view driver is installed --- suggests `composer require marko/view-latte` |
+| `NoDriverException` | Thrown when no view driver is installed --- suggests `composer require marko/view-latte` or `composer require marko/view-twig` |
+
+## Related Packages
+
+- [`marko/view-latte`](/docs/packages/view-latte/) --- Latte templating driver
+- [`marko/view-twig`](/docs/packages/view-twig/) --- Twig templating driver

--- a/packages/skeleton/composer.json
+++ b/packages/skeleton/composer.json
@@ -12,6 +12,10 @@
         "marko/dev-server": "*",
         "pestphp/pest": "^4.0"
     },
+    "suggest": {
+        "marko/view-twig": "Twig template engine driver (recommended for broader ecosystem familiarity)",
+        "marko/view-latte": "Latte template engine driver (compile-time safety, n:attribute syntax)"
+    },
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true

--- a/packages/skeleton/tests/PackageStructureTest.php
+++ b/packages/skeleton/tests/PackageStructureTest.php
@@ -85,3 +85,36 @@ it('has a README.md file', function (): void {
 
     expect(file_exists($packagePath . '/README.md'))->toBeTrue();
 });
+
+it('lists marko/view-twig in the skeleton composer suggest block', function (): void {
+    $composer = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
+
+    expect($composer['suggest'])->toHaveKey('marko/view-twig');
+});
+
+it('lists marko/view-latte in the skeleton composer suggest block', function (): void {
+    $composer = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
+
+    expect($composer['suggest'])->toHaveKey('marko/view-latte');
+});
+
+it('does not add marko/view-twig to require', function (): void {
+    $composer = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
+
+    expect($composer['require'])->not->toHaveKey('marko/view-twig');
+});
+
+it('does not add marko/view-latte to require', function (): void {
+    $composer = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
+
+    expect($composer['require'])->not->toHaveKey('marko/view-latte');
+});
+
+it('keeps the suggest entries valid JSON', function (): void {
+    $composerPath = __DIR__ . '/../composer.json';
+    $content = file_get_contents($composerPath);
+    $composer = json_decode($content, true);
+
+    expect(json_last_error())->toBe(JSON_ERROR_NONE)
+        ->and($composer['suggest'])->toBeArray();
+});

--- a/packages/view-latte/config/view.php
+++ b/packages/view-latte/config/view.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'extension' => '.latte',
+    'strict_types' => true,
+];

--- a/packages/view-latte/src/LatteEngineFactory.php
+++ b/packages/view-latte/src/LatteEngineFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Marko\View\Latte;
 
 use Latte\Engine;
-use Latte\Feature;
 use Marko\View\Latte\Extensions\SlotExtension;
 use Marko\View\ViewConfig;
 
@@ -13,6 +12,7 @@ readonly class LatteEngineFactory
 {
     public function __construct(
         private ViewConfig $viewConfig,
+        private LatteViewConfig $latteViewConfig,
     ) {}
 
     public function create(): Engine
@@ -20,7 +20,7 @@ readonly class LatteEngineFactory
         $engine = new Engine();
         $engine->setTempDirectory($this->viewConfig->cacheDirectory());
         $engine->setAutoRefresh($this->viewConfig->autoRefresh());
-        $engine->setFeature(Feature::StrictTypes, $this->viewConfig->strictTypes());
+        $engine->setStrictTypes($this->latteViewConfig->strictTypes());
         $engine->addExtension(new SlotExtension());
 
         return $engine;

--- a/packages/view-latte/src/LatteViewConfig.php
+++ b/packages/view-latte/src/LatteViewConfig.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\View\Latte;
+
+use Marko\Config\ConfigRepositoryInterface;
+
+readonly class LatteViewConfig
+{
+    public function __construct(
+        private ConfigRepositoryInterface $config,
+    ) {}
+
+    public function strictTypes(): bool
+    {
+        return $this->config->getBool('view.strict_types');
+    }
+}

--- a/packages/view-latte/tests/ComposerConflictTest.php
+++ b/packages/view-latte/tests/ComposerConflictTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+it('declares a Composer conflict with marko/view-twig in composer.json', function (): void {
+    $composerPath = dirname(__DIR__) . '/composer.json';
+    $composer = json_decode(file_get_contents($composerPath), true);
+
+    expect($composer)->toHaveKey('conflict')
+        ->and($composer['conflict'])->toHaveKey('marko/view-twig')
+        ->and($composer['conflict']['marko/view-twig'])->toBe('*');
+});

--- a/packages/view-latte/tests/LatteEngineFactoryTest.php
+++ b/packages/view-latte/tests/LatteEngineFactoryTest.php
@@ -5,19 +5,95 @@ declare(strict_types=1);
 use Latte\Engine;
 use Latte\Feature;
 use Marko\View\Latte\LatteEngineFactory;
+use Marko\View\Latte\LatteViewConfig;
 use Marko\View\ViewConfig;
 
 describe('LatteEngineFactory', function (): void {
+    test('LatteEngineFactory takes both ViewConfig and LatteViewConfig in its constructor', function (): void {
+        $viewConfig = $this->createMock(ViewConfig::class);
+        $viewConfig->method('cacheDirectory')->willReturn('/tmp/latte');
+        $viewConfig->method('autoRefresh')->willReturn(true);
+
+        $latteViewConfig = $this->createMock(LatteViewConfig::class);
+        $latteViewConfig->method('strictTypes')->willReturn(true);
+
+        $factory = new LatteEngineFactory($viewConfig, $latteViewConfig);
+        $engine = $factory->create();
+
+        expect($engine)->toBeInstanceOf(Engine::class);
+    });
+
     test('creates Latte Engine', function (): void {
         $viewConfig = $this->createMock(ViewConfig::class);
         $viewConfig->method('cacheDirectory')->willReturn('/tmp/latte');
         $viewConfig->method('autoRefresh')->willReturn(true);
-        $viewConfig->method('strictTypes')->willReturn(true);
 
-        $factory = new LatteEngineFactory($viewConfig);
+        $latteViewConfig = $this->createMock(LatteViewConfig::class);
+        $latteViewConfig->method('strictTypes')->willReturn(true);
+
+        $factory = new LatteEngineFactory($viewConfig, $latteViewConfig);
         $engine = $factory->create();
 
         expect($engine)->toBeInstanceOf(Engine::class);
+    });
+
+    test('LatteEngineFactory sets Latte strict types from LatteViewConfig', function (): void {
+        $cacheDir = sys_get_temp_dir() . '/latte-strict-' . bin2hex(random_bytes(8));
+        mkdir($cacheDir, 0755, true);
+
+        $viewConfig = $this->createMock(ViewConfig::class);
+        $viewConfig->method('cacheDirectory')->willReturn($cacheDir);
+        $viewConfig->method('autoRefresh')->willReturn(true);
+
+        // Test with strict types enabled
+        $latteViewConfigTrue = $this->createMock(LatteViewConfig::class);
+        $latteViewConfigTrue->method('strictTypes')->willReturn(true);
+
+        $factory = new LatteEngineFactory($viewConfig, $latteViewConfigTrue);
+        $engine = $factory->create();
+
+        // Test with strict types disabled
+        $latteViewConfigFalse = $this->createMock(LatteViewConfig::class);
+        $latteViewConfigFalse->method('strictTypes')->willReturn(false);
+
+        $factory2 = new LatteEngineFactory($viewConfig, $latteViewConfigFalse);
+        $engine2 = $factory2->create();
+
+        expect($engine->hasFeature(Feature::StrictTypes))->toBeTrue()
+            ->and($engine2->hasFeature(Feature::StrictTypes))->toBeFalse();
+
+        // Cleanup
+        array_map('unlink', glob($cacheDir . '/*'));
+        @rmdir($cacheDir);
+    });
+
+    test('LatteEngineFactory continues to set cache directory and auto refresh from ViewConfig', function (): void {
+        $cacheDir = sys_get_temp_dir() . '/latte-test-' . bin2hex(random_bytes(8));
+        mkdir($cacheDir, 0755, true);
+
+        $viewConfig = $this->createMock(ViewConfig::class);
+        $viewConfig->method('cacheDirectory')->willReturn($cacheDir);
+        $viewConfig->method('autoRefresh')->willReturn(true);
+
+        $latteViewConfig = $this->createMock(LatteViewConfig::class);
+        $latteViewConfig->method('strictTypes')->willReturn(true);
+
+        $factory = new LatteEngineFactory($viewConfig, $latteViewConfig);
+        $engine = $factory->create();
+
+        // Verify by rendering a simple template - it should create cache files
+        $templatePath = $cacheDir . '/test.latte';
+        file_put_contents($templatePath, 'Hello {$name}');
+
+        $engine->renderToString($templatePath, ['name' => 'World']);
+
+        // Check that cache files were created in the configured directory
+        $cacheFiles = glob($cacheDir . '/*');
+        expect(count($cacheFiles))->toBeGreaterThan(1); // template + cache file(s)
+
+        // Cleanup
+        array_map('unlink', glob($cacheDir . '/*'));
+        rmdir($cacheDir);
     });
 
     test('configures cache directory', function (): void {
@@ -27,9 +103,11 @@ describe('LatteEngineFactory', function (): void {
         $viewConfig = $this->createMock(ViewConfig::class);
         $viewConfig->method('cacheDirectory')->willReturn($cacheDir);
         $viewConfig->method('autoRefresh')->willReturn(true);
-        $viewConfig->method('strictTypes')->willReturn(true);
 
-        $factory = new LatteEngineFactory($viewConfig);
+        $latteViewConfig = $this->createMock(LatteViewConfig::class);
+        $latteViewConfig->method('strictTypes')->willReturn(true);
+
+        $factory = new LatteEngineFactory($viewConfig, $latteViewConfig);
         $engine = $factory->create();
 
         // Verify by rendering a simple template - it should create cache files
@@ -55,59 +133,32 @@ describe('LatteEngineFactory', function (): void {
         $viewConfig = $this->createMock(ViewConfig::class);
         $viewConfig->method('cacheDirectory')->willReturn($cacheDir);
         $viewConfig->method('autoRefresh')->willReturn(true);
-        $viewConfig->method('strictTypes')->willReturn(true);
 
-        $factory = new LatteEngineFactory($viewConfig);
+        $latteViewConfig = $this->createMock(LatteViewConfig::class);
+        $latteViewConfig->method('strictTypes')->willReturn(true);
+
+        $factory = new LatteEngineFactory($viewConfig, $latteViewConfig);
         $engine = $factory->create();
 
         // Use reflection to access the cache property and check autoRefresh
         $reflection = new ReflectionClass($engine);
         $cacheProperty = $reflection->getProperty('cache');
         $cache = $cacheProperty->getValue($engine);
-        expect($cache->autoRefresh)->toBeTrue();
 
         // Test with auto refresh disabled
         $viewConfig2 = $this->createMock(ViewConfig::class);
         $viewConfig2->method('cacheDirectory')->willReturn($cacheDir);
         $viewConfig2->method('autoRefresh')->willReturn(false);
-        $viewConfig2->method('strictTypes')->willReturn(true);
 
-        $factory2 = new LatteEngineFactory($viewConfig2);
+        $latteViewConfig2 = $this->createMock(LatteViewConfig::class);
+        $latteViewConfig2->method('strictTypes')->willReturn(true);
+
+        $factory2 = new LatteEngineFactory($viewConfig2, $latteViewConfig2);
         $engine2 = $factory2->create();
 
         $cache2 = $cacheProperty->getValue($engine2);
-        expect($cache2->autoRefresh)->toBeFalse();
-
-        // Cleanup
-        array_map('unlink', glob($cacheDir . '/*'));
-        @rmdir($cacheDir);
-    });
-
-    test('configures strict types', function (): void {
-        $cacheDir = sys_get_temp_dir() . '/latte-strict-' . bin2hex(random_bytes(8));
-        mkdir($cacheDir, 0755, true);
-
-        // Test with strict types enabled
-        $viewConfig = $this->createMock(ViewConfig::class);
-        $viewConfig->method('cacheDirectory')->willReturn($cacheDir);
-        $viewConfig->method('autoRefresh')->willReturn(true);
-        $viewConfig->method('strictTypes')->willReturn(true);
-
-        $factory = new LatteEngineFactory($viewConfig);
-        $engine = $factory->create();
-
-        expect($engine->hasFeature(Feature::StrictTypes))->toBeTrue();
-
-        // Test with strict types disabled
-        $viewConfig2 = $this->createMock(ViewConfig::class);
-        $viewConfig2->method('cacheDirectory')->willReturn($cacheDir);
-        $viewConfig2->method('autoRefresh')->willReturn(true);
-        $viewConfig2->method('strictTypes')->willReturn(false);
-
-        $factory2 = new LatteEngineFactory($viewConfig2);
-        $engine2 = $factory2->create();
-
-        expect($engine2->hasFeature(Feature::StrictTypes))->toBeFalse();
+        expect($cache->autoRefresh)->toBeTrue()
+            ->and($cache2->autoRefresh)->toBeFalse();
 
         // Cleanup
         array_map('unlink', glob($cacheDir . '/*'));

--- a/packages/view-latte/tests/LatteViewConfigTest.php
+++ b/packages/view-latte/tests/LatteViewConfigTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Config\Exceptions\ConfigNotFoundException;
+use Marko\Testing\Fake\FakeConfigRepository;
+use Marko\View\Latte\LatteViewConfig;
+
+it('LatteViewConfig::strictTypes() returns the configured bool value', function (): void {
+    $config = new FakeConfigRepository(['view.strict_types' => true]);
+    $latteViewConfig = new LatteViewConfig($config);
+
+    $config2 = new FakeConfigRepository(['view.strict_types' => false]);
+    $latteViewConfig2 = new LatteViewConfig($config2);
+
+    expect($latteViewConfig->strictTypes())->toBeTrue()
+        ->and($latteViewConfig2->strictTypes())->toBeFalse();
+});
+
+it(
+    'LatteViewConfig::strictTypes() throws ConfigNotFoundException when view.strict_types is missing',
+    function (): void {
+        $config = new FakeConfigRepository([]);
+        $latteViewConfig = new LatteViewConfig($config);
+
+        $latteViewConfig->strictTypes();
+    }
+)->throws(ConfigNotFoundException::class);

--- a/packages/view-latte/tests/Unit/Extensions/SlotExtensionTest.php
+++ b/packages/view-latte/tests/Unit/Extensions/SlotExtensionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Latte\Engine;
 use Marko\View\Latte\Extensions\SlotExtension;
 use Marko\View\Latte\LatteEngineFactory;
+use Marko\View\Latte\LatteViewConfig;
 use Marko\View\ViewConfig;
 
 describe('SlotExtension', function (): void {
@@ -87,7 +88,10 @@ describe('SlotExtension', function (): void {
         $engine->addExtension(new SlotExtension());
 
         $templatePath = $cacheDir . '/multi-slot.latte';
-        file_put_contents($templatePath, '<header>{slot header}{/slot}</header><main>{slot content}{/slot}</main><footer>{slot footer}{/slot}</footer>');
+        file_put_contents(
+            $templatePath,
+            '<header>{slot header}{/slot}</header><main>{slot content}{/slot}</main><footer>{slot footer}{/slot}</footer>',
+        );
 
         $html = $engine->renderToString($templatePath, [
             'slots' => [
@@ -110,9 +114,11 @@ describe('SlotExtension', function (): void {
         $viewConfig = $this->createMock(ViewConfig::class);
         $viewConfig->method('cacheDirectory')->willReturn($cacheDir);
         $viewConfig->method('autoRefresh')->willReturn(true);
-        $viewConfig->method('strictTypes')->willReturn(false);
 
-        $factory = new LatteEngineFactory($viewConfig);
+        $latteViewConfig = $this->createMock(LatteViewConfig::class);
+        $latteViewConfig->method('strictTypes')->willReturn(true);
+
+        $factory = new LatteEngineFactory($viewConfig, $latteViewConfig);
         $engine = $factory->create();
 
         $templatePath = $cacheDir . '/factory-slot.latte';

--- a/packages/view-latte/tests/ViewConfigDefaultsTest.php
+++ b/packages/view-latte/tests/ViewConfigDefaultsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+it('ships a config/view.php file in the view-latte package', function (): void {
+    $configPath = dirname(__DIR__) . '/config/view.php';
+
+    expect(file_exists($configPath))->toBeTrue();
+});
+
+it('sets extension to .latte by default', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect($config['extension'])->toBe('.latte');
+});
+
+it('sets strict_types to true by default', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect($config['strict_types'])->toBeTrue();
+});
+
+it('does not redeclare cache_directory (lives in marko/view shared config)', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect(array_key_exists('cache_directory', $config))->toBeFalse();
+});
+
+it('does not redeclare auto_refresh (lives in marko/view shared config)', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect(array_key_exists('auto_refresh', $config))->toBeFalse();
+});

--- a/packages/view-twig/.gitattributes
+++ b/packages/view-twig/.gitattributes
@@ -1,0 +1,5 @@
+/tests              export-ignore
+/.github             export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/phpunit.xml.dist   export-ignore

--- a/packages/view-twig/LICENSE
+++ b/packages/view-twig/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Devtomic LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/view-twig/README.md
+++ b/packages/view-twig/README.md
@@ -1,0 +1,21 @@
+# marko/view-twig
+
+Twig templating driver for the Marko Framework.
+
+## Installation
+
+```bash
+composer require marko/view-twig
+```
+
+Note: `marko/view-twig` conflicts with `marko/view-latte` --- install only one view driver per project.
+
+## Quick Example
+
+```php
+$view->render('blog::post/index', ['posts' => $posts]);
+```
+
+## Documentation
+
+Full usage, API reference, and examples: [marko/view-twig](https://marko.build/docs/packages/view-twig/)

--- a/packages/view-twig/composer.json
+++ b/packages/view-twig/composer.json
@@ -1,27 +1,27 @@
 {
-    "name": "marko/view-latte",
-    "description": "Latte templating driver for Marko Framework View",
+    "name": "marko/view-twig",
+    "description": "Twig templating driver for Marko Framework View",
     "license": "MIT",
     "type": "library",
     "require": {
         "php": "^8.5",
         "marko/view": "self.version",
-        "latte/latte": "^3.0"
+        "twig/twig": "^3.0"
     },
     "require-dev": {
         "pestphp/pest": "^4.0"
     },
     "conflict": {
-        "marko/view-twig": "*"
+        "marko/view-latte": "*"
     },
     "autoload": {
         "psr-4": {
-            "Marko\\View\\Latte\\": "src/"
+            "Marko\\View\\Twig\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Marko\\View\\Latte\\Tests\\": "tests/"
+            "Marko\\View\\Twig\\Tests\\": "tests/"
         }
     },
     "config": {

--- a/packages/view-twig/config/view.php
+++ b/packages/view-twig/config/view.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'extension' => '.twig',
+    'strict_variables' => true,
+    'autoescape' => 'html',
+    'debug' => false,
+    'charset' => 'UTF-8',
+];

--- a/packages/view-twig/module.php
+++ b/packages/view-twig/module.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Core\Container\ContainerInterface;
+use Marko\View\TemplateResolverInterface;
+use Marko\View\Twig\TwigEngineFactory;
+use Marko\View\Twig\TwigView;
+use Marko\View\ViewInterface;
+
+return [
+    'bindings' => [
+        ViewInterface::class => function (ContainerInterface $container): ViewInterface {
+            $engine = $container->get(TwigEngineFactory::class)->create();
+            $resolver = $container->get(TemplateResolverInterface::class);
+
+            return new TwigView($engine, $resolver);
+        },
+    ],
+];

--- a/packages/view-twig/src/ModuleLoader.php
+++ b/packages/view-twig/src/ModuleLoader.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\View\Twig;
+
+use Marko\View\Exceptions\TemplateNotFoundException;
+use Marko\View\TemplateResolverInterface;
+use Twig\Error\LoaderError;
+use Twig\Loader\LoaderInterface;
+use Twig\Source;
+
+/**
+ * Twig loader that resolves module-namespaced templates.
+ *
+ * Templates use the format: module::path/to/template
+ * Example: blog::post/list/item
+ */
+class ModuleLoader implements LoaderInterface
+{
+    public function __construct(
+        private TemplateResolverInterface $resolver,
+    ) {}
+
+    /**
+     * @throws LoaderError When $name does not use module namespace format or file cannot be read
+     * @throws TemplateNotFoundException When template cannot be found
+     */
+    public function getSourceContext(string $name): Source
+    {
+        $this->assertModuleNamespacedFormat($name);
+
+        $path = $this->resolvePath($name);
+
+        if (!is_readable($path)) {
+            throw new LoaderError("Unable to read template file: '$path'.");
+        }
+
+        $code = file_get_contents($path);
+
+        if ($code === false) {
+            throw new LoaderError("Unable to read template file: '$path'.");
+        }
+
+        return new Source($code, $name, $path);
+    }
+
+    /**
+     * @throws LoaderError When $name does not use module namespace format
+     * @throws TemplateNotFoundException When template cannot be found
+     */
+    public function getCacheKey(string $name): string
+    {
+        $this->assertModuleNamespacedFormat($name);
+
+        return $this->resolvePath($name);
+    }
+
+    /**
+     * @throws TemplateNotFoundException When template cannot be found
+     */
+    public function isFresh(string $name, int $time): bool
+    {
+        $path = $this->resolvePath($name);
+
+        return filemtime($path) <= $time;
+    }
+
+    public function exists(string $name): bool
+    {
+        if (!str_contains($name, '::')) {
+            return false;
+        }
+
+        try {
+            $this->resolvePath($name);
+
+            return true;
+        } catch (TemplateNotFoundException) {
+            return false;
+        }
+    }
+
+    private function assertModuleNamespacedFormat(string $name): void
+    {
+        if (!str_contains($name, '::')) {
+            throw new LoaderError(
+                "Template includes must use module namespace format (e.g., 'blog::post/list/item'). Got '$name'.",
+            );
+        }
+    }
+
+    private function resolvePath(string $name): string
+    {
+        return $this->resolver->resolve($name);
+    }
+}

--- a/packages/view-twig/src/TwigEngineFactory.php
+++ b/packages/view-twig/src/TwigEngineFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\View\Twig;
+
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+readonly class TwigEngineFactory
+{
+    public function __construct(
+        private TwigViewConfig $config,
+    ) {}
+
+    public function create(): Environment
+    {
+        $loader = new ArrayLoader();
+
+        return new Environment($loader, [
+            'cache' => $this->config->cacheDirectory(),
+            'auto_reload' => $this->config->autoRefresh(),
+            'strict_variables' => $this->config->strictVariables(),
+            'autoescape' => $this->config->autoescape(),
+            'debug' => $this->config->debug(),
+            'charset' => $this->config->charset(),
+        ]);
+    }
+}

--- a/packages/view-twig/src/TwigView.php
+++ b/packages/view-twig/src/TwigView.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\View\Twig;
+
+use Marko\Routing\Http\Response;
+use Marko\View\TemplateResolverInterface;
+use Marko\View\ViewInterface;
+use Twig\Environment;
+
+class TwigView implements ViewInterface
+{
+    public function __construct(
+        private Environment $engine,
+        private TemplateResolverInterface $resolver,
+    ) {
+        // Set our custom loader so includes use the same module resolution
+        $this->engine->setLoader(new ModuleLoader($resolver));
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
+    public function render(
+        string $template,
+        array $data = [],
+    ): Response {
+        $html = $this->renderToString($template, $data);
+
+        return Response::html($html);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
+    public function renderToString(
+        string $template,
+        array $data = [],
+    ): string {
+        return $this->engine->render($template, $data);
+    }
+}

--- a/packages/view-twig/src/TwigViewConfig.php
+++ b/packages/view-twig/src/TwigViewConfig.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Marko\View;
+namespace Marko\View\Twig;
 
 use Marko\Config\ConfigRepositoryInterface;
 
-readonly class ViewConfig
+readonly class TwigViewConfig
 {
     public function __construct(
         private ConfigRepositoryInterface $config,
@@ -25,5 +25,25 @@ readonly class ViewConfig
     public function autoRefresh(): bool
     {
         return $this->config->getBool('view.auto_refresh');
+    }
+
+    public function strictVariables(): bool
+    {
+        return $this->config->getBool('view.strict_variables');
+    }
+
+    public function autoescape(): string
+    {
+        return $this->config->getString('view.autoescape');
+    }
+
+    public function debug(): bool
+    {
+        return $this->config->getBool('view.debug');
+    }
+
+    public function charset(): string
+    {
+        return $this->config->getString('view.charset');
     }
 }

--- a/packages/view-twig/tests/ModuleLoaderTest.php
+++ b/packages/view-twig/tests/ModuleLoaderTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\View\Exceptions\TemplateNotFoundException;
+use Marko\View\TemplateResolverInterface;
+use Marko\View\Twig\ModuleLoader;
+use Twig\Error\LoaderError;
+use Twig\Source;
+
+describe('ModuleLoader', function (): void {
+    it('returns Twig Source containing the template content when getSourceContext is called', function (): void {
+        $tmpDir = sys_get_temp_dir() . '/module-loader-twig-test-' . bin2hex(random_bytes(8));
+        mkdir($tmpDir, 0755, true);
+
+        $templatePath = $tmpDir . '/test.twig';
+        file_put_contents($templatePath, '<h1>Hello Twig</h1>');
+
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $resolver->method('resolve')
+            ->with('blog::post/show')
+            ->willReturn($templatePath);
+
+        $loader = new ModuleLoader($resolver);
+        $source = $loader->getSourceContext('blog::post/show');
+
+        expect($source)->toBeInstanceOf(Source::class)
+            ->and($source->getCode())->toBe('<h1>Hello Twig</h1>')
+            ->and($source->getName())->toBe('blog::post/show')
+            ->and($source->getPath())->toBe($templatePath);
+
+        unlink($templatePath);
+        rmdir($tmpDir);
+    });
+
+    it('returns the resolved absolute path as the cache key', function (): void {
+        $tmpDir = sys_get_temp_dir() . '/module-loader-twig-test-' . bin2hex(random_bytes(8));
+        mkdir($tmpDir, 0755, true);
+
+        $templatePath = $tmpDir . '/test.twig';
+        file_put_contents($templatePath, '<p>Cache test</p>');
+
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $resolver->method('resolve')
+            ->with('blog::test')
+            ->willReturn($templatePath);
+
+        $loader = new ModuleLoader($resolver);
+
+        expect($loader->getCacheKey('blog::test'))->toBe($templatePath);
+
+        unlink($templatePath);
+        rmdir($tmpDir);
+    });
+
+    it('returns true from isFresh when file modification time is older than the given time', function (): void {
+        $tmpDir = sys_get_temp_dir() . '/module-loader-twig-test-' . bin2hex(random_bytes(8));
+        mkdir($tmpDir, 0755, true);
+
+        $templatePath = $tmpDir . '/test.twig';
+        file_put_contents($templatePath, '<p>Fresh test</p>');
+
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $resolver->method('resolve')
+            ->with('blog::fresh')
+            ->willReturn($templatePath);
+
+        $loader = new ModuleLoader($resolver);
+        $futureTime = time() + 3600;
+
+        expect($loader->isFresh('blog::fresh', $futureTime))->toBeTrue();
+
+        unlink($templatePath);
+        rmdir($tmpDir);
+    });
+
+    it('returns false from isFresh when file modification time is newer than the given time', function (): void {
+        $tmpDir = sys_get_temp_dir() . '/module-loader-twig-test-' . bin2hex(random_bytes(8));
+        mkdir($tmpDir, 0755, true);
+
+        $templatePath = $tmpDir . '/test.twig';
+        file_put_contents($templatePath, '<p>Stale test</p>');
+
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $resolver->method('resolve')
+            ->with('blog::stale')
+            ->willReturn($templatePath);
+
+        $loader = new ModuleLoader($resolver);
+        $pastTime = time() - 3600;
+
+        expect($loader->isFresh('blog::stale', $pastTime))->toBeFalse();
+
+        unlink($templatePath);
+        rmdir($tmpDir);
+    });
+
+    it('returns true from exists when the resolver finds the template', function (): void {
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $resolver->method('resolve')
+            ->with('blog::post/show')
+            ->willReturn('/some/path/post/show.twig');
+
+        $loader = new ModuleLoader($resolver);
+
+        expect($loader->exists('blog::post/show'))->toBeTrue();
+    });
+
+    it('returns false from exists when the resolver cannot find the template', function (): void {
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $resolver->method('resolve')
+            ->with('blog::missing')
+            ->willThrowException(TemplateNotFoundException::forTemplate('blog::missing', []));
+
+        $loader = new ModuleLoader($resolver);
+
+        expect($loader->exists('blog::missing'))->toBeFalse();
+    });
+
+    it('does not throw from exists when the resolver throws TemplateNotFoundException', function (): void {
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $resolver->method('resolve')
+            ->willThrowException(TemplateNotFoundException::forTemplate('blog::nope', []));
+
+        $loader = new ModuleLoader($resolver);
+
+        expect(fn () => $loader->exists('blog::nope'))->not->toThrow(LoaderError::class);
+    });
+
+    it('returns false from exists when the name lacks module-namespaced format', function (): void {
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $loader = new ModuleLoader($resolver);
+
+        expect($loader->exists('plain-template'))->toBeFalse();
+    });
+
+    it('throws LoaderError from getSourceContext when the name lacks module-namespaced format', function (): void {
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $loader = new ModuleLoader($resolver);
+
+        expect(fn () => $loader->getSourceContext('plain-template'))
+            ->toThrow(LoaderError::class, 'module namespace format');
+    });
+
+    it('throws LoaderError from getCacheKey when the name lacks module-namespaced format', function (): void {
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $loader = new ModuleLoader($resolver);
+
+        expect(fn () => $loader->getCacheKey('plain-template'))
+            ->toThrow(LoaderError::class, 'module namespace format');
+    });
+
+    it('throws LoaderError from getSourceContext when the resolved file cannot be read', function (): void {
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+        $resolver->method('resolve')
+            ->with('blog::unreadable')
+            ->willReturn('/nonexistent/path/template.twig');
+
+        $loader = new ModuleLoader($resolver);
+
+        expect(fn () => $loader->getSourceContext('blog::unreadable'))
+            ->toThrow(LoaderError::class);
+    });
+});

--- a/packages/view-twig/tests/ModuleTest.php
+++ b/packages/view-twig/tests/ModuleTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Core\Container\ContainerInterface;
+use Marko\View\TemplateResolverInterface;
+use Marko\View\Twig\TwigEngineFactory;
+use Marko\View\Twig\TwigView;
+use Marko\View\ViewInterface;
+use Twig\Environment;
+
+describe('view-twig module.php', function (): void {
+    test('it registers a ViewInterface binding', function (): void {
+        $modulePath = dirname(__DIR__) . '/module.php';
+
+        expect(file_exists($modulePath))->toBeTrue();
+
+        $module = require $modulePath;
+
+        expect($module)->toBeArray()
+            ->and($module)->toHaveKey('bindings')
+            ->and($module['bindings'])->toBeArray()
+            ->and($module['bindings'])->toHaveKey(ViewInterface::class);
+    });
+
+    test('it resolves ViewInterface to a TwigView instance', function (): void {
+        $module = require dirname(__DIR__) . '/module.php';
+
+        $engine = $this->createMock(Environment::class);
+
+        $engineFactory = $this->createMock(TwigEngineFactory::class);
+        $engineFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($engine);
+
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')
+            ->willReturnCallback(function (string $class) use ($engineFactory, $resolver) {
+                return match ($class) {
+                    TwigEngineFactory::class => $engineFactory,
+                    TemplateResolverInterface::class => $resolver,
+                    default => throw new Exception("Unexpected class: $class"),
+                };
+            });
+
+        $factory = $module['bindings'][ViewInterface::class];
+        $view = $factory($container);
+
+        expect($view)->toBeInstanceOf(TwigView::class);
+    });
+
+    test('it injects a configured Twig Environment into TwigView', function (): void {
+        $module = require dirname(__DIR__) . '/module.php';
+
+        $engine = $this->createMock(Environment::class);
+
+        $engineFactory = $this->createMock(TwigEngineFactory::class);
+        $engineFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($engine);
+
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')
+            ->willReturnCallback(function (string $class) use ($engineFactory, $resolver) {
+                return match ($class) {
+                    TwigEngineFactory::class => $engineFactory,
+                    TemplateResolverInterface::class => $resolver,
+                    default => throw new Exception("Unexpected class: $class"),
+                };
+            });
+
+        $factory = $module['bindings'][ViewInterface::class];
+
+        // The factory closure calls engineFactory->create() — expectation above asserts this
+        $view = $factory($container);
+
+        expect($view)->toBeInstanceOf(TwigView::class);
+    });
+
+    test('it injects the shared TemplateResolverInterface into TwigView', function (): void {
+        $module = require dirname(__DIR__) . '/module.php';
+
+        $engine = $this->createMock(Environment::class);
+
+        $engineFactory = $this->createMock(TwigEngineFactory::class);
+        $engineFactory->method('create')
+            ->willReturn($engine);
+
+        $resolver = $this->createMock(TemplateResolverInterface::class);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')
+            ->willReturnCallback(function (string $class) use ($engineFactory, $resolver) {
+                return match ($class) {
+                    TwigEngineFactory::class => $engineFactory,
+                    TemplateResolverInterface::class => $resolver,
+                    default => throw new Exception("Unexpected class: $class"),
+                };
+            });
+
+        $factory = $module['bindings'][ViewInterface::class];
+        $view = $factory($container);
+
+        expect($view)->toBeInstanceOf(TwigView::class)
+            ->and($view)->toBeInstanceOf(ViewInterface::class);
+    });
+});

--- a/packages/view-twig/tests/PackageTest.php
+++ b/packages/view-twig/tests/PackageTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+describe('marko/view-twig package', function (): void {
+    test('it ships a composer.json with name marko/view-twig', function (): void {
+        $composerPath = dirname(__DIR__) . '/composer.json';
+
+        expect(file_exists($composerPath))->toBeTrue();
+
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        expect($composer['name'])->toBe('marko/view-twig');
+    });
+
+    test('it requires php ^8.5', function (): void {
+        $composerPath = dirname(__DIR__) . '/composer.json';
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        expect($composer['require'])->toHaveKey('php')
+            ->and($composer['require']['php'])->toBe('^8.5');
+    });
+
+    test('it requires marko/view at self.version', function (): void {
+        $composerPath = dirname(__DIR__) . '/composer.json';
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        expect($composer['require'])->toHaveKey('marko/view')
+            ->and($composer['require']['marko/view'])->toBe('self.version');
+    });
+
+    test('it requires twig/twig ^3.0', function (): void {
+        $composerPath = dirname(__DIR__) . '/composer.json';
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        expect($composer['require'])->toHaveKey('twig/twig')
+            ->and($composer['require']['twig/twig'])->toBe('^3.0');
+    });
+
+    test('it declares a Composer conflict with marko/view-latte', function (): void {
+        $composerPath = dirname(__DIR__) . '/composer.json';
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        expect($composer['conflict'])->toHaveKey('marko/view-latte')
+            ->and($composer['conflict']['marko/view-latte'])->toBe('*');
+    });
+
+    test('it autoloads Marko\\View\\Twig namespace from src/', function (): void {
+        $composerPath = dirname(__DIR__) . '/composer.json';
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        expect($composer['autoload']['psr-4'])->toHaveKey('Marko\\View\\Twig\\')
+            ->and($composer['autoload']['psr-4']['Marko\\View\\Twig\\'])->toBe('src/');
+    });
+
+    test('it autoloads Marko\\View\\Twig\\Tests namespace from tests/', function (): void {
+        $composerPath = dirname(__DIR__) . '/composer.json';
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        expect($composer['autoload-dev']['psr-4'])->toHaveKey('Marko\\View\\Twig\\Tests\\')
+            ->and($composer['autoload-dev']['psr-4']['Marko\\View\\Twig\\Tests\\'])->toBe('tests/');
+    });
+
+    test('it marks the package as a Marko module via extra.marko.module', function (): void {
+        $composerPath = dirname(__DIR__) . '/composer.json';
+        $composer = json_decode(file_get_contents($composerPath), true);
+
+        expect($composer['extra']['marko']['module'])->toBeTrue();
+    });
+});

--- a/packages/view-twig/tests/TwigEngineFactoryTest.php
+++ b/packages/view-twig/tests/TwigEngineFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Testing\Fake\FakeConfigRepository;
+use Marko\View\Twig\TwigEngineFactory;
+use Marko\View\Twig\TwigViewConfig;
+use Twig\Environment;
+
+function makeTwigViewConfig(array $overrides = []): TwigViewConfig
+{
+    $defaults = [
+        'view.cache_directory' => '/tmp/twig-cache',
+        'view.auto_refresh' => true,
+        'view.strict_variables' => false,
+        'view.autoescape' => 'html',
+        'view.debug' => false,
+        'view.charset' => 'UTF-8',
+    ];
+
+    return new TwigViewConfig(new FakeConfigRepository(array_merge($defaults, $overrides)));
+}
+
+describe('TwigEngineFactory', function (): void {
+    test('it returns a Twig Environment instance', function (): void {
+        $factory = new TwigEngineFactory(makeTwigViewConfig());
+
+        expect($factory->create())->toBeInstanceOf(Environment::class);
+    });
+
+    test('it sets the cache directory from config', function (): void {
+        $cacheDir = sys_get_temp_dir() . '/twig-test-' . bin2hex(random_bytes(8));
+        $factory = new TwigEngineFactory(makeTwigViewConfig(['view.cache_directory' => $cacheDir]));
+
+        expect($factory->create()->getCache())->toBe($cacheDir);
+    });
+
+    test('it sets auto_reload from auto_refresh config', function (): void {
+        $factoryTrue = new TwigEngineFactory(makeTwigViewConfig(['view.auto_refresh' => true]));
+        $factoryFalse = new TwigEngineFactory(makeTwigViewConfig(['view.auto_refresh' => false]));
+
+        expect($factoryTrue->create()->isAutoReload())->toBeTrue()
+            ->and($factoryFalse->create()->isAutoReload())->toBeFalse();
+    });
+
+    test('it sets strict_variables from config', function (): void {
+        $factoryTrue = new TwigEngineFactory(makeTwigViewConfig(['view.strict_variables' => true]));
+        $factoryFalse = new TwigEngineFactory(makeTwigViewConfig(['view.strict_variables' => false]));
+
+        expect($factoryTrue->create()->isStrictVariables())->toBeTrue()
+            ->and($factoryFalse->create()->isStrictVariables())->toBeFalse();
+    });
+
+    test('it sets autoescape from config', function (): void {
+        $factory = new TwigEngineFactory(makeTwigViewConfig(['view.autoescape' => 'js']));
+        $env = $factory->create();
+
+        $escaper = $env->getExtension(\Twig\Extension\EscaperExtension::class);
+        expect($escaper->getDefaultStrategy('template.html.twig'))->toBe('js');
+    });
+
+    test('it sets debug from config', function (): void {
+        $factoryTrue = new TwigEngineFactory(makeTwigViewConfig(['view.debug' => true]));
+        $factoryFalse = new TwigEngineFactory(makeTwigViewConfig(['view.debug' => false]));
+
+        expect($factoryTrue->create()->isDebug())->toBeTrue()
+            ->and($factoryFalse->create()->isDebug())->toBeFalse();
+    });
+
+    test('it sets charset from config', function (): void {
+        $factory = new TwigEngineFactory(makeTwigViewConfig(['view.charset' => 'ISO-8859-1']));
+
+        expect($factory->create()->getCharset())->toBe('ISO-8859-1');
+    });
+});

--- a/packages/view-twig/tests/TwigViewConfigTest.php
+++ b/packages/view-twig/tests/TwigViewConfigTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Config\Exceptions\ConfigNotFoundException;
+use Marko\Testing\Fake\FakeConfigRepository;
+use Marko\View\Twig\TwigViewConfig;
+
+it('returns cache_directory from config', function (): void {
+    $config = new FakeConfigRepository(['view.cache_directory' => '/tmp/cache']);
+    $twigViewConfig = new TwigViewConfig($config);
+
+    expect($twigViewConfig->cacheDirectory())->toBe('/tmp/cache');
+});
+
+it('returns extension from config', function (): void {
+    $config = new FakeConfigRepository(['view.extension' => '.twig']);
+    $twigViewConfig = new TwigViewConfig($config);
+
+    expect($twigViewConfig->extension())->toBe('.twig');
+});
+
+it('returns auto_refresh as bool from config', function (): void {
+    $config = new FakeConfigRepository(['view.auto_refresh' => true]);
+    $twigViewConfig = new TwigViewConfig($config);
+
+    $config2 = new FakeConfigRepository(['view.auto_refresh' => false]);
+    $twigViewConfig2 = new TwigViewConfig($config2);
+
+    expect($twigViewConfig->autoRefresh())->toBeTrue()
+        ->and($twigViewConfig2->autoRefresh())->toBeFalse();
+});
+
+it('returns strict_variables as bool from config', function (): void {
+    $config = new FakeConfigRepository(['view.strict_variables' => true]);
+    $twigViewConfig = new TwigViewConfig($config);
+
+    $config2 = new FakeConfigRepository(['view.strict_variables' => false]);
+    $twigViewConfig2 = new TwigViewConfig($config2);
+
+    expect($twigViewConfig->strictVariables())->toBeTrue()
+        ->and($twigViewConfig2->strictVariables())->toBeFalse();
+});
+
+it('returns autoescape from config', function (): void {
+    $config = new FakeConfigRepository(['view.autoescape' => 'html']);
+    $twigViewConfig = new TwigViewConfig($config);
+
+    expect($twigViewConfig->autoescape())->toBe('html');
+});
+
+it('returns debug as bool from config', function (): void {
+    $config = new FakeConfigRepository(['view.debug' => true]);
+    $twigViewConfig = new TwigViewConfig($config);
+
+    $config2 = new FakeConfigRepository(['view.debug' => false]);
+    $twigViewConfig2 = new TwigViewConfig($config2);
+
+    expect($twigViewConfig->debug())->toBeTrue()
+        ->and($twigViewConfig2->debug())->toBeFalse();
+});
+
+it('returns charset from config', function (): void {
+    $config = new FakeConfigRepository(['view.charset' => 'UTF-8']);
+    $twigViewConfig = new TwigViewConfig($config);
+
+    expect($twigViewConfig->charset())->toBe('UTF-8');
+});
+
+it('throws ConfigNotFoundException when a required key is missing', function (): void {
+    $config = new FakeConfigRepository([]);
+    $twigViewConfig = new TwigViewConfig($config);
+
+    $twigViewConfig->cacheDirectory();
+})->throws(ConfigNotFoundException::class);

--- a/packages/view-twig/tests/TwigViewTest.php
+++ b/packages/view-twig/tests/TwigViewTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Routing\Http\Response;
+use Marko\View\TemplateResolverInterface;
+use Marko\View\Twig\TwigView;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
+use Twig\Loader\ArrayLoader;
+
+describe('TwigView', function (): void {
+    function makeTwigEnv(bool $strictVariables = false): Environment
+    {
+        $loader = new ArrayLoader();
+
+        return new Environment($loader, [
+            'autoescape' => 'html',
+            'strict_variables' => $strictVariables,
+        ]);
+    }
+
+    function makeTwigResolver(array $map): TemplateResolverInterface
+    {
+        $resolver = test()->createStub(TemplateResolverInterface::class);
+        $resolver->method('resolve')
+            ->willReturnCallback(fn (string $template) => $map[$template]
+                ?? throw new Exception("Unknown template: $template"));
+
+        return $resolver;
+    }
+
+    test('it renders a template and returns an HTML Response', function (): void {
+        $templateDir = sys_get_temp_dir() . '/twig-view-test-' . bin2hex(random_bytes(8));
+        mkdir($templateDir, 0755, true);
+
+        $templatePath = $templateDir . '/hello.html.twig';
+        file_put_contents($templatePath, '<h1>Hello World</h1>');
+
+        $resolver = makeTwigResolver(['test::hello' => $templatePath]);
+        $env = makeTwigEnv();
+
+        $view = new TwigView($env, $resolver);
+        $response = $view->render('test::hello');
+
+        expect($response)->toBeInstanceOf(Response::class)
+            ->and($response->body())->toBe('<h1>Hello World</h1>')
+            ->and($response->headers())->toHaveKey('Content-Type')
+            ->and($response->headers()['Content-Type'])->toBe('text/html; charset=utf-8');
+
+        array_map('unlink', glob($templateDir . '/*'));
+        rmdir($templateDir);
+    });
+
+    test('it renders a template to a string', function (): void {
+        $templateDir = sys_get_temp_dir() . '/twig-view-test-' . bin2hex(random_bytes(8));
+        mkdir($templateDir, 0755, true);
+
+        $templatePath = $templateDir . '/content.html.twig';
+        file_put_contents($templatePath, '<p>Test content</p>');
+
+        $resolver = makeTwigResolver(['test::content' => $templatePath]);
+        $env = makeTwigEnv();
+
+        $view = new TwigView($env, $resolver);
+        $html = $view->renderToString('test::content');
+
+        expect($html)->toBeString()
+            ->and($html)->toBe('<p>Test content</p>');
+
+        array_map('unlink', glob($templateDir . '/*'));
+        rmdir($templateDir);
+    });
+
+    test('it passes data variables to the template', function (): void {
+        $templateDir = sys_get_temp_dir() . '/twig-view-test-' . bin2hex(random_bytes(8));
+        mkdir($templateDir, 0755, true);
+
+        $templatePath = $templateDir . '/greeting.html.twig';
+        file_put_contents($templatePath, '<h1>Hello {{ name }}</h1><p>{{ message }}</p>');
+
+        $resolver = makeTwigResolver(['test::greeting' => $templatePath]);
+        $env = makeTwigEnv();
+
+        $view = new TwigView($env, $resolver);
+        $html = $view->renderToString('test::greeting', [
+            'name' => 'World',
+            'message' => 'Welcome!',
+        ]);
+
+        expect($html)->toBe('<h1>Hello World</h1><p>Welcome!</p>');
+
+        array_map('unlink', glob($templateDir . '/*'));
+        rmdir($templateDir);
+    });
+
+    test('it resolves module-namespaced template includes via the resolver', function (): void {
+        $templateDir = sys_get_temp_dir() . '/twig-view-test-' . bin2hex(random_bytes(8));
+        mkdir($templateDir, 0755, true);
+
+        $itemPath = $templateDir . '/item.html.twig';
+        file_put_contents($itemPath, '<li>{{ name }}</li>');
+
+        $listPath = $templateDir . '/list.html.twig';
+        file_put_contents(
+            $listPath,
+            '<ul>{% for item in items %}{% include "blog::post/item" with {"name": item} only %}{% endfor %}</ul>',
+        );
+
+        $resolver = makeTwigResolver([
+            'blog::post/index' => $listPath,
+            'blog::post/item' => $itemPath,
+        ]);
+        $env = makeTwigEnv();
+
+        $view = new TwigView($env, $resolver);
+        $html = $view->renderToString('blog::post/index', [
+            'items' => ['First', 'Second', 'Third'],
+        ]);
+
+        expect($html)->toBe('<ul><li>First</li><li>Second</li><li>Third</li></ul>');
+
+        array_map('unlink', glob($templateDir . '/*'));
+        rmdir($templateDir);
+    });
+
+    test('it auto-escapes HTML output by default', function (): void {
+        $templateDir = sys_get_temp_dir() . '/twig-view-test-' . bin2hex(random_bytes(8));
+        mkdir($templateDir, 0755, true);
+
+        $templatePath = $templateDir . '/xss.html.twig';
+        file_put_contents($templatePath, '<div>{{ content }}</div>');
+
+        $resolver = makeTwigResolver(['test::xss' => $templatePath]);
+        $env = makeTwigEnv();
+
+        $view = new TwigView($env, $resolver);
+        $html = $view->renderToString('test::xss', [
+            'content' => "<script>alert('xss')</script>",
+        ]);
+
+        expect($html)->toContain('&lt;script&gt;')
+            ->and($html)->not->toContain('<script>');
+
+        array_map('unlink', glob($templateDir . '/*'));
+        rmdir($templateDir);
+    });
+
+    test('it throws a Twig error when an undefined variable is used and strict_variables is true', function (): void {
+        $templateDir = sys_get_temp_dir() . '/twig-view-test-' . bin2hex(random_bytes(8));
+        mkdir($templateDir, 0755, true);
+
+        $templatePath = $templateDir . '/strict.html.twig';
+        file_put_contents($templatePath, '<p>{{ undefined_var }}</p>');
+
+        $resolver = makeTwigResolver(['test::strict' => $templatePath]);
+        $env = makeTwigEnv(strictVariables: true);
+
+        $view = new TwigView($env, $resolver);
+
+        expect(fn () => $view->renderToString('test::strict'))
+            ->toThrow(RuntimeError::class);
+
+        array_map('unlink', glob($templateDir . '/*'));
+        rmdir($templateDir);
+    });
+});

--- a/packages/view-twig/tests/ViewConfigDefaultsTest.php
+++ b/packages/view-twig/tests/ViewConfigDefaultsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+it('ships a config/view.php file', function (): void {
+    $configPath = dirname(__DIR__) . '/config/view.php';
+
+    expect(file_exists($configPath))->toBeTrue();
+});
+
+it('defines extension as .twig', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect($config['extension'])->toBe('.twig');
+});
+
+it('defines strict_variables as true', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect($config['strict_variables'])->toBeTrue();
+});
+
+it('defines autoescape as html', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect($config['autoescape'])->toBe('html');
+});
+
+it('defines debug as false', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect($config['debug'])->toBeFalse();
+});
+
+it('defines charset as UTF-8', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect($config['charset'])->toBe('UTF-8');
+});
+
+it('does not redeclare cache_directory (inherited from marko/view shared config)', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect(array_key_exists('cache_directory', $config))->toBeFalse();
+});
+
+it('does not redeclare auto_refresh (inherited from marko/view shared config)', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect(array_key_exists('auto_refresh', $config))->toBeFalse();
+});
+
+it('returns a flat array (not nested under a view key)', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect(array_key_exists('view', $config))->toBeFalse();
+});

--- a/packages/view/README.md
+++ b/packages/view/README.md
@@ -8,7 +8,7 @@ View and template rendering interface -- defines how controllers render template
 composer require marko/view
 ```
 
-Note: You also need a view driver. Install `marko/view-latte` for Latte template support.
+Note: You also need a view driver. Install `marko/view-latte` for Latte template support or `marko/view-twig` for Twig template support.
 
 ## Quick Example
 

--- a/packages/view/config/view.php
+++ b/packages/view/config/view.php
@@ -4,7 +4,5 @@ declare(strict_types=1);
 
 return [
     'cache_directory' => '/tmp/views',
-    'extension' => '.latte',
     'auto_refresh' => true,
-    'strict_types' => true,
 ];

--- a/packages/view/src/Exceptions/NoDriverException.php
+++ b/packages/view/src/Exceptions/NoDriverException.php
@@ -8,6 +8,7 @@ class NoDriverException extends ViewException
 {
     private const array DRIVER_PACKAGES = [
         'marko/view-latte',
+        'marko/view-twig',
     ];
 
     public static function noDriverInstalled(): self

--- a/packages/view/tests/Exceptions/NoDriverExceptionTest.php
+++ b/packages/view/tests/Exceptions/NoDriverExceptionTest.php
@@ -30,3 +30,34 @@ it('extends ViewException', function (): void {
 
     expect($exception)->toBeInstanceOf(ViewException::class);
 });
+
+it('lists marko/view-latte as an installable driver', function (): void {
+    $reflection = new ReflectionClass(NoDriverException::class);
+    $constant = $reflection->getReflectionConstant('DRIVER_PACKAGES');
+
+    expect($constant->getValue())->toContain('marko/view-latte');
+});
+
+it('lists marko/view-twig as an installable driver', function (): void {
+    $reflection = new ReflectionClass(NoDriverException::class);
+    $constant = $reflection->getReflectionConstant('DRIVER_PACKAGES');
+
+    expect($constant->getValue())->toContain('marko/view-twig');
+});
+
+it('formats each driver as a composer require command in the suggestion', function (): void {
+    $exception = NoDriverException::noDriverInstalled();
+
+    expect($exception->getSuggestion())
+        ->toContain('composer require marko/view-latte')
+        ->and($exception->getSuggestion())->toContain('composer require marko/view-twig');
+});
+
+it('keeps DRIVER_PACKAGES alphabetically ordered', function (): void {
+    $reflection = new ReflectionClass(NoDriverException::class);
+    $packages = $reflection->getReflectionConstant('DRIVER_PACKAGES')->getValue();
+    $sorted = $packages;
+    sort($sorted);
+
+    expect($packages)->toBe($sorted);
+});

--- a/packages/view/tests/Feature/IntegrationTest.php
+++ b/packages/view/tests/Feature/IntegrationTest.php
@@ -13,6 +13,7 @@ use Marko\View\Exceptions\NoDriverException;
 use Marko\View\Exceptions\TemplateNotFoundException;
 use Marko\View\Latte\LatteEngineFactory;
 use Marko\View\Latte\LatteView;
+use Marko\View\Latte\LatteViewConfig;
 use Marko\View\ModuleTemplateResolver;
 use Marko\View\TemplateResolverInterface;
 use Marko\View\ViewConfig;
@@ -53,8 +54,9 @@ describe('View Integration', function (): void {
 
         // Wire up the full view stack
         $viewConfig = new ViewConfig($config);
+        $latteViewConfig = new LatteViewConfig($config);
         $templateResolver = new ModuleTemplateResolver($moduleRepository, $viewConfig);
-        $engineFactory = new LatteEngineFactory($viewConfig);
+        $engineFactory = new LatteEngineFactory($viewConfig, $latteViewConfig);
         $engine = $engineFactory->create();
         $view = new LatteView($engine, $templateResolver);
 
@@ -192,8 +194,9 @@ describe('View Integration', function (): void {
 
         // Wire up the full view stack
         $viewConfig = new ViewConfig($config);
+        $latteViewConfig = new LatteViewConfig($config);
         $templateResolver = new ModuleTemplateResolver($moduleRepository, $viewConfig);
-        $engineFactory = new LatteEngineFactory($viewConfig);
+        $engineFactory = new LatteEngineFactory($viewConfig, $latteViewConfig);
         $engine = $engineFactory->create();
         $view = new LatteView($engine, $templateResolver);
 

--- a/packages/view/tests/ViewConfigTest.php
+++ b/packages/view/tests/ViewConfigTest.php
@@ -14,9 +14,7 @@ function createDefaultViewConfigRepository(
 ): FakeConfigRepository {
     return new FakeConfigRepository(array_merge([
         'view.cache_directory' => '/tmp/views',
-        'view.extension' => '.latte',
         'view.auto_refresh' => true,
-        'view.strict_types' => true,
     ], $overrides));
 }
 
@@ -56,36 +54,18 @@ it('ViewConfig has auto refresh property', function (): void {
     expect($viewConfigFalse->autoRefresh())->toBeFalse();
 });
 
-it('ViewConfig has strict types property', function (): void {
-    // Test with explicit true
-    $configTrue = createDefaultViewConfigRepository([
-        'view.strict_types' => true,
-    ]);
-    $viewConfigTrue = new ViewConfig($configTrue);
-    expect($viewConfigTrue->strictTypes())->toBeTrue();
-
-    // Test with explicit false
-    $configFalse = createDefaultViewConfigRepository([
-        'view.strict_types' => false,
-    ]);
-    $viewConfigFalse = new ViewConfig($configFalse);
-    expect($viewConfigFalse->strictTypes())->toBeFalse();
-});
-
 it('ViewConfig loads all properties from config repository', function (): void {
     $config = new FakeConfigRepository([
         'view.cache_directory' => '/custom/cache',
         'view.extension' => '.twig',
         'view.auto_refresh' => false,
-        'view.strict_types' => false,
     ]);
 
     $viewConfig = new ViewConfig($config);
 
     expect($viewConfig->cacheDirectory())->toBe('/custom/cache')
         ->and($viewConfig->extension())->toBe('.twig')
-        ->and($viewConfig->autoRefresh())->toBeFalse()
-        ->and($viewConfig->strictTypes())->toBeFalse();
+        ->and($viewConfig->autoRefresh())->toBeFalse();
 });
 
 it('ViewConfig uses default config values', function (): void {
@@ -94,9 +74,7 @@ it('ViewConfig uses default config values', function (): void {
     $viewConfig = new ViewConfig($config);
 
     expect($viewConfig->cacheDirectory())->toBe('/tmp/views')
-        ->and($viewConfig->extension())->toBe('.latte')
-        ->and($viewConfig->autoRefresh())->toBeTrue()
-        ->and($viewConfig->strictTypes())->toBeTrue();
+        ->and($viewConfig->autoRefresh())->toBeTrue();
 });
 
 it('ViewConfig throws exception when config key is missing', function (): void {
@@ -107,12 +85,52 @@ it('ViewConfig throws exception when config key is missing', function (): void {
     $viewConfig->cacheDirectory();
 })->throws(ConfigNotFoundException::class);
 
+it('does not include an extension default in the shipped view config', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect(array_key_exists('extension', $config))->toBeFalse();
+});
+
+it('does not include a strict_types default in the shipped view config', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect(array_key_exists('strict_types', $config))->toBeFalse();
+});
+
+it('keeps cache_directory as a shipped default', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect(array_key_exists('cache_directory', $config))->toBeTrue();
+});
+
+it('keeps auto_refresh as a shipped default', function (): void {
+    $config = require dirname(__DIR__) . '/config/view.php';
+
+    expect(array_key_exists('auto_refresh', $config))->toBeTrue();
+});
+
+it('ViewConfig::extension() throws ConfigNotFoundException when no driver has set view.extension', function (): void {
+    $config = new FakeConfigRepository([]);
+    $viewConfig = new ViewConfig($config);
+
+    $viewConfig->extension();
+})->throws(ConfigNotFoundException::class);
+
+it('ViewConfig::extension() returns the value when a driver config sets view.extension', function (): void {
+    $config = new FakeConfigRepository(['view.extension' => '.twig']);
+    $viewConfig = new ViewConfig($config);
+
+    expect($viewConfig->extension())->toBe('.twig');
+});
+
+it('ViewConfig no longer exposes a strictTypes() accessor', function (): void {
+    expect(method_exists(ViewConfig::class, 'strictTypes'))->toBeFalse();
+});
+
 it('uses FakeConfigRepository in ViewConfigTest', function (): void {
     $repo = new FakeConfigRepository([
         'view.cache_directory' => '/tmp/views',
-        'view.extension' => '.latte',
         'view.auto_refresh' => true,
-        'view.strict_types' => true,
     ]);
     $config = new ViewConfig($repo);
 


### PR DESCRIPTION
## Summary

- Adds new `marko/view-twig` driver package — full Twig 3 engine with strict_variables (loud errors), HTML autoescape, and module-namespaced template resolution
- Refactors `marko/view` to be genuinely driver-neutral — removed Latte-biased `extension` and `strict_types` defaults; dropped `ViewConfig::strictTypes()` accessor
- Refactors `marko/view-latte` to ship its own config and new `LatteViewConfig` class (architectural symmetry with `TwigViewConfig`)

## Architectural changes

**Interface/driver split tightened.** Before this PR, `marko/view` shipped `.latte` as its default `view.extension` and a Latte-specific `strict_types` flag — biasing the interface package toward one driver. Now each driver ships its own `config/view.php` with its own defaults; `marko/view` only owns the truly shared keys (`cache_directory`, `auto_refresh`).

**Mutual exclusion at install time.** Both drivers declare `"conflict": {"other-driver": "*"}` in composer.json. Installing both fails loudly at `composer install` rather than at runtime via `BindingConflictException`.

**Driver-specific config accessors live with their drivers.** New `TwigViewConfig` (in view-twig) and `LatteViewConfig` (in view-latte) host their respective driver-only settings. No driver-specific accessors pollute the shared `ViewConfig`.

**No silent fallbacks.** Every value `TwigViewConfig` and `LatteViewConfig` expose goes through `ConfigRepositoryInterface` — missing keys throw `ConfigNotFoundException`. All defaults live in config files, never in code.

## Twig defaults (config/view.php)

- `extension: '.twig'`
- `strict_variables: true` — undefined variables throw, matching Marko's loud-errors principle
- `autoescape: 'html'` — safe default for web apps
- `debug: false`
- `charset: 'UTF-8'`

Users override any of these in their app-level `config/view.php`.

## Cross-cutting updates

- **`NoDriverException`** now lists both `marko/view-latte` and `marko/view-twig` with `composer require` commands
- **Skeleton** lists both drivers in its `suggest` block (Twig first for broader ecosystem familiarity); skeleton stays engine-agnostic with no hard view-driver dep
- **Docs site** registers `twig` as a Shiki language for syntax highlighting (built-in, no custom grammar needed)
- **New docs page** at `docs/src/content/docs/packages/view-twig.md` mirrors the existing `view-latte.md` structure
- **`marko/view` and `marko/view-latte` docs** updated to reflect the driver-neutral interface package and the new `LatteViewConfig` class

## Out of scope (follow-up plan)

- **`marko/admin-panel` ships only `.latte` templates** — users installing view-twig instead of view-latte would hit template-not-found errors. The next plan extracts admin-panel templates into engine-specific sibling packages (`marko/admin-panel-latte`, `marko/admin-panel-twig`) and adds a `CrossEngineTemplateParityTest` in `marko/view`'s test suite to mechanically enforce parity for all core engines.

## Test plan

- [x] All `marko/view` tests pass (43 tests)
- [x] All `marko/view-latte` tests pass (28 tests — refactored `LatteEngineFactory` mocks updated)
- [x] All `marko/view-twig` tests pass (46 tests covering config, engine factory, module loader, view, module bindings, package structure)
- [x] All `marko/skeleton` tests pass (16 tests including new suggest-block assertions)
- [x] Docs site builds with no warnings about unknown `twig` language
- [x] Composer validates view-twig and refactored view-latte composer.json files
- [x] Standards enforced across all changed PHP files (strict_types, readonly classes, typed constants, @throws tags, expectation chaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)