### PR TITLE
refactor(view): align ViewInterface bindings with Marko's simple-binding preference

### DIFF
--- a/packages/view-latte/module.php
+++ b/packages/view-latte/module.php
@@ -2,19 +2,17 @@
 
 declare(strict_types=1);
 
+use Latte\Engine;
 use Marko\Core\Container\ContainerInterface;
 use Marko\View\Latte\LatteEngineFactory;
 use Marko\View\Latte\LatteView;
-use Marko\View\TemplateResolverInterface;
 use Marko\View\ViewInterface;
 
 return [
     'bindings' => [
-        ViewInterface::class => function (ContainerInterface $container): ViewInterface {
-            $engine = $container->get(LatteEngineFactory::class)->create();
-            $resolver = $container->get(TemplateResolverInterface::class);
-
-            return new LatteView($engine, $resolver);
+        ViewInterface::class => LatteView::class,
+        Engine::class => function (ContainerInterface $container): Engine {
+            return $container->get(LatteEngineFactory::class)->create();
         },
     ],
 ];

--- a/packages/view-latte/tests/ModuleTest.php
+++ b/packages/view-latte/tests/ModuleTest.php
@@ -6,11 +6,10 @@ use Latte\Engine;
 use Marko\Core\Container\ContainerInterface;
 use Marko\View\Latte\LatteEngineFactory;
 use Marko\View\Latte\LatteView;
-use Marko\View\TemplateResolverInterface;
 use Marko\View\ViewInterface;
 
 describe('view-latte module.php', function (): void {
-    test('module.php exists with correct structure', function (): void {
+    test('it has a bindings array', function (): void {
         $modulePath = dirname(__DIR__) . '/module.php';
 
         expect(file_exists($modulePath))->toBeTrue();
@@ -22,43 +21,40 @@ describe('view-latte module.php', function (): void {
             ->and($module['bindings'])->toBeArray();
     });
 
-    test('module.php binds ViewInterface via factory', function (): void {
+    test('it binds ViewInterface to LatteView as a simple class mapping', function (): void {
         $module = require dirname(__DIR__) . '/module.php';
 
         expect($module['bindings'])->toHaveKey(ViewInterface::class)
-            ->and($module['bindings'][ViewInterface::class])->toBeInstanceOf(Closure::class);
+            ->and($module['bindings'][ViewInterface::class])->toBe(LatteView::class);
     });
 
-    test('module.php uses LatteEngineFactory', function (): void {
+    test('it binds Latte Engine via a closure that calls LatteEngineFactory', function (): void {
         $module = require dirname(__DIR__) . '/module.php';
 
-        // Mock the engine from factory
+        expect($module['bindings'])->toHaveKey(Engine::class)
+            ->and($module['bindings'][Engine::class])->toBeInstanceOf(Closure::class);
+    });
+
+    test('the Engine closure resolves the engine via LatteEngineFactory::create()', function (): void {
+        $module = require dirname(__DIR__) . '/module.php';
+
         $engine = $this->createMock(Engine::class);
 
-        // Mock the LatteEngineFactory
         $engineFactory = $this->createMock(LatteEngineFactory::class);
         $engineFactory->expects($this->once())
             ->method('create')
             ->willReturn($engine);
 
-        // Mock the TemplateResolverInterface
-        $resolver = $this->createMock(TemplateResolverInterface::class);
-
-        // Mock the container
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')
-            ->willReturnCallback(function (string $class) use ($engineFactory, $resolver) {
-                return match ($class) {
-                    LatteEngineFactory::class => $engineFactory,
-                    TemplateResolverInterface::class => $resolver,
-                    default => throw new Exception("Unexpected class: $class"),
-                };
+            ->willReturnCallback(fn (string $class) => match ($class) {
+                LatteEngineFactory::class => $engineFactory,
+                default => throw new Exception("Unexpected class: $class"),
             });
 
-        // Call the factory closure
-        $factory = $module['bindings'][ViewInterface::class];
-        $view = $factory($container);
+        $closure = $module['bindings'][Engine::class];
+        $result = $closure($container);
 
-        expect($view)->toBeInstanceOf(LatteView::class);
+        expect($result)->toBe($engine);
     });
 });

--- a/packages/view-twig/module.php
+++ b/packages/view-twig/module.php
@@ -3,18 +3,16 @@
 declare(strict_types=1);
 
 use Marko\Core\Container\ContainerInterface;
-use Marko\View\TemplateResolverInterface;
 use Marko\View\Twig\TwigEngineFactory;
 use Marko\View\Twig\TwigView;
 use Marko\View\ViewInterface;
+use Twig\Environment;
 
 return [
     'bindings' => [
-        ViewInterface::class => function (ContainerInterface $container): ViewInterface {
-            $engine = $container->get(TwigEngineFactory::class)->create();
-            $resolver = $container->get(TemplateResolverInterface::class);
-
-            return new TwigView($engine, $resolver);
+        ViewInterface::class => TwigView::class,
+        Environment::class => function (ContainerInterface $container): Environment {
+            return $container->get(TwigEngineFactory::class)->create();
         },
     ],
 ];

--- a/packages/view-twig/tests/ModuleTest.php
+++ b/packages/view-twig/tests/ModuleTest.php
@@ -3,14 +3,13 @@
 declare(strict_types=1);
 
 use Marko\Core\Container\ContainerInterface;
-use Marko\View\TemplateResolverInterface;
 use Marko\View\Twig\TwigEngineFactory;
 use Marko\View\Twig\TwigView;
 use Marko\View\ViewInterface;
 use Twig\Environment;
 
 describe('view-twig module.php', function (): void {
-    test('it registers a ViewInterface binding', function (): void {
+    test('it has a bindings array', function (): void {
         $modulePath = dirname(__DIR__) . '/module.php';
 
         expect(file_exists($modulePath))->toBeTrue();
@@ -19,11 +18,24 @@ describe('view-twig module.php', function (): void {
 
         expect($module)->toBeArray()
             ->and($module)->toHaveKey('bindings')
-            ->and($module['bindings'])->toBeArray()
-            ->and($module['bindings'])->toHaveKey(ViewInterface::class);
+            ->and($module['bindings'])->toBeArray();
     });
 
-    test('it resolves ViewInterface to a TwigView instance', function (): void {
+    test('it binds ViewInterface to TwigView as a simple class mapping', function (): void {
+        $module = require dirname(__DIR__) . '/module.php';
+
+        expect($module['bindings'])->toHaveKey(ViewInterface::class)
+            ->and($module['bindings'][ViewInterface::class])->toBe(TwigView::class);
+    });
+
+    test('it binds Twig Environment via a closure that calls TwigEngineFactory', function (): void {
+        $module = require dirname(__DIR__) . '/module.php';
+
+        expect($module['bindings'])->toHaveKey(Environment::class)
+            ->and($module['bindings'][Environment::class])->toBeInstanceOf(Closure::class);
+    });
+
+    test('the Environment closure resolves the engine via TwigEngineFactory::create()', function (): void {
         $module = require dirname(__DIR__) . '/module.php';
 
         $engine = $this->createMock(Environment::class);
@@ -33,79 +45,16 @@ describe('view-twig module.php', function (): void {
             ->method('create')
             ->willReturn($engine);
 
-        $resolver = $this->createMock(TemplateResolverInterface::class);
-
         $container = $this->createMock(ContainerInterface::class);
         $container->method('get')
-            ->willReturnCallback(function (string $class) use ($engineFactory, $resolver) {
-                return match ($class) {
-                    TwigEngineFactory::class => $engineFactory,
-                    TemplateResolverInterface::class => $resolver,
-                    default => throw new Exception("Unexpected class: $class"),
-                };
+            ->willReturnCallback(fn (string $class) => match ($class) {
+                TwigEngineFactory::class => $engineFactory,
+                default => throw new Exception("Unexpected class: $class"),
             });
 
-        $factory = $module['bindings'][ViewInterface::class];
-        $view = $factory($container);
+        $closure = $module['bindings'][Environment::class];
+        $result = $closure($container);
 
-        expect($view)->toBeInstanceOf(TwigView::class);
-    });
-
-    test('it injects a configured Twig Environment into TwigView', function (): void {
-        $module = require dirname(__DIR__) . '/module.php';
-
-        $engine = $this->createMock(Environment::class);
-
-        $engineFactory = $this->createMock(TwigEngineFactory::class);
-        $engineFactory->expects($this->once())
-            ->method('create')
-            ->willReturn($engine);
-
-        $resolver = $this->createMock(TemplateResolverInterface::class);
-
-        $container = $this->createMock(ContainerInterface::class);
-        $container->method('get')
-            ->willReturnCallback(function (string $class) use ($engineFactory, $resolver) {
-                return match ($class) {
-                    TwigEngineFactory::class => $engineFactory,
-                    TemplateResolverInterface::class => $resolver,
-                    default => throw new Exception("Unexpected class: $class"),
-                };
-            });
-
-        $factory = $module['bindings'][ViewInterface::class];
-
-        // The factory closure calls engineFactory->create() — expectation above asserts this
-        $view = $factory($container);
-
-        expect($view)->toBeInstanceOf(TwigView::class);
-    });
-
-    test('it injects the shared TemplateResolverInterface into TwigView', function (): void {
-        $module = require dirname(__DIR__) . '/module.php';
-
-        $engine = $this->createMock(Environment::class);
-
-        $engineFactory = $this->createMock(TwigEngineFactory::class);
-        $engineFactory->method('create')
-            ->willReturn($engine);
-
-        $resolver = $this->createMock(TemplateResolverInterface::class);
-
-        $container = $this->createMock(ContainerInterface::class);
-        $container->method('get')
-            ->willReturnCallback(function (string $class) use ($engineFactory, $resolver) {
-                return match ($class) {
-                    TwigEngineFactory::class => $engineFactory,
-                    TemplateResolverInterface::class => $resolver,
-                    default => throw new Exception("Unexpected class: $class"),
-                };
-            });
-
-        $factory = $module['bindings'][ViewInterface::class];
-        $view = $factory($container);
-
-        expect($view)->toBeInstanceOf(TwigView::class)
-            ->and($view)->toBeInstanceOf(ViewInterface::class);
+        expect($result)->toBe($engine);
     });
 });


### PR DESCRIPTION
## Summary

The `view-latte` and `view-twig` `module.php` files wrapped `ViewInterface` in a closure that manually built `LatteView` / `TwigView`. The closure existed for a real reason — the engine (`Latte\Engine` / `Twig\Environment`) needs `LatteEngineFactory::create()` (a method call, not direct autowiring). But the closure was at the wrong level: `LatteView` and `TwigView` both have fully-autowirable constructors (only type-hinted interfaces/classes).

Per Marko's binding guidance in `architecture.md`:

> **Prefer simple bindings.** Only use closures when autowiring can't express what you need. If a class takes only type-hinted interfaces/classes as constructor params, it's autowirable — no closure needed.

The closure should sit on the dependency that genuinely needs the factory method, not bubble up to the parent.

## Before

```php
return [
    'bindings' => [
        ViewInterface::class => function (ContainerInterface \$container): ViewInterface {
            \$engine = \$container->get(LatteEngineFactory::class)->create();
            \$resolver = \$container->get(TemplateResolverInterface::class);
            return new LatteView(\$engine, \$resolver);
        },
    ],
];
```

## After

```php
return [
    'bindings' => [
        ViewInterface::class => LatteView::class,
        Engine::class => function (ContainerInterface \$container): Engine {
            return \$container->get(LatteEngineFactory::class)->create();
        },
    ],
];
```

- `ViewInterface` binding becomes a simple class mapping (autowired)
- The closure is scoped to `Latte\Engine` (or `Twig\Environment` for view-twig) — the actual service that needs custom build logic
- `LatteView`'s autowired constructor receives the engine (from closure) and resolver (autowired); the `setLoader()` side effect still runs in the constructor

Same restructure applied to both `view-latte/module.php` and `view-twig/module.php` to keep them symmetric.

## Why this matters

Future copy-paste from view's `module.php` propagates the **correct** pattern. View is one of the most-likely-to-be-cargo-culted module configurations in the framework, so getting its shape right matters beyond just these two packages.

## Test plan

- [x] `packages/view-latte/tests/` — 29 tests pass (ModuleTest updated to verify new shape)
- [x] `packages/view-twig/tests/` — 48 tests pass (ModuleTest updated)
- [x] `packages/view/tests/` — 43 tests pass (no changes here, regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)