### PR TITLE
fix: harden 0.7.0 release (lint config, test fixes, dep refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,6 @@ Entries from `0.4.0` onward are generated automatically by `bin/release.sh` from
 * @michalbiarda made their first contribution in https://github.com/marko-php/marko/pull/58
 
 
-## [Unreleased]
-
-### New Features
-* feat: add marko/page-cache and marko/page-cache-file packages
-* feat(database): add `selectRaw`, `whereRaw`, and `orderByRaw` to `QueryBuilderInterface` with positional bindings and denylist validation
-* feat(core): add module-declared global middleware support via globalMiddleware key in module.php
-
 ## [0.5.0] - 2026-05-01
 
 ### New Features

--- a/composer.json
+++ b/composer.json
@@ -548,6 +548,9 @@
             "Marko\\View\\Twig\\Tests\\": "packages/view-twig/tests/",
             "Marko\\Vite\\Tests\\": "packages/vite/tests/",
             "Marko\\Webhook\\Tests\\": "packages/webhook/tests/"
-        }
+        },
+        "files": [
+            "packages/database-mysql/tests/Connection/Helpers.php"
+        ]
     }
 }

--- a/packages/admin-panel-latte/tests/ResolverIntegrationTest.php
+++ b/packages/admin-panel-latte/tests/ResolverIntegrationTest.php
@@ -8,25 +8,28 @@ use Marko\Testing\Fake\FakeConfigRepository;
 use Marko\View\ModuleTemplateResolver;
 use Marko\View\ViewConfig;
 
-it('ModuleTemplateResolver resolves admin-panel::dashboard/index to the new admin-panel-latte path', function (): void {
-    $adminPanelLatteDir = dirname(__DIR__);
-
-    $modules = [
-        new ModuleManifest(
-            name: 'marko/admin-panel-latte',
-            version: '1.0.0',
-            path: $adminPanelLatteDir,
-            source: 'vendor',
-            extra: ['marko' => ['templates_for' => 'marko/admin-panel']],
-        ),
-    ];
-
-    $resolver = new ModuleTemplateResolver(
-        new ModuleRepository($modules),
-        new ViewConfig(new FakeConfigRepository(['view.extension' => '.latte'])),
-    );
-
-    $result = $resolver->resolve('admin-panel::dashboard/index');
-
-    expect($result)->toBe($adminPanelLatteDir . '/resources/views/dashboard/index.latte');
-});
+it(
+    'ModuleTemplateResolver resolves admin-panel::dashboard/index to the new admin-panel-latte path',
+    function (): void {
+        $adminPanelLatteDir = dirname(__DIR__);
+    
+        $modules = [
+            new ModuleManifest(
+                name: 'marko/admin-panel-latte',
+                version: '1.0.0',
+                path: $adminPanelLatteDir,
+                source: 'vendor',
+                extra: ['marko' => ['templates_for' => 'marko/admin-panel']],
+            ),
+        ];
+    
+        $resolver = new ModuleTemplateResolver(
+            new ModuleRepository($modules),
+            new ViewConfig(new FakeConfigRepository(['view.extension' => '.latte'])),
+        );
+    
+        $result = $resolver->resolve('admin-panel::dashboard/index');
+    
+        expect($result)->toBe($adminPanelLatteDir . '/resources/views/dashboard/index.latte');
+    }
+);

--- a/packages/admin-panel-latte/tests/TemplateMigrationTest.php
+++ b/packages/admin-panel-latte/tests/TemplateMigrationTest.php
@@ -30,7 +30,9 @@ it('LayoutTemplateTest.php exists in packages/admin-panel-latte/tests/', functio
 it('LayoutTemplateTest.php has been removed from packages/admin-panel/tests/Unit/Template/', function (): void {
     $oldTestPath = dirname(__DIR__, 2) . '/admin-panel/tests/Unit/Template/LayoutTemplateTest.php';
 
-    expect(file_exists($oldTestPath))->toBeFalse('LayoutTemplateTest.php should not exist in admin-panel/tests/Unit/Template/');
+    expect(file_exists($oldTestPath))->toBeFalse(
+        'LayoutTemplateTest.php should not exist in admin-panel/tests/Unit/Template/'
+    );
 });
 
 it('the moved Pest file uses dirname(__DIR__) for $viewsPath (one level up)', function (): void {

--- a/packages/admin-panel-twig/tests/TemplateExistenceTest.php
+++ b/packages/admin-panel-twig/tests/TemplateExistenceTest.php
@@ -5,43 +5,52 @@ declare(strict_types=1);
 describe('admin-panel-twig templates', function (): void {
     $viewsDir = dirname(__DIR__) . '/resources/views';
 
-    test('auth/login.twig exists and renders a form with email and password fields', function () use ($viewsDir): void {
-        $path = $viewsDir . '/auth/login.twig';
+    test(
+        'auth/login.twig exists and renders a form with email and password fields',
+        function () use ($viewsDir): void {
+            $path = $viewsDir . '/auth/login.twig';
+    
+            expect(file_exists($path))->toBeTrue();
+    
+            $contents = file_get_contents($path);
+    
+            expect($contents)
+                ->toContain('<form')
+                ->and($contents)->toContain('name="email"')
+                ->and($contents)->toContain('name="password"');
+        }
+    );
 
-        expect(file_exists($path))->toBeTrue();
+    test(
+        'layout/base.twig exists and contains HTML doctype, sidebar include, and content block',
+        function () use ($viewsDir): void {
+            $path = $viewsDir . '/layout/base.twig';
+    
+            expect(file_exists($path))->toBeTrue();
+    
+            $contents = file_get_contents($path);
+    
+            expect($contents)
+                ->toContain('<!DOCTYPE html>')
+                ->and($contents)->toContain("{% include 'admin-panel::partials/sidebar'")
+                ->and($contents)->toContain('{% block content %}');
+        }
+    );
 
-        $contents = file_get_contents($path);
-
-        expect($contents)
-            ->toContain('<form')
-            ->and($contents)->toContain('name="email"')
-            ->and($contents)->toContain('name="password"');
-    });
-
-    test('layout/base.twig exists and contains HTML doctype, sidebar include, and content block', function () use ($viewsDir): void {
-        $path = $viewsDir . '/layout/base.twig';
-
-        expect(file_exists($path))->toBeTrue();
-
-        $contents = file_get_contents($path);
-
-        expect($contents)
-            ->toContain('<!DOCTYPE html>')
-            ->and($contents)->toContain("{% include 'admin-panel::partials/sidebar'")
-            ->and($contents)->toContain('{% block content %}');
-    });
-
-    test('dashboard/index.twig exists and extends layout/base.twig with a content block', function () use ($viewsDir): void {
-        $path = $viewsDir . '/dashboard/index.twig';
-
-        expect(file_exists($path))->toBeTrue();
-
-        $contents = file_get_contents($path);
-
-        expect($contents)
-            ->toContain("{% extends 'admin-panel::layout/base' %}")
-            ->and($contents)->toContain('{% block content %}');
-    });
+    test(
+        'dashboard/index.twig exists and extends layout/base.twig with a content block',
+        function () use ($viewsDir): void {
+            $path = $viewsDir . '/dashboard/index.twig';
+    
+            expect(file_exists($path))->toBeTrue();
+    
+            $contents = file_get_contents($path);
+    
+            expect($contents)
+                ->toContain("{% extends 'admin-panel::layout/base' %}")
+                ->and($contents)->toContain('{% block content %}');
+        }
+    );
 
     test('partials/sidebar.twig exists and iterates menu items', function () use ($viewsDir): void {
         $path = $viewsDir . '/partials/sidebar.twig';
@@ -81,18 +90,21 @@ describe('admin-panel-twig templates', function (): void {
             ->and($contents)->toContain('{{ csrfToken }}');
     });
 
-    test('the layout\'s content block can be overridden by child templates (verified via dashboard.twig)', function () use ($viewsDir): void {
-        $layoutPath  = $viewsDir . '/layout/base.twig';
-        $dashboardPath = $viewsDir . '/dashboard/index.twig';
-
-        expect(file_exists($layoutPath))->toBeTrue()
-            ->and(file_exists($dashboardPath))->toBeTrue();
-
-        $layoutContents    = file_get_contents($layoutPath);
-        $dashboardContents = file_get_contents($dashboardPath);
-
-        expect($layoutContents)->toContain('{% block content %}')
-            ->and($dashboardContents)->toContain('{% block content %}')
-            ->and($dashboardContents)->toContain('{% endblock %}');
-    });
+    test(
+        'the layout\'s content block can be overridden by child templates (verified via dashboard.twig)',
+        function () use ($viewsDir): void {
+            $layoutPath  = $viewsDir . '/layout/base.twig';
+            $dashboardPath = $viewsDir . '/dashboard/index.twig';
+    
+            expect(file_exists($layoutPath))->toBeTrue()
+                ->and(file_exists($dashboardPath))->toBeTrue();
+    
+            $layoutContents    = file_get_contents($layoutPath);
+            $dashboardContents = file_get_contents($dashboardPath);
+    
+            expect($layoutContents)->toContain('{% block content %}')
+                ->and($dashboardContents)->toContain('{% block content %}')
+                ->and($dashboardContents)->toContain('{% endblock %}');
+        }
+    );
 });

--- a/packages/admin-panel/tests/Unit/Controller/DashboardControllerTest.php
+++ b/packages/admin-panel/tests/Unit/Controller/DashboardControllerTest.php
@@ -106,7 +106,9 @@ class StubAdminSection implements AdminSectionInterface
 }
 
 it('requires authentication via AdminAuthMiddleware for dashboard', function (): void {
-    $middlewareAttributes = (new ReflectionMethod(DashboardController::class, 'index'))->getAttributes(Middleware::class);
+    $middlewareAttributes = (new ReflectionMethod(DashboardController::class, 'index'))->getAttributes(
+        Middleware::class
+    );
 
     expect($middlewareAttributes)->toHaveCount(1)
         ->and($middlewareAttributes[0]->newInstance()->middleware)->toContain(AdminAuthMiddleware::class);

--- a/packages/admin-panel/tests/Unit/EngineSiblingCleanupTest.php
+++ b/packages/admin-panel/tests/Unit/EngineSiblingCleanupTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 it('packages/admin-panel/resources/views/ no longer exists', function (): void {
     $viewsDir = dirname(__DIR__, 2) . '/resources/views';
 
-    expect(is_dir($viewsDir))->toBeFalse('resources/views/ directory should not exist after engine sibling extraction');
+    expect(is_dir($viewsDir))->toBeFalse(
+        'resources/views/ directory should not exist after engine sibling extraction'
+    );
 });
 
 it('packages/admin-panel/composer.json includes a suggest block', function (): void {

--- a/packages/admin/tests/Unit/Exceptions/NoDriverExceptionTest.php
+++ b/packages/admin/tests/Unit/Exceptions/NoDriverExceptionTest.php
@@ -6,17 +6,20 @@ use Marko\Admin\Exceptions\AdminException;
 use Marko\Admin\Exceptions\NoDriverException;
 
 describe('NoDriverException', function (): void {
-    it('has DRIVER_PACKAGES constant listing marko/admin-api, marko/admin-auth, and marko/admin-panel', function (): void {
-        $reflection = new ReflectionClass(NoDriverException::class);
-        $constants = $reflection->getConstants();
-
-        expect($constants)->toHaveKey('DRIVER_PACKAGES')
-            ->and($constants['DRIVER_PACKAGES'])->toBe([
-                'marko/admin-api',
-                'marko/admin-auth',
-                'marko/admin-panel',
-            ]);
-    });
+    it(
+        'has DRIVER_PACKAGES constant listing marko/admin-api, marko/admin-auth, and marko/admin-panel',
+        function (): void {
+            $reflection = new ReflectionClass(NoDriverException::class);
+            $constants = $reflection->getConstants();
+    
+            expect($constants)->toHaveKey('DRIVER_PACKAGES')
+                ->and($constants['DRIVER_PACKAGES'])->toBe([
+                    'marko/admin-api',
+                    'marko/admin-auth',
+                    'marko/admin-panel',
+                ]);
+        }
+    );
 
     it('provides suggestion with composer require commands for all driver packages', function (): void {
         $exception = NoDriverException::noDriverInstalled();

--- a/packages/amphp/src/Command/PubSubListenCommand.php
+++ b/packages/amphp/src/Command/PubSubListenCommand.php
@@ -18,7 +18,10 @@ readonly class PubSubListenCommand implements CommandInterface
         private EventLoopRunner $runner,
     ) {}
 
-    public function execute(Input $input, Output $output): int
+    public function execute(
+        Input $input,
+        Output $output,
+    ): int
     {
         $output->writeLine('Starting pub/sub listener...');
         $output->writeLine('Press Ctrl+C to stop.');

--- a/packages/authentication/tests/KnownDriversValidationTest.php
+++ b/packages/authentication/tests/KnownDriversValidationTest.php
@@ -7,9 +7,12 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all authentication drivers', function () use ($knownDriversPath, $skeletonComposerPath) {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all authentication drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath) {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every authentication driver follows marko slash prefix pattern', function () use ($knownDriversPath) {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);

--- a/packages/authentication/tests/Unit/Guard/SessionGuardTest.php
+++ b/packages/authentication/tests/Unit/Guard/SessionGuardTest.php
@@ -316,17 +316,26 @@ test('it authenticates via remember token cookie', function (): void {
             return null;
         }
 
-        public function validateCredentials(AuthenticatableInterface $user, array $credentials): bool
+        public function validateCredentials(
+            AuthenticatableInterface $user,
+            array $credentials,
+        ): bool
         {
             return false;
         }
 
-        public function retrieveByRememberToken(int|string $identifier, string $token): ?AuthenticatableInterface
+        public function retrieveByRememberToken(
+            int|string $identifier,
+            string $token,
+        ): ?AuthenticatableInterface
         {
             return $this->userByRememberToken;
         }
 
-        public function updateRememberToken(AuthenticatableInterface $user, ?string $token): void
+        public function updateRememberToken(
+            AuthenticatableInterface $user,
+            ?string $token,
+        ): void
         {
             $user->setRememberToken($token);
         }
@@ -416,17 +425,26 @@ test('it regenerates remember token on each use', function (): void {
             return null;
         }
 
-        public function validateCredentials(AuthenticatableInterface $user, array $credentials): bool
+        public function validateCredentials(
+            AuthenticatableInterface $user,
+            array $credentials,
+        ): bool
         {
             return false;
         }
 
-        public function retrieveByRememberToken(int|string $identifier, string $token): ?AuthenticatableInterface
+        public function retrieveByRememberToken(
+            int|string $identifier,
+            string $token,
+        ): ?AuthenticatableInterface
         {
             return $this->userByRememberToken;
         }
 
-        public function updateRememberToken(AuthenticatableInterface $user, ?string $token): void
+        public function updateRememberToken(
+            AuthenticatableInterface $user,
+            ?string $token,
+        ): void
         {
             $user->setRememberToken($token);
         }

--- a/packages/cache/tests/KnownDriversValidationTest.php
+++ b/packages/cache/tests/KnownDriversValidationTest.php
@@ -8,27 +8,33 @@ use PHPUnit\Framework\SkippedWithMessageException;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all cache drivers', function () use ($knownDriversPath, $skeletonComposerPath): void {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all cache drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath): void {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every cache driver follows marko slash prefix pattern', function () use ($knownDriversPath): void {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);
 });
 
-test('validation test skips skeleton parity assertion when skeleton is absent', function () use ($knownDriversPath): void {
-    $nonExistentPath = __DIR__ . '/non-existent-path/composer.json';
-
-    expect(file_exists($nonExistentPath))->toBeFalse();
-
-    $skipped = false;
-
-    try {
-        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $nonExistentPath);
-    } catch (SkippedWithMessageException $e) {
-        $skipped = true;
-        expect($e->getMessage())->toContain('not found');
+test(
+    'validation test skips skeleton parity assertion when skeleton is absent',
+    function () use ($knownDriversPath): void {
+        $nonExistentPath = __DIR__ . '/non-existent-path/composer.json';
+    
+        expect(file_exists($nonExistentPath))->toBeFalse();
+    
+        $skipped = false;
+    
+        try {
+            KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $nonExistentPath);
+        } catch (SkippedWithMessageException $e) {
+            $skipped = true;
+            expect($e->getMessage())->toContain('not found');
+        }
+    
+        expect($skipped)->toBeTrue();
     }
-
-    expect($skipped)->toBeTrue();
-});
+);

--- a/packages/core/src/Application.php
+++ b/packages/core/src/Application.php
@@ -304,7 +304,6 @@ class Application
         $this->commandRunner = new CommandRunner($this->container, $this->commandRegistry);
     }
 
-
     /**
      * @throws RouteException|RouteConflictException|ReflectionException
      */

--- a/packages/core/src/Commands/ListCommand.php
+++ b/packages/core/src/Commands/ListCommand.php
@@ -34,7 +34,10 @@ readonly class ListCommand implements CommandInterface
         $displayNames = [];
         foreach ($commands as $definition) {
             if ($definition->aliases !== []) {
-                $displayNames[$definition->name] = $definition->name . ' (' . implode(', ', $definition->aliases) . ')';
+                $displayNames[$definition->name] = $definition->name . ' (' . implode(
+                    ', ',
+                    $definition->aliases
+                ) . ')';
             } else {
                 $displayNames[$definition->name] = $definition->name;
             }

--- a/packages/core/src/Exceptions/ModuleException.php
+++ b/packages/core/src/Exceptions/ModuleException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Marko\Core\Exceptions;
 
+use Marko\Routing\Middleware\MiddlewareInterface;
+
 class ModuleException extends MarkoException
 {
     public static function invalidManifest(
@@ -36,7 +38,7 @@ class ModuleException extends MarkoException
         return new self(
             message: "Invalid globalMiddleware entry in module '$moduleName': $reason",
             context: "While resolving global middleware for '$moduleName'",
-            suggestion: "Ensure '$className' exists and implements " . \Marko\Routing\Middleware\MiddlewareInterface::class,
+            suggestion: "Ensure '$className' exists and implements " . MiddlewareInterface::class,
         );
     }
 

--- a/packages/core/tests/Feature/Plugin/PluginInterceptionIntegrationTest.php
+++ b/packages/core/tests/Feature/Plugin/PluginInterceptionIntegrationTest.php
@@ -46,7 +46,10 @@ class PIIT_HasherAfterPlugin
     public static array $log = [];
 
     /** @noinspection PhpUnused - Invoked via plugin interception */
-    public function hash(mixed $result, string $value): string
+    public function hash(
+        mixed $result,
+        string $value,
+    ): string
     {
         self::$log[] = "after:$result";
 
@@ -67,7 +70,10 @@ class PIIT_LoggingPlugin
     }
 
     /** @noinspection PhpUnused - Invoked via plugin interception */
-    public function hashAfter(mixed $result, string $value): string
+    public function hashAfter(
+        mixed $result,
+        string $value,
+    ): string
     {
         self::$log[] = "after:$result";
 
@@ -98,7 +104,10 @@ class PIIT_FirstAfterPlugin
     public static array $log = [];
 
     /** @noinspection PhpUnused - Invoked via plugin interception */
-    public function hash(mixed $result, string $value): string
+    public function hash(
+        mixed $result,
+        string $value,
+    ): string
     {
         self::$log[] = "first-after:$result";
 
@@ -111,7 +120,10 @@ class PIIT_SecondAfterPlugin
     public static array $log = [];
 
     /** @noinspection PhpUnused - Invoked via plugin interception */
-    public function hash(mixed $result, string $value): string
+    public function hash(
+        mixed $result,
+        string $value,
+    ): string
     {
         self::$log[] = "second-after:$result";
 

--- a/packages/core/tests/Unit/ApplicationTest.php
+++ b/packages/core/tests/Unit/ApplicationTest.php
@@ -1694,7 +1694,10 @@ it('throws RuntimeException with helpful message when routing package is not ins
     $app = new Application();
 
     expect(fn () => $app->handleRequest())
-        ->toThrow(RuntimeException::class, 'Cannot handle HTTP requests: marko/routing is not installed. Run: composer require marko/routing');
+        ->toThrow(
+            RuntimeException::class,
+            'Cannot handle HTTP requests: marko/routing is not installed. Run: composer require marko/routing'
+        );
 });
 
 it('creates a request from globals and routes it through the router', function (): void {
@@ -2004,4 +2007,3 @@ PHP;
 
     appTestCleanupDirectory($baseDir);
 });
-

--- a/packages/core/tests/Unit/Module/GlobalMiddlewareResolverTest.php
+++ b/packages/core/tests/Unit/Module/GlobalMiddlewareResolverTest.php
@@ -23,9 +23,9 @@ function makeMiddlewareClass(string $className): void
 
     eval(
         "namespace $namespace; " .
-        "class $shortName implements \\" . MiddlewareInterface::class . " { " .
+        "class $shortName implements \\" . MiddlewareInterface::class . ' { ' .
         "public function handle(\Marko\Routing\Http\Request \$request, callable \$next): \Marko\Routing\Http\Response { return \$next(\$request); } " .
-        "}"
+        '}'
     );
 }
 

--- a/packages/core/tests/Unit/Plugin/PluginInterceptorTest.php
+++ b/packages/core/tests/Unit/Plugin/PluginInterceptorTest.php
@@ -50,7 +50,10 @@ class PIT_GreeterAfterPlugin
 {
     public static array $callLog = [];
 
-    public function greet(mixed $result, string $name): mixed
+    public function greet(
+        mixed $result,
+        string $name,
+    ): mixed
     {
         self::$callLog[] = 'PIT_GreeterAfterPlugin::greet';
 
@@ -130,7 +133,10 @@ class PIT_ArgsService
 {
     public static array $callLog = [];
 
-    public function process(string $name, int $count): string
+    public function process(
+        string $name,
+        int $count,
+    ): string
     {
         self::$callLog[] = "PIT_ArgsService::process($name, $count)";
 
@@ -142,7 +148,10 @@ class PIT_ArgsBeforePlugin
 {
     public static array $receivedArgs = [];
 
-    public function process(string $name, int $count): ?string
+    public function process(
+        string $name,
+        int $count,
+    ): ?string
     {
         self::$receivedArgs = ['name' => $name, 'count' => $count];
         PIT_ArgsService::$callLog[] = "PIT_ArgsBeforePlugin::process($name, $count)";
@@ -153,7 +162,10 @@ class PIT_ArgsBeforePlugin
 
 class PIT_ArgsModifyingBeforePlugin
 {
-    public function process(string $name, int $count): ?array
+    public function process(
+        string $name,
+        int $count,
+    ): ?array
     {
         return ['modified-name', $count + 10];
     }
@@ -163,7 +175,11 @@ class PIT_ArgsAfterPlugin
 {
     public static array $receivedArgs = [];
 
-    public function process(mixed $result, string $name, int $count): mixed
+    public function process(
+        mixed $result,
+        string $name,
+        int $count,
+    ): mixed
     {
         self::$receivedArgs = ['result' => $result, 'name' => $name, 'count' => $count];
 
@@ -245,7 +261,10 @@ class PIT_AdderAfterPlugin
 
 class PIT_RequiredParamService
 {
-    public function create(string $name, int $age): string
+    public function create(
+        string $name,
+        int $age,
+    ): string
     {
         return "$name is $age";
     }
@@ -253,7 +272,10 @@ class PIT_RequiredParamService
 
 class PIT_WrongCountBeforePlugin
 {
-    public function create(string $name, int $age): ?array
+    public function create(
+        string $name,
+        int $age,
+    ): ?array
     {
         return ['only-one'];
     }
@@ -265,7 +287,10 @@ class PIT_WrongCountBeforePlugin
 
 class PIT_ChainArgService
 {
-    public function transform(string $text, int $mult): string
+    public function transform(
+        string $text,
+        int $mult,
+    ): string
     {
         return "result: $text x$mult";
     }
@@ -273,7 +298,10 @@ class PIT_ChainArgService
 
 class PIT_ChainArgFirstPlugin
 {
-    public function transform(string $text, int $mult): ?array
+    public function transform(
+        string $text,
+        int $mult,
+    ): ?array
     {
         return ["$text-first", $mult + 1];
     }
@@ -281,7 +309,10 @@ class PIT_ChainArgFirstPlugin
 
 class PIT_ChainArgSecondPlugin
 {
-    public function transform(string $text, int $mult): ?array
+    public function transform(
+        string $text,
+        int $mult,
+    ): ?array
     {
         return ["$text-second", $mult + 1];
     }
@@ -315,7 +346,10 @@ class PIT_CompleteFlowBeforePlugin
 
 class PIT_CompleteFlowAfterPlugin
 {
-    public function process(mixed $result, string $input): string
+    public function process(
+        mixed $result,
+        string $input,
+    ): string
     {
         PIT_CompleteFlowService::$callLog[] = "PIT_CompleteFlowAfterPlugin::process($result, $input)";
 
@@ -550,7 +584,11 @@ it('creates interceptor that passes instanceof check for target interface', func
     ));
 
     $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_GreeterInterface::class, PIT_ConcreteGreeter::class, new PIT_ConcreteGreeter());
+    $proxy = $interceptor->createProxy(
+        PIT_GreeterInterface::class,
+        PIT_ConcreteGreeter::class,
+        new PIT_ConcreteGreeter()
+    );
 
     expect($proxy)->toBeInstanceOf(PIT_GreeterInterface::class);
 });
@@ -612,7 +650,11 @@ it('short-circuits when before plugin returns non-null non-array value', functio
     ));
 
     $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_ShortCircuitService::class, PIT_ShortCircuitService::class, new PIT_ShortCircuitService());
+    $proxy = $interceptor->createProxy(
+        PIT_ShortCircuitService::class,
+        PIT_ShortCircuitService::class,
+        new PIT_ShortCircuitService()
+    );
 
     $result = $proxy->fetch('mykey');
 
@@ -631,7 +673,11 @@ it('passes through to target method when before plugin returns null', function (
     ));
 
     $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_ShortCircuitService::class, PIT_ShortCircuitService::class, new PIT_ShortCircuitService());
+    $proxy = $interceptor->createProxy(
+        PIT_ShortCircuitService::class,
+        PIT_ShortCircuitService::class,
+        new PIT_ShortCircuitService()
+    );
 
     $result = $proxy->fetch('mykey');
 
@@ -668,7 +714,11 @@ it('throws PluginArgumentCountException when before plugin returns array with wr
     ));
 
     $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_RequiredParamService::class, PIT_RequiredParamService::class, new PIT_RequiredParamService());
+    $proxy = $interceptor->createProxy(
+        PIT_RequiredParamService::class,
+        PIT_RequiredParamService::class,
+        new PIT_RequiredParamService()
+    );
 
     expect(fn () => $proxy->create('Alice', 30))->toThrow(PluginArgumentCountException::class);
 });
@@ -690,7 +740,11 @@ it('chains argument modifications through multiple before plugins', function ():
     ));
 
     $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_ChainArgService::class, PIT_ChainArgService::class, new PIT_ChainArgService());
+    $proxy = $interceptor->createProxy(
+        PIT_ChainArgService::class,
+        PIT_ChainArgService::class,
+        new PIT_ChainArgService()
+    );
 
     $result = $proxy->transform('hello', 1);
 
@@ -738,7 +792,9 @@ it('passes result and arguments to after plugins', function (): void {
 
     $proxy->process('test', 42);
 
-    expect(PIT_ArgsAfterPlugin::$receivedArgs)->toBe(['result' => 'processed: test, 42', 'name' => 'test', 'count' => 42]);
+    expect(PIT_ArgsAfterPlugin::$receivedArgs)->toBe(
+        ['result' => 'processed: test, 42', 'name' => 'test', 'count' => 42]
+    );
 });
 
 it('chains modified results through multiple after plugins', function (): void {
@@ -758,7 +814,11 @@ it('chains modified results through multiple after plugins', function (): void {
     ));
 
     $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_ResultModService::class, PIT_ResultModService::class, new PIT_ResultModService());
+    $proxy = $interceptor->createProxy(
+        PIT_ResultModService::class,
+        PIT_ResultModService::class,
+        new PIT_ResultModService()
+    );
 
     $result = $proxy->getValue();
 
@@ -812,7 +872,11 @@ it('executes complete before-target-after flow', function (): void {
     ));
 
     $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_CompleteFlowService::class, PIT_CompleteFlowService::class, new PIT_CompleteFlowService());
+    $proxy = $interceptor->createProxy(
+        PIT_CompleteFlowService::class,
+        PIT_CompleteFlowService::class,
+        new PIT_CompleteFlowService()
+    );
 
     $result = $proxy->process('test');
 
@@ -879,7 +943,11 @@ it('calls plugin method by name returned from registry', function (): void {
     ));
 
     $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_MethodNameService::class, PIT_MethodNameService::class, new PIT_MethodNameService());
+    $proxy = $interceptor->createProxy(
+        PIT_MethodNameService::class,
+        PIT_MethodNameService::class,
+        new PIT_MethodNameService()
+    );
 
     $result = $proxy->save('hello');
 
@@ -899,7 +967,11 @@ it('executes plugins using explicit method param with different method names', f
     ));
 
     $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_MethodNameService::class, PIT_MethodNameService::class, new PIT_MethodNameService());
+    $proxy = $interceptor->createProxy(
+        PIT_MethodNameService::class,
+        PIT_MethodNameService::class,
+        new PIT_MethodNameService()
+    );
 
     $result = $proxy->save('test data');
 
@@ -907,25 +979,32 @@ it('executes plugins using explicit method param with different method names', f
         ->and($result)->toBe('saved: test data');
 });
 
-it('finds plugins when interface is resolved to concrete class (originalId differs from resolvedId)', function (): void {
-    $container = new Container();
-    $registry = new PluginRegistry();
-
-    $registry->register(new PluginDefinition(
-        pluginClass: PIT_HasherPlugin::class,
-        targetClass: PIT_HasherInterface::class,
-        beforeMethods: ['hash' => ['pluginMethod' => 'hash', 'sortOrder' => 10]],
-    ));
-
-    $interceptor = makePluginInterceptor($container, $registry);
-    $proxy = $interceptor->createProxy(PIT_HasherInterface::class, PIT_BcryptHasher::class, new PIT_BcryptHasher());
-
-    $result = $proxy->hash('secret');
-
-    expect(PIT_HasherPlugin::$callLog)->toBe(['PIT_HasherPlugin::hash(secret)'])
-        ->and(PIT_BcryptHasher::$callLog)->toBe(['PIT_BcryptHasher::hash(secret)'])
-        ->and($result)->toBe('bcrypt:secret');
-});
+it(
+    'finds plugins when interface is resolved to concrete class (originalId differs from resolvedId)',
+    function (): void {
+        $container = new Container();
+        $registry = new PluginRegistry();
+    
+        $registry->register(new PluginDefinition(
+            pluginClass: PIT_HasherPlugin::class,
+            targetClass: PIT_HasherInterface::class,
+            beforeMethods: ['hash' => ['pluginMethod' => 'hash', 'sortOrder' => 10]],
+        ));
+    
+        $interceptor = makePluginInterceptor($container, $registry);
+        $proxy = $interceptor->createProxy(
+            PIT_HasherInterface::class,
+            PIT_BcryptHasher::class,
+            new PIT_BcryptHasher()
+        );
+    
+        $result = $proxy->hash('secret');
+    
+        expect(PIT_HasherPlugin::$callLog)->toBe(['PIT_HasherPlugin::hash(secret)'])
+            ->and(PIT_BcryptHasher::$callLog)->toBe(['PIT_BcryptHasher::hash(secret)'])
+            ->and($result)->toBe('bcrypt:secret');
+    }
+);
 
 it('exposes original target via getPluginTarget', function (): void {
     $container = new Container();
@@ -957,7 +1036,13 @@ it('throws PluginException for readonly concrete class with direct plugins', fun
 
     $interceptor = makePluginInterceptor($container, $registry);
 
-    expect(fn () => $interceptor->createProxy(PIT_ReadonlyService::class, PIT_ReadonlyService::class, new PIT_ReadonlyService()))
+    expect(
+        fn () => $interceptor->createProxy(
+            PIT_ReadonlyService::class,
+            PIT_ReadonlyService::class,
+            new PIT_ReadonlyService()
+        )
+    )
         ->toThrow(PluginException::class);
 });
 

--- a/packages/database-mysql/src/Query/MySqlQueryBuilder.php
+++ b/packages/database-mysql/src/Query/MySqlQueryBuilder.php
@@ -300,7 +300,7 @@ class MySqlQueryBuilder implements QueryBuilderInterface
         foreach ($columns as $column) {
             if (!IdentifierValidator::isValidIdentifier($column) && !preg_match(
                 '/^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$/',
-                $column
+                $column,
             )) {
                 throw InvalidColumnException::invalidColumn($column);
             }
@@ -954,5 +954,4 @@ class MySqlQueryBuilder implements QueryBuilderInterface
 
         return $sql;
     }
-
 }

--- a/packages/database-mysql/tests/Connection/Helpers.php
+++ b/packages/database-mysql/tests/Connection/Helpers.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Database\MySql\Tests\Connection;
+
+use Marko\Core\Path\ProjectPaths;
+use Marko\Database\Config\DatabaseConfig;
+use Marko\Database\MySql\Connection\MySqlConnection;
+use PDO;
+
+function createTestDatabaseConfig(
+    string $host = 'localhost',
+    int $port = 3306,
+    string $database = 'test',
+    string $username = 'root',
+    string $password = '',
+    ?string $sslCa = null,
+    bool $sslVerifyServerCert = false,
+    ?string $sslCert = null,
+    ?string $sslKey = null,
+): DatabaseConfig {
+    $tempDir = sys_get_temp_dir() . '/marko_mysql_test_' . bin2hex(random_bytes(8));
+    mkdir($tempDir . '/config', recursive: true);
+
+    $configArray = [
+        'driver' => 'mysql',
+        'host' => $host,
+        'port' => $port,
+        'database' => $database,
+        'username' => $username,
+        'password' => $password,
+    ];
+
+    if ($sslCa !== null) {
+        $configArray['ssl_ca'] = $sslCa;
+    }
+
+    if ($sslVerifyServerCert) {
+        $configArray['ssl_verify_server_cert'] = true;
+    }
+
+    if ($sslCert !== null) {
+        $configArray['ssl_cert'] = $sslCert;
+    }
+
+    if ($sslKey !== null) {
+        $configArray['ssl_key'] = $sslKey;
+    }
+
+    file_put_contents(
+        $tempDir . '/config/database.php',
+        '<?php return ' . var_export($configArray, true) . ';',
+    );
+
+    $paths = new ProjectPaths($tempDir);
+    $config = new DatabaseConfig($paths);
+
+    unlink($tempDir . '/config/database.php');
+    rmdir($tempDir . '/config');
+    rmdir($tempDir);
+
+    return $config;
+}
+
+/**
+ * Connect a MySqlConnection and return the PDO options it passed.
+ *
+ * @return array<int, mixed>
+ */
+function connectAndCapturePdoOptions(DatabaseConfig $config): array
+{
+    $capturedOptions = [];
+
+    $connection = new class ($config, $capturedOptions) extends MySqlConnection
+    {
+        public function __construct(
+            DatabaseConfig $config,
+            private array &$capturedOptions,
+        ) {
+            parent::__construct($config);
+        }
+
+        protected function createPdo(
+            string $dsn,
+            string $username,
+            string $password,
+            array $options,
+        ): PDO {
+            $this->capturedOptions = $options;
+
+            return new PDO('sqlite::memory:');
+        }
+    };
+
+    $connection->connect();
+
+    return $capturedOptions;
+}

--- a/packages/database-mysql/tests/Connection/MySqlConnectionTest.php
+++ b/packages/database-mysql/tests/Connection/MySqlConnectionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Marko\Database\MySql\Tests\Connection;
 
-use Marko\Core\Path\ProjectPaths;
 use Marko\Database\Config\DatabaseConfig;
 use Marko\Database\Connection\ConnectionInterface;
 use Marko\Database\Connection\StatementInterface;
@@ -14,96 +13,6 @@ use Marko\Database\MySql\Connection\MySqlConnection;
 use Marko\Database\MySql\Exceptions\ConnectionException;
 use PDO;
 use RuntimeException;
-
-function createTestDatabaseConfig(
-    string $host = 'localhost',
-    int $port = 3306,
-    string $database = 'test',
-    string $username = 'root',
-    string $password = '',
-    ?string $sslCa = null,
-    bool $sslVerifyServerCert = false,
-    ?string $sslCert = null,
-    ?string $sslKey = null,
-): DatabaseConfig {
-    $tempDir = sys_get_temp_dir() . '/marko_mysql_test_' . bin2hex(random_bytes(8));
-    mkdir($tempDir . '/config', recursive: true);
-
-    $configArray = [
-        'driver' => 'mysql',
-        'host' => $host,
-        'port' => $port,
-        'database' => $database,
-        'username' => $username,
-        'password' => $password,
-    ];
-
-    if ($sslCa !== null) {
-        $configArray['ssl_ca'] = $sslCa;
-    }
-
-    if ($sslVerifyServerCert) {
-        $configArray['ssl_verify_server_cert'] = true;
-    }
-
-    if ($sslCert !== null) {
-        $configArray['ssl_cert'] = $sslCert;
-    }
-
-    if ($sslKey !== null) {
-        $configArray['ssl_key'] = $sslKey;
-    }
-
-    file_put_contents(
-        $tempDir . '/config/database.php',
-        '<?php return ' . var_export($configArray, true) . ';',
-    );
-
-    $paths = new ProjectPaths($tempDir);
-    $config = new DatabaseConfig($paths);
-
-    // Clean up temp files immediately (config is already loaded)
-    unlink($tempDir . '/config/database.php');
-    rmdir($tempDir . '/config');
-    rmdir($tempDir);
-
-    return $config;
-}
-
-/**
- * Connect a MySqlConnection and return the PDO options it passed.
- *
- * @return array<int, mixed>
- */
-function connectAndCapturePdoOptions(DatabaseConfig $config): array
-{
-    $capturedOptions = [];
-
-    $connection = new class ($config, $capturedOptions) extends MySqlConnection
-    {
-        public function __construct(
-            DatabaseConfig $config,
-            private array &$capturedOptions,
-        ) {
-            parent::__construct($config);
-        }
-
-        protected function createPdo(
-            string $dsn,
-            string $username,
-            string $password,
-            array $options,
-        ): PDO {
-            $this->capturedOptions = $options;
-
-            return new PDO('sqlite::memory:');
-        }
-    };
-
-    $connection->connect();
-
-    return $capturedOptions;
-}
 
 describe('MySqlConnection', function (): void {
     it('implements ConnectionInterface', function (): void {

--- a/packages/database-mysql/tests/Module/ModuleBindingsTest.php
+++ b/packages/database-mysql/tests/Module/ModuleBindingsTest.php
@@ -52,7 +52,7 @@ describe('MySQL module.php bindings', function (): void {
 
         expect($moduleConfig['bindings'])->toHaveKey(QueryBuilderFactoryInterface::class)
             ->and($moduleConfig['bindings'][QueryBuilderFactoryInterface::class])->toBe(
-                MySqlQueryBuilderFactory::class
+                MySqlQueryBuilderFactory::class,
             );
     });
 

--- a/packages/database-mysql/tests/Query/MySqlJsonQueryBuilderTest.php
+++ b/packages/database-mysql/tests/Query/MySqlJsonQueryBuilderTest.php
@@ -35,7 +35,10 @@ class MySqlMockConnection implements ConnectionInterface
         return true;
     }
 
-    public function query(string $sql, array $bindings = []): array
+    public function query(
+        string $sql,
+        array $bindings = [],
+    ): array
     {
         $this->lastQuerySql = $sql;
         $this->lastQueryBindings = $bindings;
@@ -43,7 +46,10 @@ class MySqlMockConnection implements ConnectionInterface
         return $this->queryReturn;
     }
 
-    public function execute(string $sql, array $bindings = []): int
+    public function execute(
+        string $sql,
+        array $bindings = [],
+    ): int
     {
         return 0;
     }
@@ -111,22 +117,25 @@ describe('MySqlQueryBuilder JSON operators', function (): void {
             ->and($result)->toHaveCount(1);
     });
 
-    it('returns rows whose JSON object contains a nested value via whereJsonContains() with a path', function (): void {
-        $connection = new MySqlMockConnection(
-            queryReturn: [['id' => 2]],
-        );
-        $builder = new MySqlQueryBuilder($connection);
-
-        $result = $builder
-            ->table('users')
-            ->whereJsonContains('data->roles', 'admin')
-            ->get();
-
-        expect($connection->lastQuerySql)
-            ->toContain("JSON_CONTAINS(JSON_EXTRACT(`data`, '$.roles'), ?)")
-            ->and($connection->lastQueryBindings[0])->toBe('"admin"')
-            ->and($result)->toHaveCount(1);
-    });
+    it(
+        'returns rows whose JSON object contains a nested value via whereJsonContains() with a path',
+        function (): void {
+            $connection = new MySqlMockConnection(
+                queryReturn: [['id' => 2]],
+            );
+            $builder = new MySqlQueryBuilder($connection);
+    
+            $result = $builder
+                ->table('users')
+                ->whereJsonContains('data->roles', 'admin')
+                ->get();
+    
+            expect($connection->lastQuerySql)
+                ->toContain("JSON_CONTAINS(JSON_EXTRACT(`data`, '$.roles'), ?)")
+                ->and($connection->lastQueryBindings[0])->toBe('"admin"')
+                ->and($result)->toHaveCount(1);
+        }
+    );
 
     it('returns rows where a JSON path exists via whereJsonExists()', function (): void {
         $connection = new MySqlMockConnection(
@@ -176,39 +185,42 @@ describe('MySqlQueryBuilder JSON operators', function (): void {
             ->and($connection->lastQueryBindings)->toBe([$maliciousValue]);
     });
 
-    it('emits correct MySQL SQL for every JSON operator (JSON_EXTRACT / JSON_UNQUOTE / JSON_CONTAINS / JSON_CONTAINS_PATH)', function (): void {
-        $connection = new MySqlMockConnection();
-        $builder = new MySqlQueryBuilder($connection);
-
-        // JSON_EXTRACT via -> in WHERE
+    it(
+        'emits correct MySQL SQL for every JSON operator (JSON_EXTRACT / JSON_UNQUOTE / JSON_CONTAINS / JSON_CONTAINS_PATH)',
+        function (): void {
+            $connection = new MySqlMockConnection();
+            $builder = new MySqlQueryBuilder($connection);
+    
+            // JSON_EXTRACT via -> in WHERE
         $builder->table('users')->where('data->user->name', '=', 'Bob')->get();
-        expect($connection->lastQuerySql)
-            ->toContain("JSON_EXTRACT(`data`, '$.user.name')");
-
-        // JSON_UNQUOTE via ->> in WHERE
+            expect($connection->lastQuerySql)
+                ->toContain("JSON_EXTRACT(`data`, '$.user.name')");
+    
+            // JSON_UNQUOTE via ->> in WHERE
         $builder2 = new MySqlQueryBuilder($connection);
-        $builder2->table('users')->where('data->>user', '=', 'Bob')->get();
-        expect($connection->lastQuerySql)
-            ->toContain("JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.user'))");
-
-        // JSON_CONTAINS on plain column
+            $builder2->table('users')->where('data->>user', '=', 'Bob')->get();
+            expect($connection->lastQuerySql)
+                ->toContain("JSON_UNQUOTE(JSON_EXTRACT(`data`, '$.user'))");
+    
+            // JSON_CONTAINS on plain column
         $builder3 = new MySqlQueryBuilder($connection);
-        $builder3->table('users')->whereJsonContains('tags', 'premium')->get();
-        expect($connection->lastQuerySql)
-            ->toContain('JSON_CONTAINS(`tags`, ?)');
-
-        // JSON_CONTAINS_PATH existence
+            $builder3->table('users')->whereJsonContains('tags', 'premium')->get();
+            expect($connection->lastQuerySql)
+                ->toContain('JSON_CONTAINS(`tags`, ?)');
+    
+            // JSON_CONTAINS_PATH existence
         $builder4 = new MySqlQueryBuilder($connection);
-        $builder4->table('users')->whereJsonExists('data->addr')->get();
-        expect($connection->lastQuerySql)
-            ->toContain("JSON_CONTAINS_PATH(`data`, 'one', '$.addr')");
-
-        // NOT JSON_CONTAINS_PATH missing
+            $builder4->table('users')->whereJsonExists('data->addr')->get();
+            expect($connection->lastQuerySql)
+                ->toContain("JSON_CONTAINS_PATH(`data`, 'one', '$.addr')");
+    
+            // NOT JSON_CONTAINS_PATH missing
         $builder5 = new MySqlQueryBuilder($connection);
-        $builder5->table('users')->whereJsonMissing('data->addr')->get();
-        expect($connection->lastQuerySql)
-            ->toContain("NOT JSON_CONTAINS_PATH(`data`, 'one', '$.addr')");
-    });
+            $builder5->table('users')->whereJsonMissing('data->addr')->get();
+            expect($connection->lastQuerySql)
+                ->toContain("NOT JSON_CONTAINS_PATH(`data`, 'one', '$.addr')");
+        }
+    );
 
     it('composes JSON path operators with WHERE, GROUP BY, HAVING, ORDER BY, and LIMIT correctly', function (): void {
         $connection = new MySqlMockConnection();

--- a/packages/database-mysql/tests/Query/MySqlQueryBuilderAggregatesTest.php
+++ b/packages/database-mysql/tests/Query/MySqlQueryBuilderAggregatesTest.php
@@ -165,29 +165,35 @@ describe('MySqlQueryBuilder aggregates', function (): void {
         expect($min)->toBe(20);
     });
 
-    it('rejects aggregate column identifiers that fail the identifier whitelist (no SQL injection)', function (): void {
-        expect(fn () => $this->builder->table('scores')->min('points; DROP TABLE scores--'))
-            ->toThrow(InvalidColumnException::class)
-            ->and(fn () => $this->builder->table('scores')->max("col' OR '1'='1"))
-            ->toThrow(InvalidColumnException::class)
-            ->and(fn () => $this->builder->table('scores')->sum('1=1'))
-            ->toThrow(InvalidColumnException::class)
-            ->and(fn () => $this->builder->table('scores')->avg('/*bad*/'))
-            ->toThrow(InvalidColumnException::class);
-    });
+    it(
+        'rejects aggregate column identifiers that fail the identifier whitelist (no SQL injection)',
+        function (): void {
+            expect(fn () => $this->builder->table('scores')->min('points; DROP TABLE scores--'))
+                ->toThrow(InvalidColumnException::class)
+                ->and(fn () => $this->builder->table('scores')->max("col' OR '1'='1"))
+                ->toThrow(InvalidColumnException::class)
+                ->and(fn () => $this->builder->table('scores')->sum('1=1'))
+                ->toThrow(InvalidColumnException::class)
+                ->and(fn () => $this->builder->table('scores')->avg('/*bad*/'))
+                ->toThrow(InvalidColumnException::class);
+        }
+    );
 
-    it('existing int return type of count() remains int (no nullable); only the signature gains an optional column argument', function (): void {
-        $reflection = new ReflectionClass(MySqlQueryBuilder::class);
-        $method = $reflection->getMethod('count');
-        $returnType = $method->getReturnType();
-        $params = $method->getParameters();
-
-        expect($returnType?->getName())->toBe('int')
-            ->and($returnType?->allowsNull())->toBeFalse()
-            ->and($params)->toHaveCount(1)
-            ->and($params[0]->getName())->toBe('column')
-            ->and($params[0]->isOptional())->toBeTrue()
-            ->and($params[0]->allowsNull())->toBeTrue()
-            ->and($params[0]->getDefaultValue())->toBeNull();
-    });
+    it(
+        'existing int return type of count() remains int (no nullable); only the signature gains an optional column argument',
+        function (): void {
+            $reflection = new ReflectionClass(MySqlQueryBuilder::class);
+            $method = $reflection->getMethod('count');
+            $returnType = $method->getReturnType();
+            $params = $method->getParameters();
+    
+            expect($returnType?->getName())->toBe('int')
+                ->and($returnType?->allowsNull())->toBeFalse()
+                ->and($params)->toHaveCount(1)
+                ->and($params[0]->getName())->toBe('column')
+                ->and($params[0]->isOptional())->toBeTrue()
+                ->and($params[0]->allowsNull())->toBeTrue()
+                ->and($params[0]->getDefaultValue())->toBeNull();
+        }
+    );
 });

--- a/packages/database-mysql/tests/Query/MySqlQueryBuilderGroupByTest.php
+++ b/packages/database-mysql/tests/Query/MySqlQueryBuilderGroupByTest.php
@@ -29,7 +29,10 @@ function makeRecordingConnection(string &$lastSql, array &$lastBindings): MySqlC
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             $this->lastSql = $sql;
             $this->lastBindings = $bindings;
@@ -37,7 +40,10 @@ function makeRecordingConnection(string &$lastSql, array &$lastBindings): MySqlC
             return [];
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             return 0;
         }
@@ -157,19 +163,22 @@ describe('MySqlQueryBuilder GROUP BY / HAVING', function (): void {
         );
     });
 
-    it('validates GROUP BY column identifiers against the alias/identifier whitelist (reuses the whitelist introduced in task 006)', function (): void {
-        $sql = '';
-        $bindings = [];
-        $conn = makeRecordingConnection($sql, $bindings);
-
-        expect(
-            fn () => (new MySqlQueryBuilder($conn))
-            ->table('orders')
-            ->select('status')
-            ->groupBy('status; DROP TABLE orders--')
-            ->get(),
-        )->toThrow(InvalidColumnException::class);
-    });
+    it(
+        'validates GROUP BY column identifiers against the alias/identifier whitelist (reuses the whitelist introduced in task 006)',
+        function (): void {
+            $sql = '';
+            $bindings = [];
+            $conn = makeRecordingConnection($sql, $bindings);
+    
+            expect(
+                fn () => (new MySqlQueryBuilder($conn))
+                ->table('orders')
+                ->select('status')
+                ->groupBy('status; DROP TABLE orders--')
+                ->get(),
+            )->toThrow(InvalidColumnException::class);
+        }
+    );
 
     it('rejects HAVING expressions containing semicolons or SQL comments', function (): void {
         $sql = '';
@@ -204,22 +213,25 @@ describe('MySqlQueryBuilder GROUP BY / HAVING', function (): void {
         )->toThrow(InvalidColumnException::class);
     });
 
-    it('composes HAVING bindings with WHERE bindings in the correct positional order at execute time', function (): void {
-        $sql = '';
-        $bindings = [];
-        $conn = makeRecordingConnection($sql, $bindings);
-
-        (new MySqlQueryBuilder($conn))
-            ->table('orders')
-            ->select('status', 'country')
-            ->where('active', '=', 1)
-            ->groupBy('status', 'country')
-            ->having('COUNT(*) BETWEEN ? AND ?', [3, 10])
-            ->get();
-
-        expect($sql)->toBe(
-            'SELECT `status`, `country` FROM `orders` WHERE `active` = ? GROUP BY `status`, `country` HAVING COUNT(*) BETWEEN ? AND ?',
-        )
-            ->and($bindings)->toBe([1, 3, 10]);
-    });
+    it(
+        'composes HAVING bindings with WHERE bindings in the correct positional order at execute time',
+        function (): void {
+            $sql = '';
+            $bindings = [];
+            $conn = makeRecordingConnection($sql, $bindings);
+    
+            (new MySqlQueryBuilder($conn))
+                ->table('orders')
+                ->select('status', 'country')
+                ->where('active', '=', 1)
+                ->groupBy('status', 'country')
+                ->having('COUNT(*) BETWEEN ? AND ?', [3, 10])
+                ->get();
+    
+            expect($sql)->toBe(
+                'SELECT `status`, `country` FROM `orders` WHERE `active` = ? GROUP BY `status`, `country` HAVING COUNT(*) BETWEEN ? AND ?',
+            )
+                ->and($bindings)->toBe([1, 3, 10]);
+        }
+    );
 });

--- a/packages/database-mysql/tests/Query/MySqlQueryBuilderTest.php
+++ b/packages/database-mysql/tests/Query/MySqlQueryBuilderTest.php
@@ -343,8 +343,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function query(
                 string $sql,
                 array $bindings = [],
-            ): array
-            {
+            ): array {
                 $this->lastSql = $sql;
                 $this->lastBindings = $bindings;
 
@@ -354,8 +353,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function execute(
                 string $sql,
                 array $bindings = [],
-            ): int
-            {
+            ): int {
                 return 0;
             }
         };
@@ -384,14 +382,14 @@ describe('MySqlQueryBuilder', function (): void {
             $left = (new MySqlQueryBuilder($this->connection))
                 ->table('users')
                 ->select('name', 'email');
-    
+
             $right = (new MySqlQueryBuilder($this->connection))
                 ->table('users')
                 ->select('name');
-    
+
             expect(fn () => $left->union($right))
                 ->toThrow(UnionShapeMismatchException::class);
-        }
+        },
     );
 
     it('combines two queries with UNION ALL preserving duplicates', function (): void {
@@ -410,8 +408,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function query(
                 string $sql,
                 array $bindings = [],
-            ): array
-            {
+            ): array {
                 $this->lastSql = $sql;
                 $this->lastBindings = $bindings;
 
@@ -421,8 +418,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function execute(
                 string $sql,
                 array $bindings = [],
-            ): int
-            {
+            ): int {
                 return 0;
             }
         };
@@ -456,8 +452,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function query(
                 string $sql,
                 array $bindings = [],
-            ): array
-            {
+            ): array {
                 $this->lastSql = $sql;
 
                 return [];
@@ -466,8 +461,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function execute(
                 string $sql,
                 array $bindings = [],
-            ): int
-            {
+            ): int {
                 return 0;
             }
         };
@@ -498,8 +492,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function query(
                 string $sql,
                 array $bindings = [],
-            ): array
-            {
+            ): array {
                 $this->lastSql = $sql;
 
                 return [];
@@ -508,8 +501,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function execute(
                 string $sql,
                 array $bindings = [],
-            ): int
-            {
+            ): int {
                 return 0;
             }
         };
@@ -545,8 +537,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function query(
                 string $sql,
                 array $bindings = [],
-            ): array
-            {
+            ): array {
                 $this->lastSql = $sql;
                 $this->lastBindings = $bindings;
 
@@ -556,8 +547,7 @@ describe('MySqlQueryBuilder', function (): void {
             public function execute(
                 string $sql,
                 array $bindings = [],
-            ): int
-            {
+            ): int {
                 return 0;
             }
         };
@@ -650,35 +640,33 @@ describe('MySqlQueryBuilder', function (): void {
                 $recordingConnection = new class ($recordedSql) extends MySqlConnection
                 {
                     public function __construct(public string &$lastSql) {}
-    
+
                     public function connect(): void {}
-    
+
                     public function query(
                         string $sql,
                         array $bindings = [],
-                    ): array
-                    {
+                    ): array {
                         $this->lastSql = $sql;
-    
+
                         return [];
                     }
-    
+
                     public function execute(
                         string $sql,
                         array $bindings = [],
-                    ): int
-                    {
+                    ): int {
                         return 0;
                     }
                 };
-    
+
                 (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->selectRaw('1 AS one')
                     ->get();
-    
+
                 expect($recordedSql)->toBe('SELECT *, 1 AS one FROM `users`');
-            }
+            },
         );
 
         it(
@@ -688,37 +676,35 @@ describe('MySqlQueryBuilder', function (): void {
                 $recordingConnection = new class ($recordedSql) extends MySqlConnection
                 {
                     public function __construct(public string &$lastSql) {}
-    
+
                     public function connect(): void {}
-    
+
                     public function query(
                         string $sql,
                         array $bindings = [],
-                    ): array
-                    {
+                    ): array {
                         $this->lastSql = $sql;
-    
+
                         return [];
                     }
-    
+
                     public function execute(
                         string $sql,
                         array $bindings = [],
-                    ): int
-                    {
+                    ): int {
                         return 0;
                     }
                 };
-    
+
                 (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->select('name')
                     ->selectRaw('1 AS first')
                     ->selectRaw('2 AS second')
                     ->get();
-    
+
                 expect($recordedSql)->toBe('SELECT `name`, 1 AS first, 2 AS second FROM `users`');
-            }
+            },
         );
 
         it(
@@ -728,36 +714,34 @@ describe('MySqlQueryBuilder', function (): void {
                 $recordingConnection = new class ($recordedSql) extends MySqlConnection
                 {
                     public function __construct(public string &$lastSql) {}
-    
+
                     public function connect(): void {}
-    
+
                     public function query(
                         string $sql,
                         array $bindings = [],
-                    ): array
-                    {
+                    ): array {
                         $this->lastSql = $sql;
-    
+
                         return [];
                     }
-    
+
                     public function execute(
                         string $sql,
                         array $bindings = [],
-                    ): int
-                    {
+                    ): int {
                         return 0;
                     }
                 };
-    
+
                 (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->select('name', 'email')
                     ->selectRaw('1 AS computed')
                     ->get();
-    
+
                 expect($recordedSql)->toBe('SELECT `name`, `email`, 1 AS computed FROM `users`');
-            }
+            },
         );
 
         it(
@@ -767,36 +751,34 @@ describe('MySqlQueryBuilder', function (): void {
                 $recordingConnection = new class ($recordedBindings) extends MySqlConnection
                 {
                     public function __construct(public array &$lastBindings) {}
-    
+
                     public function connect(): void {}
-    
+
                     public function query(
                         string $sql,
                         array $bindings = [],
-                    ): array
-                    {
+                    ): array {
                         $this->lastBindings = $bindings;
-    
+
                         return [];
                     }
-    
+
                     public function execute(
                         string $sql,
                         array $bindings = [],
-                    ): int
-                    {
+                    ): int {
                         return 0;
                     }
                 };
-    
+
                 (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->selectRaw('? AS val', [42])
                     ->where('status', '=', 'active')
                     ->get();
-    
+
                 expect($recordedBindings)->toBe([42, 'active']);
-            }
+            },
         );
 
         it('selectRaw bindings from multiple calls concatenate in call order', function (): void {
@@ -810,8 +792,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function query(
                     string $sql,
                     array $bindings = [],
-                ): array
-                {
+                ): array {
                     $this->lastBindings = $bindings;
 
                     return [];
@@ -820,8 +801,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function execute(
                     string $sql,
                     array $bindings = [],
-                ): int
-                {
+                ): int {
                     return 0;
                 }
             };
@@ -846,40 +826,38 @@ describe('MySqlQueryBuilder', function (): void {
                         public array &$sqls,
                         public array &$bindingsList,
                     ) {}
-    
+
                     public function connect(): void {}
-    
+
                     public function query(
                         string $sql,
                         array $bindings = [],
-                    ): array
-                    {
+                    ): array {
                         $this->sqls[] = $sql;
                         $this->bindingsList[] = $bindings;
-    
+
                         return [];
                     }
-    
+
                     public function execute(
                         string $sql,
                         array $bindings = [],
-                    ): int
-                    {
+                    ): int {
                         return 0;
                     }
                 };
-    
+
                 $builder = (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->selectRaw('? AS val', [99])
                     ->where('status', '=', 'active');
-    
+
                 $builder->get();
                 $builder->get();
-    
+
                 expect($sqls[0])->toBe($sqls[1])
                     ->and($bindingsList[0])->toBe($bindingsList[1]);
-            }
+            },
         );
 
         it('selectRaw throws InvalidColumnException when the expression contains a semicolon', function (): void {
@@ -892,7 +870,7 @@ describe('MySqlQueryBuilder', function (): void {
             function (): void {
                 expect(fn () => $this->builder->selectRaw('1 -- comment'))
                     ->toThrow(InvalidColumnException::class);
-            }
+            },
         );
 
         it(
@@ -900,7 +878,7 @@ describe('MySqlQueryBuilder', function (): void {
             function (): void {
                 expect(fn () => $this->builder->selectRaw('/* comment */ 1'))
                     ->toThrow(InvalidColumnException::class);
-            }
+            },
         );
 
         it('selectRaw throws InvalidColumnException when the expression contains a backtick', function (): void {
@@ -924,12 +902,12 @@ describe('MySqlQueryBuilder', function (): void {
                     ->where('status', '=', 'active')
                     ->whereRaw("name != 'Bob'")
                     ->get();
-    
+
                 $names = array_column($results, 'name');
                 expect($results)->toHaveCount(2)
                     ->and($names)->toContain('Alice')
                     ->and($names)->toContain('Charlie');
-            }
+            },
         );
 
         it('whereRaw used alone (no prior where) emits "WHERE <expression>" with no leading AND', function (): void {
@@ -943,8 +921,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function query(
                     string $sql,
                     array $bindings = [],
-                ): array
-                {
+                ): array {
                     $this->lastSql = $sql;
 
                     return [];
@@ -953,8 +930,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function execute(
                     string $sql,
                     array $bindings = [],
-                ): int
-                {
+                ): int {
                     return 0;
                 }
             };
@@ -978,8 +954,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function query(
                     string $sql,
                     array $bindings = [],
-                ): array
-                {
+                ): array {
                     $this->lastSql = $sql;
 
                     return [];
@@ -988,8 +963,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function execute(
                     string $sql,
                     array $bindings = [],
-                ): int
-                {
+                ): int {
                     return 0;
                 }
             };
@@ -1010,36 +984,34 @@ describe('MySqlQueryBuilder', function (): void {
                 $recordingConnection = new class ($recordedSql) extends MySqlConnection
                 {
                     public function __construct(public string &$lastSql) {}
-    
+
                     public function connect(): void {}
-    
+
                     public function query(
                         string $sql,
                         array $bindings = [],
-                    ): array
-                    {
+                    ): array {
                         $this->lastSql = $sql;
-    
+
                         return [];
                     }
-    
+
                     public function execute(
                         string $sql,
                         array $bindings = [],
-                    ): int
-                    {
+                    ): int {
                         return 0;
                     }
                 };
-    
+
                 (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->where('status', '=', 'active')
                     ->whereRaw('name != ?', ['Bob'])
                     ->get();
-    
+
                 expect($recordedSql)->toBe('SELECT * FROM `users` WHERE `status` = ? AND name != ?');
-            }
+            },
         );
 
         it(
@@ -1049,37 +1021,35 @@ describe('MySqlQueryBuilder', function (): void {
                 $recordingConnection = new class ($recordedBindings) extends MySqlConnection
                 {
                     public function __construct(public array &$lastBindings) {}
-    
+
                     public function connect(): void {}
-    
+
                     public function query(
                         string $sql,
                         array $bindings = [],
-                    ): array
-                    {
+                    ): array {
                         $this->lastBindings = $bindings;
-    
+
                         return [];
                     }
-    
+
                     public function execute(
                         string $sql,
                         array $bindings = [],
-                    ): int
-                    {
+                    ): int {
                         return 0;
                     }
                 };
-    
+
                 (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->selectRaw('? AS sel', ['sel_val'])
                     ->where('status', '=', 'active')
                     ->whereRaw('name != ?', ['Bob'])
                     ->get();
-    
+
                 expect($recordedBindings)->toBe(['sel_val', 'active', 'Bob']);
-            }
+            },
         );
 
         it('whereRaw bindings from multiple calls concatenate in call order', function (): void {
@@ -1093,8 +1063,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function query(
                     string $sql,
                     array $bindings = [],
-                ): array
-                {
+                ): array {
                     $this->lastBindings = $bindings;
 
                     return [];
@@ -1103,8 +1072,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function execute(
                     string $sql,
                     array $bindings = [],
-                ): int
-                {
+                ): int {
                     return 0;
                 }
             };
@@ -1152,7 +1120,7 @@ describe('MySqlQueryBuilder', function (): void {
             function (): void {
                 expect(fn () => $this->builder->whereRaw('1 -- comment'))
                     ->toThrow(InvalidColumnException::class);
-            }
+            },
         );
 
         it(
@@ -1160,7 +1128,7 @@ describe('MySqlQueryBuilder', function (): void {
             function (): void {
                 expect(fn () => $this->builder->whereRaw('/* comment */ 1'))
                     ->toThrow(InvalidColumnException::class);
-            }
+            },
         );
 
         it('whereRaw throws InvalidColumnException when the expression contains a backtick', function (): void {
@@ -1182,36 +1150,34 @@ describe('MySqlQueryBuilder', function (): void {
                 $recordingConnection = new class ($recordedBindings) extends MySqlConnection
                 {
                     public function __construct(public array &$lastBindings) {}
-    
+
                     public function connect(): void {}
-    
+
                     public function query(
                         string $sql,
                         array $bindings = [],
-                    ): array
-                    {
+                    ): array {
                         $this->lastBindings = $bindings;
-    
+
                         return [];
                     }
-    
+
                     public function execute(
                         string $sql,
                         array $bindings = [],
-                    ): int
-                    {
+                    ): int {
                         return 0;
                     }
                 };
-    
+
                 (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->selectRaw('? AS sel', ['sel_val'])
                     ->whereRaw('status = ?', ['active'])
                     ->get();
-    
+
                 expect($recordedBindings)->toBe(['sel_val', 'active']);
-            }
+            },
         );
 
         it(
@@ -1225,45 +1191,43 @@ describe('MySqlQueryBuilder', function (): void {
                         public string &$lastSql,
                         public array &$lastBindings,
                     ) {}
-    
+
                     public function connect(): void {}
-    
+
                     public function query(
                         string $sql,
                         array $bindings = [],
-                    ): array
-                    {
+                    ): array {
                         $this->lastSql = $sql;
                         $this->lastBindings = $bindings;
-    
+
                         return [];
                     }
-    
+
                     public function execute(
                         string $sql,
                         array $bindings = [],
-                    ): int
-                    {
+                    ): int {
                         return 0;
                     }
                 };
-    
+
                 $left = (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->select('name');
-    
+
                 $right = (new MySqlQueryBuilder($recordingConnection))
                     ->table('users')
                     ->select('name')
                     ->selectRaw('? AS sel', ['sel_val'])
                     ->whereRaw('status = ?', ['active']);
-    
+
                 $left->union($right)->get();
-    
+
                 expect($recordedSql)->toContain('? AS sel')
                     ->and($recordedSql)->toContain('status = ?')
                     ->and($recordedBindings)->toBe(['sel_val', 'active']);
-            }
+            },
         );
     });
 
@@ -1279,8 +1243,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function query(
                     string $sql,
                     array $bindings = [],
-                ): array
-                {
+                ): array {
                     $this->lastSql = $sql;
 
                     return [];
@@ -1289,8 +1252,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function execute(
                     string $sql,
                     array $bindings = [],
-                ): int
-                {
+                ): int {
                     return 0;
                 }
             };
@@ -1315,8 +1277,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function query(
                     string $sql,
                     array $bindings = [],
-                ): array
-                {
+                ): array {
                     $this->lastSql = $sql;
 
                     return [];
@@ -1325,8 +1286,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function execute(
                     string $sql,
                     array $bindings = [],
-                ): int
-                {
+                ): int {
                     return 0;
                 }
             };
@@ -1351,8 +1311,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function query(
                     string $sql,
                     array $bindings = [],
-                ): array
-                {
+                ): array {
                     $this->lastSql = $sql;
 
                     return [];
@@ -1361,8 +1320,7 @@ describe('MySqlQueryBuilder', function (): void {
                 public function execute(
                     string $sql,
                     array $bindings = [],
-                ): int
-                {
+                ): int {
                     return 0;
                 }
             };

--- a/packages/database-pgsql/src/Query/PgSqlQueryBuilder.php
+++ b/packages/database-pgsql/src/Query/PgSqlQueryBuilder.php
@@ -299,7 +299,7 @@ class PgSqlQueryBuilder implements QueryBuilderInterface
         foreach ($columns as $column) {
             if (!IdentifierValidator::isValidIdentifier($column) && !preg_match(
                 '/^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$/',
-                $column
+                $column,
             )) {
                 throw InvalidColumnException::invalidColumn($column);
             }

--- a/packages/database-pgsql/tests/Fixtures/Variant/VariantQueryBuilder.php
+++ b/packages/database-pgsql/tests/Fixtures/Variant/VariantQueryBuilder.php
@@ -21,8 +21,7 @@ class VariantQueryBuilder implements QueryBuilderInterface
     public function selectRaw(
         string $expression,
         array $bindings = [],
-    ): static
-    {
+    ): static {
         return $this;
     }
 
@@ -35,16 +34,14 @@ class VariantQueryBuilder implements QueryBuilderInterface
         string $column,
         string $operator,
         mixed $value,
-    ): static
-    {
+    ): static {
         return $this;
     }
 
     public function whereIn(
         string $column,
         array $values,
-    ): static
-    {
+    ): static {
         return $this;
     }
 
@@ -61,8 +58,7 @@ class VariantQueryBuilder implements QueryBuilderInterface
     public function whereJsonContains(
         string $path,
         mixed $value,
-    ): static
-    {
+    ): static {
         return $this;
     }
 
@@ -80,16 +76,14 @@ class VariantQueryBuilder implements QueryBuilderInterface
         string $column,
         string $operator,
         mixed $value,
-    ): static
-    {
+    ): static {
         return $this;
     }
 
     public function whereRaw(
         string $expression,
         array $bindings = [],
-    ): static
-    {
+    ): static {
         return $this;
     }
 
@@ -98,8 +92,7 @@ class VariantQueryBuilder implements QueryBuilderInterface
         string $first,
         string $operator,
         string $second,
-    ): static
-    {
+    ): static {
         return $this;
     }
 
@@ -108,8 +101,7 @@ class VariantQueryBuilder implements QueryBuilderInterface
         string $first,
         string $operator,
         string $second,
-    ): static
-    {
+    ): static {
         return $this;
     }
 
@@ -118,8 +110,7 @@ class VariantQueryBuilder implements QueryBuilderInterface
         string $first,
         string $operator,
         string $second,
-    ): static
-    {
+    ): static {
         return $this;
     }
 
@@ -131,24 +122,21 @@ class VariantQueryBuilder implements QueryBuilderInterface
     public function having(
         string $expression,
         array $bindings = [],
-    ): static
-    {
+    ): static {
         return $this;
     }
 
     public function orderBy(
         string $column,
         string $direction = 'ASC',
-    ): static
-    {
+    ): static {
         return $this;
     }
 
     public function orderByRaw(
         string $expression,
         string $direction = 'ASC',
-    ): static
-    {
+    ): static {
         return $this;
     }
 
@@ -235,8 +223,7 @@ class VariantQueryBuilder implements QueryBuilderInterface
     public function raw(
         string $sql,
         array $bindings = [],
-    ): array
-    {
+    ): array {
         return [];
     }
 }

--- a/packages/database-pgsql/tests/Fixtures/Variant/VariantSqlGenerator.php
+++ b/packages/database-pgsql/tests/Fixtures/Variant/VariantSqlGenerator.php
@@ -36,16 +36,14 @@ class VariantSqlGenerator implements SqlGeneratorInterface
     public function generateAddColumn(
         string $table,
         Column $column,
-    ): string
-    {
+    ): string {
         return '';
     }
 
     public function generateDropColumn(
         string $table,
         string $columnName,
-    ): string
-    {
+    ): string {
         return '';
     }
 
@@ -53,40 +51,35 @@ class VariantSqlGenerator implements SqlGeneratorInterface
         string $table,
         Column $column,
         Column $oldColumn,
-    ): string
-    {
+    ): string {
         return '';
     }
 
     public function generateAddIndex(
         string $table,
         Index $index,
-    ): string
-    {
+    ): string {
         return '';
     }
 
     public function generateDropIndex(
         string $table,
         string $indexName,
-    ): string
-    {
+    ): string {
         return '';
     }
 
     public function generateAddForeignKey(
         string $table,
         ForeignKey $foreignKey,
-    ): string
-    {
+    ): string {
         return '';
     }
 
     public function generateDropForeignKey(
         string $table,
         string $keyName,
-    ): string
-    {
+    ): string {
         return '';
     }
 }

--- a/packages/database-pgsql/tests/Module/DialectOverrideTest.php
+++ b/packages/database-pgsql/tests/Module/DialectOverrideTest.php
@@ -104,31 +104,32 @@ describe('Dialect override via boot callback', function (): void {
         'still resolves ConnectionInterface to PgSqlConnection because the variant did not rebind it',
         function (): void {
             $container = buildVariantContainer();
-    
+
             // PgSqlConnection requires DatabaseConfig which in turn requires ProjectPaths.
-        // Resolving the class binding is enough to prove ConnectionInterface is still
-        // bound to PgSqlConnection — we verify by inspecting the binding, not by
-        // constructing the full object (which requires a real config file).
-        // We do this by binding a minimal stub for DatabaseConfig's dependency and
-        // checking the binding resolves to the correct class.
-        //
-        // Simpler: just assert the container would resolve to PgSqlConnection by
-        // checking it IS registered and not overridden by the variant.
-        // We use the container's has() + a Closure binding trick to inspect without
-        // instantiating the full dependency graph.
-        $container2 = buildVariantContainer();
+            // Resolving the class binding is enough to prove ConnectionInterface is still
+            // bound to PgSqlConnection — we verify by inspecting the binding, not by
+            // constructing the full object (which requires a real config file).
+            // We do this by binding a minimal stub for DatabaseConfig's dependency and
+            // checking the binding resolves to the correct class.
+            //
+            // Simpler: just assert the container would resolve to PgSqlConnection by
+            // checking it IS registered and not overridden by the variant.
+            // We use the container's has() + a Closure binding trick to inspect without
+            // instantiating the full dependency graph.
+            $container2 = buildVariantContainer();
             $container2->bind(
                 ConnectionInterface::class,
                 /** @noinspection PhpMissingParentConstructorInspection - Test stub intentionally skips parent */
-                static fn () => new class () extends PgSqlConnection {
+                static fn () => new class () extends PgSqlConnection
+                {
                     /** @noinspection PhpMissingParentConstructorInspection */
                     public function __construct() {}
                 },
             );
-    
+
             expect($container2->get(ConnectionInterface::class))
                 ->toBeInstanceOf(PgSqlConnection::class);
-        }
+        },
     );
 
     it(
@@ -136,14 +137,14 @@ describe('Dialect override via boot callback', function (): void {
         function (): void {
             $modulePath = dirname(__DIR__, 2);
             $pgsqlConfig = require $modulePath . '/module.php';
-    
+
             $moduleA = new ModuleManifest(
                 name: 'marko/database-pgsql',
                 version: '1.0.0',
                 bindings: $pgsqlConfig['bindings'],
                 source: 'vendor',
             );
-    
+
             $moduleB = new ModuleManifest(
                 name: 'acme/database-cockroach',
                 version: '1.0.0',
@@ -152,14 +153,14 @@ describe('Dialect override via boot callback', function (): void {
                 ],
                 source: 'vendor',
             );
-    
+
             $container = new Container();
             $registry = new BindingRegistry($container);
             $registry->registerModule($moduleA);
-    
+
             expect(static fn () => $registry->registerModule($moduleB))
                 ->toThrow(BindingConflictException::class);
-        }
+        },
     );
 
     it(
@@ -167,16 +168,16 @@ describe('Dialect override via boot callback', function (): void {
         function (): void {
             $modulePath = dirname(__DIR__, 2);
             $pgsqlConfig = require $modulePath . '/module.php';
-    
+
             $singletons = $pgsqlConfig['singletons'] ?? [];
-    
+
             $dialectInterfaces = [
                 SqlGeneratorInterface::class,
                 IntrospectorInterface::class,
                 QueryBuilderInterface::class,
                 QueryBuilderFactoryInterface::class,
             ];
-    
+
             foreach ($dialectInterfaces as $interface) {
                 expect(in_array($interface, $singletons, strict: true))->toBeFalse(
                     "Expected $interface to NOT be in pgsql singletons, but it was. "
@@ -187,6 +188,6 @@ describe('Dialect override via boot callback', function (): void {
                         . 'Declaring dialect interfaces as singletons would break the boot-callback override pattern.',
                     );
             }
-        }
+        },
     );
 });

--- a/packages/database-pgsql/tests/Query/PgSqlJsonQueryBuilderTest.php
+++ b/packages/database-pgsql/tests/Query/PgSqlJsonQueryBuilderTest.php
@@ -104,16 +104,16 @@ describe('PgSqlQueryBuilder JSON operators', function (): void {
                 queryReturn: [['id' => 2]],
             );
             $builder = new PgSqlQueryBuilder($connection);
-    
+
             $result = $builder
                 ->table('users')
                 ->whereJsonContains('data->roles', 'admin')
                 ->get();
-    
+
             expect($connection->lastQuerySql)
                 ->toContain('"data"->\'roles\' @> ?')
                 ->and($result)->toHaveCount(1);
-        }
+        },
     );
 
     it('returns rows where a JSON path exists via whereJsonExists()', function (): void {

--- a/packages/database-pgsql/tests/Query/PgSqlQueryBuilderGroupByTest.php
+++ b/packages/database-pgsql/tests/Query/PgSqlQueryBuilderGroupByTest.php
@@ -98,7 +98,7 @@ describe('PgSqlQueryBuilder GROUP BY / HAVING', function (): void {
         'validates GROUP BY column identifiers against the alias/identifier whitelist (reuses the whitelist introduced in task 006)',
         function (): void {
             $conn = new MockConnection();
-    
+
             expect(
                 fn () => (new PgSqlQueryBuilder($conn))
                 ->table('orders')
@@ -106,7 +106,7 @@ describe('PgSqlQueryBuilder GROUP BY / HAVING', function (): void {
                 ->groupBy('status; DROP TABLE orders--')
                 ->get(),
             )->toThrow(InvalidColumnException::class);
-        }
+        },
     );
 
     it('rejects HAVING expressions containing semicolons or SQL comments', function (): void {
@@ -144,7 +144,7 @@ describe('PgSqlQueryBuilder GROUP BY / HAVING', function (): void {
         'composes HAVING bindings with WHERE bindings in the correct positional order at execute time',
         function (): void {
             $conn = new MockConnection();
-    
+
             (new PgSqlQueryBuilder($conn))
                 ->table('orders')
                 ->select('status', 'country')
@@ -152,11 +152,11 @@ describe('PgSqlQueryBuilder GROUP BY / HAVING', function (): void {
                 ->groupBy('status', 'country')
                 ->having('COUNT(*) BETWEEN ? AND ?', [3, 10])
                 ->get();
-    
+
             expect($conn->lastQuerySql)->toBe(
                 'SELECT "status", "country" FROM "orders" WHERE "active" = ? GROUP BY "status", "country" HAVING COUNT(*) BETWEEN ? AND ?',
             )
                 ->and($conn->lastQueryBindings)->toBe([1, 3, 10]);
-        }
+        },
     );
 });

--- a/packages/database-pgsql/tests/Query/PgSqlQueryBuilderTest.php
+++ b/packages/database-pgsql/tests/Query/PgSqlQueryBuilderTest.php
@@ -258,16 +258,16 @@ describe('PgSqlQueryBuilder', function (): void {
         'throws UnionShapeMismatchException when the two queries select different numbers of columns',
         function (): void {
             $connection = new MockConnection();
-    
+
             $left = new PgSqlQueryBuilder($connection);
             $left->table('users')->select('name', 'email');
-    
+
             $right = new PgSqlQueryBuilder(new MockConnection());
             $right->table('admins')->select('name');
-    
+
             expect(fn () => $left->union($right))
                 ->toThrow(UnionShapeMismatchException::class);
-        }
+        },
     );
 
     it('combines two queries with UNION ALL preserving duplicates', function (): void {

--- a/packages/database-readwrite/tests/Module/ModuleBootTest.php
+++ b/packages/database-readwrite/tests/Module/ModuleBootTest.php
@@ -29,16 +29,14 @@ function makeTestConnection(): ConnectionInterface&TransactionInterface
         public function query(
             string $sql,
             array $bindings = [],
-        ): array
-        {
+        ): array {
             return [];
         }
 
         public function execute(
             string $sql,
             array $bindings = [],
-        ): int
-        {
+        ): int {
             return 0;
         }
 
@@ -98,8 +96,7 @@ function makeConfigRepository(
         public function get(
             string $key,
             ?string $scope = null,
-        ): mixed
-        {
+        ): mixed {
             return match ($key) {
                 'database.driver' => $this->driver,
                 'database.connections' => [
@@ -114,48 +111,42 @@ function makeConfigRepository(
         public function has(
             string $key,
             ?string $scope = null,
-        ): bool
-        {
+        ): bool {
             return true;
         }
 
         public function getString(
             string $key,
             ?string $scope = null,
-        ): string
-        {
+        ): string {
             return '';
         }
 
         public function getInt(
             string $key,
             ?string $scope = null,
-        ): int
-        {
+        ): int {
             return 0;
         }
 
         public function getBool(
             string $key,
             ?string $scope = null,
-        ): bool
-        {
+        ): bool {
             return false;
         }
 
         public function getFloat(
             string $key,
             ?string $scope = null,
-        ): float
-        {
+        ): float {
             return 0.0;
         }
 
         public function getArray(
             string $key,
             ?string $scope = null,
-        ): array
-        {
+        ): array {
             return [];
         }
 
@@ -202,8 +193,7 @@ function makeTestContainer(ConfigRepositoryInterface $config, ConnectionFactoryI
         public function instance(
             string $id,
             object $instance,
-        ): void
-        {
+        ): void {
             $this->registered[$id] = $instance;
         }
 
@@ -311,8 +301,7 @@ describe('module boot callback', function (): void {
             public function get(
                 string $key,
                 ?string $scope = null,
-            ): mixed
-            {
+            ): mixed {
                 return match ($key) {
                     'database.driver' => 'readwrite',
                     'database.connections' => [
@@ -330,48 +319,42 @@ describe('module boot callback', function (): void {
             public function has(
                 string $key,
                 ?string $scope = null,
-            ): bool
-            {
+            ): bool {
                 return true;
             }
 
             public function getString(
                 string $key,
                 ?string $scope = null,
-            ): string
-            {
+            ): string {
                 return '';
             }
 
             public function getInt(
                 string $key,
                 ?string $scope = null,
-            ): int
-            {
+            ): int {
                 return 0;
             }
 
             public function getBool(
                 string $key,
                 ?string $scope = null,
-            ): bool
-            {
+            ): bool {
                 return false;
             }
 
             public function getFloat(
                 string $key,
                 ?string $scope = null,
-            ): float
-            {
+            ): float {
                 return 0.0;
             }
 
             public function getArray(
                 string $key,
                 ?string $scope = null,
-            ): array
-            {
+            ): array {
                 return [];
             }
 

--- a/packages/database/src/Entity/EntityCollection.php
+++ b/packages/database/src/Entity/EntityCollection.php
@@ -115,7 +115,10 @@ class EntityCollection implements Countable, IteratorAggregate
     /**
      * @return self<T>
      */
-    public function sortBy(string $property, bool $descending = false): self
+    public function sortBy(
+        string $property,
+        bool $descending = false,
+    ): self
     {
         $sorted = $this->entities;
         usort($sorted, function (Entity $a, Entity $b) use ($property, $descending): int {

--- a/packages/database/src/Entity/EntityCompanionStorage.php
+++ b/packages/database/src/Entity/EntityCompanionStorage.php
@@ -67,7 +67,10 @@ class EntityCompanionStorage
     /**
      * Attach a companion to an entity, keyed by the companion's class.
      */
-    public function attach(Entity $entity, Entity $companion): void
+    public function attach(
+        Entity $entity,
+        Entity $companion,
+    ): void
     {
         $bag = $this->companions[$entity] ?? [];
         $bag[$companion::class] = $companion;

--- a/packages/database/src/Entity/EntityHydrator.php
+++ b/packages/database/src/Entity/EntityHydrator.php
@@ -235,7 +235,10 @@ class EntityHydrator
      * Delegates into the shared EntityCompanionStorage so companions set here
      * are visible through Entity::companions() / Entity::companion().
      */
-    public function attachCompanion(Entity $entity, Entity $companion): void
+    public function attachCompanion(
+        Entity $entity,
+        Entity $companion,
+    ): void
     {
         EntityCompanionStorage::instance()->attach($entity, $companion);
     }

--- a/packages/database/src/Entity/RelationshipLoader.php
+++ b/packages/database/src/Entity/RelationshipLoader.php
@@ -410,7 +410,10 @@ readonly class RelationshipLoader
      * @param Entity[] $entities
      * @return array<mixed>
      */
-    private function collectPropertyValues(array $entities, string $propertyName): array
+    private function collectPropertyValues(
+        array $entities,
+        string $propertyName,
+    ): array
     {
         return array_map(fn (Entity $entity) => $this->getPropertyValue($entity, $propertyName), $entities);
     }
@@ -418,7 +421,10 @@ readonly class RelationshipLoader
     /**
      * Get a property value from an entity via reflection.
      */
-    private function getPropertyValue(Entity $entity, string $propertyName): mixed
+    private function getPropertyValue(
+        Entity $entity,
+        string $propertyName,
+    ): mixed
     {
         $reflection = new ReflectionClass($entity);
         $property = $reflection->getProperty($propertyName);
@@ -433,7 +439,11 @@ readonly class RelationshipLoader
     /**
      * Set a property value on an entity via reflection.
      */
-    private function setProperty(Entity $entity, string $propertyName, mixed $value): void
+    private function setProperty(
+        Entity $entity,
+        string $propertyName,
+        mixed $value,
+    ): void
     {
         $reflection = new ReflectionClass($entity);
         $property = $reflection->getProperty($propertyName);
@@ -454,7 +464,11 @@ readonly class RelationshipLoader
      *
      * @param Entity[] $entities
      */
-    private function setPropertyOnAll(array $entities, string $propertyName, mixed $value): void
+    private function setPropertyOnAll(
+        array $entities,
+        string $propertyName,
+        mixed $value,
+    ): void
     {
         foreach ($entities as $entity) {
             $this->setProperty($entity, $propertyName, $value);

--- a/packages/database/src/Repository/RepositoryQueryBuilder.php
+++ b/packages/database/src/Repository/RepositoryQueryBuilder.php
@@ -102,7 +102,10 @@ class RepositoryQueryBuilder implements EntityQueryBuilderInterface
         return $this;
     }
 
-    public function whereJsonContains(string $path, mixed $value): static
+    public function whereJsonContains(
+        string $path,
+        mixed $value,
+    ): static
     {
         $this->queryBuilder->whereJsonContains($path, $value);
 
@@ -192,7 +195,10 @@ class RepositoryQueryBuilder implements EntityQueryBuilderInterface
         return $this;
     }
 
-    public function having(string $expression, array $bindings = []): static
+    public function having(
+        string $expression,
+        array $bindings = [],
+    ): static
     {
         $this->queryBuilder->having($expression, $bindings);
 

--- a/packages/database/src/Schema/SchemaRegistry.php
+++ b/packages/database/src/Schema/SchemaRegistry.php
@@ -168,7 +168,10 @@ class SchemaRegistry
                     }
 
                     // Merge foreign keys (use parent table name for FK name generation)
-                    foreach ($this->schemaBuilder->buildForeignKeysForTable($parentMetadata->tableName, $extenderMetadata->columns) as $fk) {
+                    foreach ($this->schemaBuilder->buildForeignKeysForTable(
+                        $parentMetadata->tableName,
+                        $extenderMetadata->columns
+                    ) as $fk) {
                         $table = $table->withForeignKey($fk);
                     }
                 }

--- a/packages/database/tests/Attributes/RelationshipAttributeTest.php
+++ b/packages/database/tests/Attributes/RelationshipAttributeTest.php
@@ -21,7 +21,12 @@ class RelUserEntity extends Entity
     #[HasMany(RelPostEntity::class, foreignKey: 'author_id')]
     public array $posts = [];
 
-    #[BelongsToMany(RelRoleEntity::class, pivotClass: RelUserRoleEntity::class, foreignKey: 'user_id', relatedKey: 'role_id')]
+    #[BelongsToMany(
+        RelRoleEntity::class,
+        pivotClass: RelUserRoleEntity::class,
+        foreignKey: 'user_id',
+        relatedKey: 'role_id'
+    )]
     public array $roles = [];
 }
 

--- a/packages/database/tests/Entity/EntityCollectionTest.php
+++ b/packages/database/tests/Entity/EntityCollectionTest.php
@@ -160,7 +160,9 @@ describe('Filtering & Transformation', function (): void {
     it('checks contains with callback returning false when no match', function (): void {
         $collection = new EntityCollection([makeEntity(1, 'Alice'), makeEntity(2, 'Bob')]);
 
-        expect($collection->contains(fn (Entity $e): bool => $e->name === 'Charlie'))->toBeFalse(); // @phpstan-ignore-line
+        expect(
+            $collection->contains(fn (Entity $e): bool => $e->name === 'Charlie')
+        )->toBeFalse(); // @phpstan-ignore-line
     });
 });
 

--- a/packages/database/tests/Entity/EntityHydratorTest.php
+++ b/packages/database/tests/Entity/EntityHydratorTest.php
@@ -663,7 +663,9 @@ it('hydrates the parent and multiple companions when metadata has multiple exten
 
     expect($entity->companions())->toHaveCount(2)
         ->and($entity->companion(HydratorTestProductExt::class))->toBeInstanceOf(HydratorTestProductExt::class)
-        ->and($entity->companion(HydratorTestProductPricing::class))->toBeInstanceOf(HydratorTestProductPricing::class);
+        ->and($entity->companion(HydratorTestProductPricing::class))->toBeInstanceOf(
+            HydratorTestProductPricing::class
+        );
 });
 
 it('attaches each companion under its own class-string in the companions bag', function (): void {
@@ -815,51 +817,60 @@ it('extractAll uses each companion\'s own metadata for column resolution', funct
         ->and($extracted['price'])->toBe(19.99);
 });
 
-it('does not require the EntityMetadataFactory call for entities without extenders (no extra parse)', function (): void {
-    // Factory with no entries — if parse() is called it will throw a key error
+it(
+    'does not require the EntityMetadataFactory call for entities without extenders (no extra parse)',
+    function (): void {
+        // Factory with no entries — if parse() is called it will throw a key error
     $factory = createStubMetadataFactory([]);
-    $hydrator = new EntityHydrator($factory);
+        $hydrator = new EntityHydrator($factory);
+        $metadata = createProductMetadata(); // extenders: []
+
+        $row = ['id' => 1, 'name' => 'Safe'];
+    
+        // Should not throw even though factory has no entries
+    /** @var HydratorTestProduct $entity */
+        $entity = $hydrator->hydrate(HydratorTestProduct::class, $row, $metadata);
+    
+        expect($entity)->toBeInstanceOf(HydratorTestProduct::class);
+    }
+);
+
+it(
+    'constructs without the EntityMetadataFactory and hydrates non-extended entities correctly (backward compat)',
+    function (): void {
+        $hydrator = new EntityHydrator(); // no factory
     $metadata = createProductMetadata(); // extenders: []
 
-    $row = ['id' => 1, 'name' => 'Safe'];
+        $row = ['id' => 10, 'name' => 'Compat'];
+        /** @var HydratorTestProduct $entity */
+        $entity = $hydrator->hydrate(HydratorTestProduct::class, $row, $metadata);
+    
+        expect($entity)->toBeInstanceOf(HydratorTestProduct::class)
+            ->and($entity->id)->toBe(10)
+            ->and($entity->name)->toBe('Compat');
+    }
+);
 
-    // Should not throw even though factory has no entries
-    /** @var HydratorTestProduct $entity */
-    $entity = $hydrator->hydrate(HydratorTestProduct::class, $row, $metadata);
-
-    expect($entity)->toBeInstanceOf(HydratorTestProduct::class);
-});
-
-it('constructs without the EntityMetadataFactory and hydrates non-extended entities correctly (backward compat)', function (): void {
-    $hydrator = new EntityHydrator(); // no factory
-    $metadata = createProductMetadata(); // extenders: []
-
-    $row = ['id' => 10, 'name' => 'Compat'];
-    /** @var HydratorTestProduct $entity */
-    $entity = $hydrator->hydrate(HydratorTestProduct::class, $row, $metadata);
-
-    expect($entity)->toBeInstanceOf(HydratorTestProduct::class)
-        ->and($entity->id)->toBe(10)
-        ->and($entity->name)->toBe('Compat');
-});
-
-it('correctly hydrates companions when the factory has not seen the extender classes before (on-demand parse)', function (): void {
-    // Use a real EntityMetadataFactory — it has never parsed HydratorTestProductExt before
+it(
+    'correctly hydrates companions when the factory has not seen the extender classes before (on-demand parse)',
+    function (): void {
+        // Use a real EntityMetadataFactory — it has never parsed HydratorTestProductExt before
     $factory = new EntityMetadataFactory();
-    $hydrator = new EntityHydrator($factory);
-    $metadata = createProductMetadataWithExtenders(HydratorTestProductExt::class);
-
-    $row = ['id' => 4, 'name' => 'Fresh', 'sku' => 'FRS-04', 'stock' => 7];
-    /** @var HydratorTestProduct $entity */
-    $entity = $hydrator->hydrate(HydratorTestProduct::class, $row, $metadata);
-
-    /** @var HydratorTestProductExt $ext */
-    $ext = $entity->companion(HydratorTestProductExt::class);
-
-    expect($ext)->toBeInstanceOf(HydratorTestProductExt::class)
-        ->and($ext->sku)->toBe('FRS-04')
-        ->and($ext->stock)->toBe(7);
-});
+        $hydrator = new EntityHydrator($factory);
+        $metadata = createProductMetadataWithExtenders(HydratorTestProductExt::class);
+    
+        $row = ['id' => 4, 'name' => 'Fresh', 'sku' => 'FRS-04', 'stock' => 7];
+        /** @var HydratorTestProduct $entity */
+        $entity = $hydrator->hydrate(HydratorTestProduct::class, $row, $metadata);
+    
+        /** @var HydratorTestProductExt $ext */
+        $ext = $entity->companion(HydratorTestProductExt::class);
+    
+        expect($ext)->toBeInstanceOf(HydratorTestProductExt::class)
+            ->and($ext->sku)->toBe('FRS-04')
+            ->and($ext->stock)->toBe(7);
+    }
+);
 
 // -------------------------------------------------------------------------
 // Helper functions to create metadata

--- a/packages/database/tests/Entity/EntityMetadataFactoryRelationshipTest.php
+++ b/packages/database/tests/Entity/EntityMetadataFactoryRelationshipTest.php
@@ -303,7 +303,12 @@ it('parses BelongsToMany attribute from entity property', function (): void {
         #[Column(primaryKey: true, autoIncrement: true)]
         public int $id;
 
-        #[BelongsToMany(entityClass: Entity::class, pivotClass: Entity::class, foreignKey: 'user_id', relatedKey: 'role_id')]
+        #[BelongsToMany(
+            entityClass: Entity::class,
+            pivotClass: Entity::class,
+            foreignKey: 'user_id',
+            relatedKey: 'role_id'
+        )]
         public array $roles = [];
     };
 
@@ -318,7 +323,12 @@ it('extracts entity class from BelongsToMany attribute', function (): void {
         #[Column(primaryKey: true, autoIncrement: true)]
         public int $id;
 
-        #[BelongsToMany(entityClass: Entity::class, pivotClass: Entity::class, foreignKey: 'user_id', relatedKey: 'role_id')]
+        #[BelongsToMany(
+            entityClass: Entity::class,
+            pivotClass: Entity::class,
+            foreignKey: 'user_id',
+            relatedKey: 'role_id'
+        )]
         public array $roles = [];
     };
 
@@ -333,7 +343,12 @@ it('extracts pivot class from BelongsToMany attribute', function (): void {
         #[Column(primaryKey: true, autoIncrement: true)]
         public int $id;
 
-        #[BelongsToMany(entityClass: Entity::class, pivotClass: Entity::class, foreignKey: 'user_id', relatedKey: 'role_id')]
+        #[BelongsToMany(
+            entityClass: Entity::class,
+            pivotClass: Entity::class,
+            foreignKey: 'user_id',
+            relatedKey: 'role_id'
+        )]
         public array $roles = [];
     };
 
@@ -348,7 +363,12 @@ it('extracts foreign key from BelongsToMany attribute', function (): void {
         #[Column(primaryKey: true, autoIncrement: true)]
         public int $id;
 
-        #[BelongsToMany(entityClass: Entity::class, pivotClass: Entity::class, foreignKey: 'user_id', relatedKey: 'role_id')]
+        #[BelongsToMany(
+            entityClass: Entity::class,
+            pivotClass: Entity::class,
+            foreignKey: 'user_id',
+            relatedKey: 'role_id'
+        )]
         public array $roles = [];
     };
 
@@ -363,7 +383,12 @@ it('extracts related key from BelongsToMany attribute', function (): void {
         #[Column(primaryKey: true, autoIncrement: true)]
         public int $id;
 
-        #[BelongsToMany(entityClass: Entity::class, pivotClass: Entity::class, foreignKey: 'user_id', relatedKey: 'role_id')]
+        #[BelongsToMany(
+            entityClass: Entity::class,
+            pivotClass: Entity::class,
+            foreignKey: 'user_id',
+            relatedKey: 'role_id'
+        )]
         public array $roles = [];
     };
 
@@ -378,7 +403,12 @@ it('sets relationship type to BelongsToMany', function (): void {
         #[Column(primaryKey: true, autoIncrement: true)]
         public int $id;
 
-        #[BelongsToMany(entityClass: Entity::class, pivotClass: Entity::class, foreignKey: 'user_id', relatedKey: 'role_id')]
+        #[BelongsToMany(
+            entityClass: Entity::class,
+            pivotClass: Entity::class,
+            foreignKey: 'user_id',
+            relatedKey: 'role_id'
+        )]
         public array $roles = [];
     };
 
@@ -450,7 +480,12 @@ it('accepts EntityCollection type for BelongsToMany property', function (): void
         #[Column(primaryKey: true, autoIncrement: true)]
         public int $id;
 
-        #[BelongsToMany(entityClass: Entity::class, pivotClass: Entity::class, foreignKey: 'user_id', relatedKey: 'role_id')]
+        #[BelongsToMany(
+            entityClass: Entity::class,
+            pivotClass: Entity::class,
+            foreignKey: 'user_id',
+            relatedKey: 'role_id'
+        )]
         public EntityCollection $roles;
     };
 

--- a/packages/database/tests/Entity/EntityTest.php
+++ b/packages/database/tests/Entity/EntityTest.php
@@ -140,18 +140,21 @@ it('overwrites an existing companion of the same class when reattached', functio
         ->and($parent->companion(CompanionEntity::class))->toBe($second);
 });
 
-it('shares storage between the public Entity::attachCompanion and the internal hydrator attach (one WeakMap, not two)', function (): void {
-    $hydrator = new EntityHydrator();
-    $parent = new ParentEntity();
-    $companionViaEntity = new CompanionEntity();
-    $companionViaHydrator = new AnotherCompanionEntity();
-
-    // Attach one via Entity public API, one via hydrator internal API
+it(
+    'shares storage between the public Entity::attachCompanion and the internal hydrator attach (one WeakMap, not two)',
+    function (): void {
+        $hydrator = new EntityHydrator();
+        $parent = new ParentEntity();
+        $companionViaEntity = new CompanionEntity();
+        $companionViaHydrator = new AnotherCompanionEntity();
+    
+        // Attach one via Entity public API, one via hydrator internal API
     $parent->attachCompanion($companionViaEntity);
-    $hydrator->attachCompanion($parent, $companionViaHydrator);
-
-    // Both are visible through the same Entity::companions() call
+        $hydrator->attachCompanion($parent, $companionViaHydrator);
+    
+        // Both are visible through the same Entity::companions() call
     expect($parent->companions())->toHaveCount(2)
-        ->and($parent->companion(CompanionEntity::class))->toBe($companionViaEntity)
-        ->and($parent->companion(AnotherCompanionEntity::class))->toBe($companionViaHydrator);
-});
+            ->and($parent->companion(CompanionEntity::class))->toBe($companionViaEntity)
+            ->and($parent->companion(AnotherCompanionEntity::class))->toBe($companionViaHydrator);
+    }
+);

--- a/packages/database/tests/Entity/RelationshipLoaderBelongsToManyTest.php
+++ b/packages/database/tests/Entity/RelationshipLoaderBelongsToManyTest.php
@@ -373,7 +373,10 @@ function makeBtmFakeQueryBuilder(array $rows): QueryBuilderInterface
             return [];
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -393,7 +396,10 @@ function makeBtmFakeQueryBuilder(array $rows): QueryBuilderInterface
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -649,7 +655,10 @@ function makeBtmDataAndTrackingFactory(array $responsesQueue, array &$queries): 
                     return [];
                 }
 
-                public function whereJsonContains(string $path, mixed $value): static
+                public function whereJsonContains(
+                    string $path,
+                    mixed $value,
+                ): static
                 {
                     return $this;
                 }
@@ -669,7 +678,10 @@ function makeBtmDataAndTrackingFactory(array $responsesQueue, array &$queries): 
                     return $this;
                 }
 
-                public function having(string $expression, array $bindings = []): static
+                public function having(
+                    string $expression,
+                    array $bindings = [],
+                ): static
                 {
                     return $this;
                 }

--- a/packages/database/tests/Entity/RelationshipLoaderNestedTest.php
+++ b/packages/database/tests/Entity/RelationshipLoaderNestedTest.php
@@ -383,7 +383,10 @@ function makeNestedFakeQueryBuilder(array $rows): QueryBuilderInterface
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -538,7 +541,10 @@ function makeNestedFakeQueryBuilder(array $rows): QueryBuilderInterface
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }

--- a/packages/database/tests/Entity/RelationshipLoaderTest.php
+++ b/packages/database/tests/Entity/RelationshipLoaderTest.php
@@ -291,7 +291,10 @@ function makeFakeQueryBuilder(array $rows): QueryBuilderInterface
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -446,7 +449,10 @@ function makeFakeQueryBuilder(array $rows): QueryBuilderInterface
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -545,7 +551,10 @@ function makeTrackingQueryBuilderFactory(array &$queries): QueryBuilderFactoryIn
                     return $this;
                 }
 
-                public function whereJsonContains(string $path, mixed $value): static
+                public function whereJsonContains(
+                    string $path,
+                    mixed $value,
+                ): static
                 {
                     return $this;
                 }
@@ -700,7 +709,10 @@ function makeTrackingQueryBuilderFactory(array &$queries): QueryBuilderFactoryIn
                     return $this;
                 }
 
-                public function having(string $expression, array $bindings = []): static
+                public function having(
+                    string $expression,
+                    array $bindings = [],
+                ): static
                 {
                     return $this;
                 }

--- a/packages/database/tests/Entity/RelationshipValidationTest.php
+++ b/packages/database/tests/Entity/RelationshipValidationTest.php
@@ -83,7 +83,10 @@ function makeValidationQueryBuilder(): QueryBuilderInterface
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -238,7 +241,10 @@ function makeValidationQueryBuilder(): QueryBuilderInterface
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }

--- a/packages/database/tests/Integration/TableExtensionIntegrationTest.php
+++ b/packages/database/tests/Integration/TableExtensionIntegrationTest.php
@@ -67,7 +67,10 @@ function createSqliteConnection(): ConnectionInterface
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             $statement = $this->pdo->prepare($sql);
             $statement->execute($bindings);
@@ -75,7 +78,10 @@ function createSqliteConnection(): ConnectionInterface
             return $statement->fetchAll(PDO::FETCH_ASSOC);
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             $statement = $this->pdo->prepare($sql);
             $statement->execute($bindings);
@@ -292,39 +298,42 @@ describe('Table Extension Integration', function (): void {
             ->and($rows[0]['timezone'])->toBe('Asia/Shanghai');
     });
 
-    it('silently skips companion hydration when the extender\'s columns are dropped from the schema (rolling deploy)', function (): void {
-        $metadataFactory = new EntityMetadataFactory();
-        $connection = createSqliteConnection();
-
-        // Create a table WITHOUT the extender columns (simulates rolling deploy where
+    it(
+        'silently skips companion hydration when the extender\'s columns are dropped from the schema (rolling deploy)',
+        function (): void {
+            $metadataFactory = new EntityMetadataFactory();
+            $connection = createSqliteConnection();
+    
+            // Create a table WITHOUT the extender columns (simulates rolling deploy where
         // the DB schema is still on the old version without profile columns)
         $connection->execute(
-            'CREATE TABLE int_users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, email TEXT NOT NULL)',
-        );
-
-        // Seed a row that has no profile columns at all
+                'CREATE TABLE int_users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, email TEXT NOT NULL)',
+            );
+    
+            // Seed a row that has no profile columns at all
         $connection->execute(
-            'INSERT INTO int_users (name, email) VALUES (?, ?)',
-            ['Eve', 'eve@example.com'],
-        );
-        $insertedId = $connection->lastInsertId();
-
-        // Register entities so metadata knows about the extender
+                'INSERT INTO int_users (name, email) VALUES (?, ?)',
+                ['Eve', 'eve@example.com'],
+            );
+            $insertedId = $connection->lastInsertId();
+    
+            // Register entities so metadata knows about the extender
         $schemaBuilder = new SchemaBuilder();
-        $registry = new SchemaRegistry($metadataFactory, $schemaBuilder);
-        $registry->registerEntities([IntUser::class, IntUserProfile::class]);
-
-        $hydrator = new EntityHydrator($metadataFactory);
-        $repository = new IntUserRepository($connection, $metadataFactory, $hydrator);
-
-        /** @var IntUser $user */
-        $user = $repository->find($insertedId);
-
-        // Hydration must succeed without error and companion must simply be absent
+            $registry = new SchemaRegistry($metadataFactory, $schemaBuilder);
+            $registry->registerEntities([IntUser::class, IntUserProfile::class]);
+    
+            $hydrator = new EntityHydrator($metadataFactory);
+            $repository = new IntUserRepository($connection, $metadataFactory, $hydrator);
+    
+            /** @var IntUser $user */
+            $user = $repository->find($insertedId);
+    
+            // Hydration must succeed without error and companion must simply be absent
         expect($user)->not->toBeNull()
-            ->and($user->name)->toBe('Eve')
-            ->and($user->companion(IntUserProfile::class))->toBeNull();
-    });
+                ->and($user->name)->toBe('Eve')
+                ->and($user->companion(IntUserProfile::class))->toBeNull();
+        }
+    );
 
     it('detects column-name conflicts at registration time across two extenders', function (): void {
         $metadataFactory = new EntityMetadataFactory();
@@ -339,79 +348,85 @@ describe('Table Extension Integration', function (): void {
         ]))->toThrow(EntityException::class);
     });
 
-    it('preserves migrate diff parity by including extender columns in the parent\'s Table value object', function (): void {
-        // Approach: assert on the merged Table value object (no real DB differ needed).
+    it(
+        'preserves migrate diff parity by including extender columns in the parent\'s Table value object',
+        function (): void {
+            // Approach: assert on the merged Table value object (no real DB differ needed).
         // The merged Table is what SchemaRegistry exposes after registerEntities(),
         // and it is the same object handed to DiffCalculator — so if the Table has
         // the extender columns, the differ will produce the correct ADD COLUMN statements.
 
-        $metadataFactory = new EntityMetadataFactory();
-        $schemaBuilder = new SchemaBuilder();
-        $registry = new SchemaRegistry($metadataFactory, $schemaBuilder);
-        $registry->registerEntities([IntUser::class, IntUserProfile::class]);
-
-        $mergedTable = $registry->getTable('int_users');
-
-        // Simulate an existing DB table that is missing the extender columns
+            $metadataFactory = new EntityMetadataFactory();
+            $schemaBuilder = new SchemaBuilder();
+            $registry = new SchemaRegistry($metadataFactory, $schemaBuilder);
+            $registry->registerEntities([IntUser::class, IntUserProfile::class]);
+    
+            $mergedTable = $registry->getTable('int_users');
+    
+            // Simulate an existing DB table that is missing the extender columns
         $dbTable = new Table(
-            name: 'int_users',
-            columns: [
-                new Column(name: 'id', type: 'INTEGER', primaryKey: true, autoIncrement: true),
-                new Column(name: 'name', type: 'TEXT'),
-                new Column(name: 'email', type: 'TEXT'),
-            ],
-            indexes: [],
-        );
+                name: 'int_users',
+                columns: [
+                    new Column(name: 'id', type: 'INTEGER', primaryKey: true, autoIncrement: true),
+                    new Column(name: 'name', type: 'TEXT'),
+                    new Column(name: 'email', type: 'TEXT'),
+                ],
+                indexes: [],
+            );
+    
+            $diffCalculator = new DiffCalculator();
+            $diff = $diffCalculator->calculate(
+                ['int_users' => $mergedTable],
+                ['int_users' => $dbTable],
+            );
+    
+            expect($diff->tablesToAlter)->toHaveKey('int_users');
+    
+            $tableDiff = $diff->tablesToAlter['int_users'];
+            $addedNames = array_map(fn ($col) => $col->name, $tableDiff->columnsToAdd);
+    
+            expect($addedNames)
+                ->toContain('bio')
+                ->toContain('timezone');
+        }
+    );
 
-        $diffCalculator = new DiffCalculator();
-        $diff = $diffCalculator->calculate(
-            ['int_users' => $mergedTable],
-            ['int_users' => $dbTable],
-        );
-
-        expect($diff->tablesToAlter)->toHaveKey('int_users');
-
-        $tableDiff = $diff->tablesToAlter['int_users'];
-        $addedNames = array_map(fn ($col) => $col->name, $tableDiff->columnsToAdd);
-
-        expect($addedNames)
-            ->toContain('bio')
-            ->toContain('timezone');
-    });
-
-    it('discovers an extender via EntityDiscovery and registers it correctly into the parent\'s merged schema', function (): void {
-        $fixturesPath = __DIR__ . '/Fixtures';
-
-        $classFileParser = new ClassFileParser();
-        $discovery = new EntityDiscovery($classFileParser);
-
-        $discovered = $discovery->discoverInPath($fixturesPath);
-
-        // All three fixture classes live in the Fixtures directory
+    it(
+        'discovers an extender via EntityDiscovery and registers it correctly into the parent\'s merged schema',
+        function (): void {
+            $fixturesPath = __DIR__ . '/Fixtures';
+    
+            $classFileParser = new ClassFileParser();
+            $discovery = new EntityDiscovery($classFileParser);
+    
+            $discovered = $discovery->discoverInPath($fixturesPath);
+    
+            // All three fixture classes live in the Fixtures directory
         expect($discovered)->toContain(IntUser::class)
-            ->and($discovered)->toContain(IntUserProfile::class);
-
-        // Register the discovered set (parent + extender only, exclude conflict fixture)
+                ->and($discovered)->toContain(IntUserProfile::class);
+    
+            // Register the discovered set (parent + extender only, exclude conflict fixture)
         $filteredClasses = array_values(array_filter(
-            $discovered,
-            fn (string $class) => $class !== IntUserSettings::class,
-        ));
-
-        $metadataFactory = new EntityMetadataFactory();
-        $schemaBuilder = new SchemaBuilder();
-        $registry = new SchemaRegistry($metadataFactory, $schemaBuilder);
-        $registry->registerEntities($filteredClasses);
-
-        $table = $registry->getTable('int_users');
-        $columnNames = array_map(fn ($col) => $col->name, $table->columns);
-
-        expect($columnNames)
-            ->toContain('id')
-            ->toContain('name')
-            ->toContain('email')
-            ->toContain('bio')
-            ->toContain('timezone');
-    });
+                $discovered,
+                fn (string $class) => $class !== IntUserSettings::class,
+            ));
+    
+            $metadataFactory = new EntityMetadataFactory();
+            $schemaBuilder = new SchemaBuilder();
+            $registry = new SchemaRegistry($metadataFactory, $schemaBuilder);
+            $registry->registerEntities($filteredClasses);
+    
+            $table = $registry->getTable('int_users');
+            $columnNames = array_map(fn ($col) => $col->name, $table->columns);
+    
+            expect($columnNames)
+                ->toContain('id')
+                ->toContain('name')
+                ->toContain('email')
+                ->toContain('bio')
+                ->toContain('timezone');
+        }
+    );
 
     it('raises a loud error when constructing a Repository against an extender class', function (): void {
         $metadataFactory = new EntityMetadataFactory();

--- a/packages/database/tests/KnownDriversValidationTest.php
+++ b/packages/database/tests/KnownDriversValidationTest.php
@@ -7,9 +7,12 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all database drivers', function () use ($knownDriversPath, $skeletonComposerPath): void {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all database drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath): void {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every database driver follows marko slash prefix pattern', function () use ($knownDriversPath): void {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);

--- a/packages/database/tests/Query/QueryBuilderInterfaceTest.php
+++ b/packages/database/tests/Query/QueryBuilderInterfaceTest.php
@@ -290,10 +290,10 @@ describe('QueryBuilderInterface', function (): void {
             $reflection = new ReflectionClass(QueryBuilderInterface::class);
             $method = $reflection->getMethod('selectRaw');
             $params = $method->getParameters();
-    
+
             expect($params[0]->getName())->toBe('expression')
                 ->and($params[0]->getType()?->getName())->toBe('string');
-        }
+        },
     );
 
     it(
@@ -302,12 +302,12 @@ describe('QueryBuilderInterface', function (): void {
             $reflection = new ReflectionClass(QueryBuilderInterface::class);
             $method = $reflection->getMethod('selectRaw');
             $params = $method->getParameters();
-    
+
             expect($params[1]->getName())->toBe('bindings')
                 ->and($params[1]->getType()?->getName())->toBe('array')
                 ->and($params[1]->isDefaultValueAvailable())->toBeTrue()
                 ->and($params[1]->getDefaultValue())->toBeEmpty();
-        }
+        },
     );
 
     it('QueryBuilderInterface::selectRaw returns static', function (): void {
@@ -330,10 +330,10 @@ describe('QueryBuilderInterface', function (): void {
             $reflection = new ReflectionClass(QueryBuilderInterface::class);
             $method = $reflection->getMethod('whereRaw');
             $params = $method->getParameters();
-    
+
             expect($params[0]->getName())->toBe('expression')
                 ->and($params[0]->getType()?->getName())->toBe('string');
-        }
+        },
     );
 
     it(
@@ -342,12 +342,12 @@ describe('QueryBuilderInterface', function (): void {
             $reflection = new ReflectionClass(QueryBuilderInterface::class);
             $method = $reflection->getMethod('whereRaw');
             $params = $method->getParameters();
-    
+
             expect($params[1]->getName())->toBe('bindings')
                 ->and($params[1]->getType()?->getName())->toBe('array')
                 ->and($params[1]->isDefaultValueAvailable())->toBeTrue()
                 ->and($params[1]->getDefaultValue())->toBeEmpty();
-        }
+        },
     );
 
     it('QueryBuilderInterface::whereRaw returns static', function (): void {
@@ -370,10 +370,10 @@ describe('QueryBuilderInterface', function (): void {
             $reflection = new ReflectionClass(QueryBuilderInterface::class);
             $method = $reflection->getMethod('orderByRaw');
             $params = $method->getParameters();
-    
+
             expect($params[0]->getName())->toBe('expression')
                 ->and($params[0]->getType()?->getName())->toBe('string');
-        }
+        },
     );
 
     it(
@@ -382,12 +382,12 @@ describe('QueryBuilderInterface', function (): void {
             $reflection = new ReflectionClass(QueryBuilderInterface::class);
             $method = $reflection->getMethod('orderByRaw');
             $params = $method->getParameters();
-    
+
             expect($params[1]->getName())->toBe('direction')
                 ->and($params[1]->getType()?->getName())->toBe('string')
                 ->and($params[1]->isDefaultValueAvailable())->toBeTrue()
                 ->and($params[1]->getDefaultValue())->toBe('ASC');
-        }
+        },
     );
 
     it('QueryBuilderInterface::orderByRaw returns static', function (): void {

--- a/packages/database/tests/Query/QuerySpecificationTest.php
+++ b/packages/database/tests/Query/QuerySpecificationTest.php
@@ -75,7 +75,10 @@ describe('QuerySpecification', function (): void {
                 return $this;
             }
 
-            public function whereJsonContains(string $path, mixed $value): static
+            public function whereJsonContains(
+                string $path,
+                mixed $value,
+            ): static
             {
                 return $this;
             }
@@ -230,7 +233,10 @@ describe('QuerySpecification', function (): void {
                 return $this;
             }
 
-            public function having(string $expression, array $bindings = []): static
+            public function having(
+                string $expression,
+                array $bindings = [],
+            ): static
             {
                 return $this;
             }
@@ -314,7 +320,10 @@ describe('QuerySpecification', function (): void {
                 return $this;
             }
 
-            public function whereJsonContains(string $path, mixed $value): static
+            public function whereJsonContains(
+                string $path,
+                mixed $value,
+            ): static
             {
                 return $this;
             }
@@ -469,7 +478,10 @@ describe('QuerySpecification', function (): void {
                 return $this;
             }
 
-            public function having(string $expression, array $bindings = []): static
+            public function having(
+                string $expression,
+                array $bindings = [],
+            ): static
             {
                 return $this;
             }

--- a/packages/database/tests/Query/SpecEagerLoadCompositionTest.php
+++ b/packages/database/tests/Query/SpecEagerLoadCompositionTest.php
@@ -126,14 +126,21 @@ function makeSpecStubBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function where(string $column, string $operator, mixed $value): static
+        public function where(
+            string $column,
+            string $operator,
+            mixed $value,
+        ): static
         {
             $this->wheresCalled[] = "$column $operator $value";
 
             return $this;
         }
 
-        public function whereIn(string $column, array $values): static
+        public function whereIn(
+            string $column,
+            array $values,
+        ): static
         {
             return $this;
         }
@@ -148,7 +155,10 @@ function makeSpecStubBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -163,42 +173,73 @@ function makeSpecStubBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function orWhere(string $column, string $operator, mixed $value): static
+        public function orWhere(
+            string $column,
+            string $operator,
+            mixed $value,
+        ): static
         {
             return $this;
         }
 
-        public function join(string $table, string $first, string $operator, string $second): static
+        public function join(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function leftJoin(string $table, string $first, string $operator, string $second): static
+        public function leftJoin(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function rightJoin(string $table, string $first, string $operator, string $second): static
+        public function rightJoin(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function orderBy(string $column, string $direction = 'ASC'): static
+        public function orderBy(
+            string $column,
+            string $direction = 'ASC',
+        ): static
         {
             return $this;
         }
 
-        public function orderByRaw(string $expression, string $direction = 'ASC'): static
+        public function orderByRaw(
+            string $expression,
+            string $direction = 'ASC',
+        ): static
         {
             return $this;
         }
 
-        public function selectRaw(string $expression, array $bindings = []): static
+        public function selectRaw(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
 
-        public function whereRaw(string $expression, array $bindings = []): static
+        public function whereRaw(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -268,7 +309,10 @@ function makeSpecStubBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -293,7 +337,10 @@ function makeSpecStubBuilder(array $rows = []): QueryBuilderInterface
             return null;
         }
 
-        public function raw(string $sql, array $bindings = []): array
+        public function raw(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             return [];
         }
@@ -326,12 +373,19 @@ function makeCountingBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function where(string $column, string $operator, mixed $value): static
+        public function where(
+            string $column,
+            string $operator,
+            mixed $value,
+        ): static
         {
             return $this;
         }
 
-        public function whereIn(string $column, array $values): static
+        public function whereIn(
+            string $column,
+            array $values,
+        ): static
         {
             $this->whereInCount++;
 
@@ -348,7 +402,10 @@ function makeCountingBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -363,42 +420,73 @@ function makeCountingBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function orWhere(string $column, string $operator, mixed $value): static
+        public function orWhere(
+            string $column,
+            string $operator,
+            mixed $value,
+        ): static
         {
             return $this;
         }
 
-        public function join(string $table, string $first, string $operator, string $second): static
+        public function join(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function leftJoin(string $table, string $first, string $operator, string $second): static
+        public function leftJoin(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function rightJoin(string $table, string $first, string $operator, string $second): static
+        public function rightJoin(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function orderBy(string $column, string $direction = 'ASC'): static
+        public function orderBy(
+            string $column,
+            string $direction = 'ASC',
+        ): static
         {
             return $this;
         }
 
-        public function orderByRaw(string $expression, string $direction = 'ASC'): static
+        public function orderByRaw(
+            string $expression,
+            string $direction = 'ASC',
+        ): static
         {
             return $this;
         }
 
-        public function selectRaw(string $expression, array $bindings = []): static
+        public function selectRaw(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
 
-        public function whereRaw(string $expression, array $bindings = []): static
+        public function whereRaw(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -468,7 +556,10 @@ function makeCountingBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -493,7 +584,10 @@ function makeCountingBuilder(array $rows = []): QueryBuilderInterface
             return null;
         }
 
-        public function raw(string $sql, array $bindings = []): array
+        public function raw(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             return [];
         }
@@ -515,12 +609,18 @@ function makeSpecConnection(array $rows = []): ConnectionInterface
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             return $this->rows;
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             return 0;
         }
@@ -618,12 +718,19 @@ it('lets a spec call $builder->with(\'relation\') inside apply() to declare eage
             return $this;
         }
 
-        public function where(string $column, string $operator, mixed $value): static
+        public function where(
+            string $column,
+            string $operator,
+            mixed $value,
+        ): static
         {
             return $this;
         }
 
-        public function whereIn(string $column, array $values): static
+        public function whereIn(
+            string $column,
+            array $values,
+        ): static
         {
             return $this;
         }
@@ -638,7 +745,10 @@ it('lets a spec call $builder->with(\'relation\') inside apply() to declare eage
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -653,42 +763,73 @@ it('lets a spec call $builder->with(\'relation\') inside apply() to declare eage
             return $this;
         }
 
-        public function orWhere(string $column, string $operator, mixed $value): static
+        public function orWhere(
+            string $column,
+            string $operator,
+            mixed $value,
+        ): static
         {
             return $this;
         }
 
-        public function join(string $table, string $first, string $operator, string $second): static
+        public function join(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function leftJoin(string $table, string $first, string $operator, string $second): static
+        public function leftJoin(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function rightJoin(string $table, string $first, string $operator, string $second): static
+        public function rightJoin(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function orderBy(string $column, string $direction = 'ASC'): static
+        public function orderBy(
+            string $column,
+            string $direction = 'ASC',
+        ): static
         {
             return $this;
         }
 
-        public function orderByRaw(string $expression, string $direction = 'ASC'): static
+        public function orderByRaw(
+            string $expression,
+            string $direction = 'ASC',
+        ): static
         {
             return $this;
         }
 
-        public function selectRaw(string $expression, array $bindings = []): static
+        public function selectRaw(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
 
-        public function whereRaw(string $expression, array $bindings = []): static
+        public function whereRaw(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -758,7 +899,10 @@ it('lets a spec call $builder->with(\'relation\') inside apply() to declare eage
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -783,7 +927,10 @@ it('lets a spec call $builder->with(\'relation\') inside apply() to declare eage
             return null;
         }
 
-        public function raw(string $sql, array $bindings = []): array
+        public function raw(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             return [];
         }
@@ -882,51 +1029,57 @@ it('merges eager loads across multiple specs without duplicating queries', funct
     expect($countingBuilder->whereInCount)->toBe(1);
 });
 
-it('still supports explicit $repo->with(...)->matching(...) callers (fixes pre-existing bug where matching() passed the raw inner builder)', function (): void {
-    $postRows = [['id' => 1, 'title' => 'Hello', 'status' => 'published', 'author_id' => 5]];
-    $authorRows = [['id' => 5, 'name' => 'Alice', 'author_id' => 5]];
-
-    $primaryBuilder = makeSpecStubBuilder($postRows);
-    $relatedBuilder = makeSpecStubBuilder($authorRows);
-    $loader = makeSpecLoader($relatedBuilder);
-    $repo = makeSpecRepository(loader: $loader, primaryBuilder: $primaryBuilder);
-
-    // Plain spec that applies no eager load — eager load comes from call-site with()
+it(
+    'still supports explicit $repo->with(...)->matching(...) callers (fixes pre-existing bug where matching() passed the raw inner builder)',
+    function (): void {
+        $postRows = [['id' => 1, 'title' => 'Hello', 'status' => 'published', 'author_id' => 5]];
+        $authorRows = [['id' => 5, 'name' => 'Alice', 'author_id' => 5]];
+    
+        $primaryBuilder = makeSpecStubBuilder($postRows);
+        $relatedBuilder = makeSpecStubBuilder($authorRows);
+        $loader = makeSpecLoader($relatedBuilder);
+        $repo = makeSpecRepository(loader: $loader, primaryBuilder: $primaryBuilder);
+    
+        // Plain spec that applies no eager load — eager load comes from call-site with()
     $spec = new class () implements QuerySpecification
-    {
-        public function apply(EntityQueryBuilderInterface $builder): void
         {
-            $builder->where('status', '=', 'published');
-        }
-    };
+            public function apply(EntityQueryBuilderInterface $builder): void
+            {
+                $builder->where('status', '=', 'published');
+            }
+        };
+    
+        $collection = $repo->with('author')->matching($spec);
+    
+        expect($collection->count())->toBe(1)
+            ->and($collection->first()->author)->toBeInstanceOf(SpecAuthor::class);
+    }
+);
 
-    $collection = $repo->with('author')->matching($spec);
-
-    expect($collection->count())->toBe(1)
-        ->and($collection->first()->author)->toBeInstanceOf(SpecAuthor::class);
-});
-
-it('merges call-site $repo->with(...) relationships with spec-declared with() relationships without duplicates', function (): void {
-    $postRows = [['id' => 1, 'title' => 'Hello', 'status' => 'published', 'author_id' => 5]];
-
-    $countingBuilder = makeCountingBuilder([['id' => 5, 'name' => 'Alice', 'author_id' => 5]]);
-    $primaryBuilder = makeSpecStubBuilder($postRows);
-    $loader = makeSpecLoader($countingBuilder);
-    $repo = makeSpecRepository(loader: $loader, primaryBuilder: $primaryBuilder);
-
-    $spec = new class () implements QuerySpecification
-    {
-        public function apply(EntityQueryBuilderInterface $builder): void
+it(
+    'merges call-site $repo->with(...) relationships with spec-declared with() relationships without duplicates',
+    function (): void {
+        $postRows = [['id' => 1, 'title' => 'Hello', 'status' => 'published', 'author_id' => 5]];
+    
+        $countingBuilder = makeCountingBuilder([['id' => 5, 'name' => 'Alice', 'author_id' => 5]]);
+        $primaryBuilder = makeSpecStubBuilder($postRows);
+        $loader = makeSpecLoader($countingBuilder);
+        $repo = makeSpecRepository(loader: $loader, primaryBuilder: $primaryBuilder);
+    
+        $spec = new class () implements QuerySpecification
         {
-            $builder->with('author');
-        }
-    };
-
-    // Both call-site and spec declare 'author' — should issue only one query
+            public function apply(EntityQueryBuilderInterface $builder): void
+            {
+                $builder->with('author');
+            }
+        };
+    
+        // Both call-site and spec declare 'author' — should issue only one query
     $repo->with('author')->matching($spec);
-
-    expect($countingBuilder->whereInCount)->toBe(1);
-});
+    
+        expect($countingBuilder->whereInCount)->toBe(1);
+    }
+);
 
 it('does not execute N+1 queries when a spec declares eager loads', function (): void {
     // 3 posts, all with author_id = 5
@@ -956,36 +1109,42 @@ it('does not execute N+1 queries when a spec declares eager loads', function ():
         ->and($countingBuilder->whereInCount)->toBe(1);
 });
 
-it('validates each spec-declared relationship name against entity metadata and throws on unknown names (consistent with Repository::with())', function (): void {
-    $postRows = [['id' => 1, 'title' => 'Hello', 'status' => 'published', 'author_id' => 5]];
-    $primaryBuilder = makeSpecStubBuilder($postRows);
-    $loader = makeSpecLoader(makeSpecStubBuilder());
-    $repo = makeSpecRepository(loader: $loader, primaryBuilder: $primaryBuilder);
-
-    $spec = new class () implements QuerySpecification
-    {
-        public function apply(EntityQueryBuilderInterface $builder): void
+it(
+    'validates each spec-declared relationship name against entity metadata and throws on unknown names (consistent with Repository::with())',
+    function (): void {
+        $postRows = [['id' => 1, 'title' => 'Hello', 'status' => 'published', 'author_id' => 5]];
+        $primaryBuilder = makeSpecStubBuilder($postRows);
+        $loader = makeSpecLoader(makeSpecStubBuilder());
+        $repo = makeSpecRepository(loader: $loader, primaryBuilder: $primaryBuilder);
+    
+        $spec = new class () implements QuerySpecification
         {
-            $builder->with('nonExistentRelationship');
-        }
-    };
+            public function apply(EntityQueryBuilderInterface $builder): void
+            {
+                $builder->with('nonExistentRelationship');
+            }
+        };
+    
+        expect(fn () => $repo->matching($spec))->toThrow(RepositoryException::class);
+    }
+);
 
-    expect(fn () => $repo->matching($spec))->toThrow(RepositoryException::class);
-});
-
-it('existing single-method QuerySpecification implementations continue to compile after updating only the apply() parameter type hint', function (): void {
-    // A spec using the new signature — verifies backward-compatible refactor
+it(
+    'existing single-method QuerySpecification implementations continue to compile after updating only the apply() parameter type hint',
+    function (): void {
+        // A spec using the new signature — verifies backward-compatible refactor
     $spec = new class () implements QuerySpecification
-    {
-        public function apply(EntityQueryBuilderInterface $builder): void
         {
-            $builder->where('status', '=', 'active');
-        }
-    };
-
-    $reflection = new ReflectionClass($spec);
-    $method = $reflection->getMethod('apply');
-    $params = $method->getParameters();
-
-    expect($params[0]->getType()?->getName())->toBe(EntityQueryBuilderInterface::class);
-});
+            public function apply(EntityQueryBuilderInterface $builder): void
+            {
+                $builder->where('status', '=', 'active');
+            }
+        };
+    
+        $reflection = new ReflectionClass($spec);
+        $method = $reflection->getMethod('apply');
+        $params = $method->getParameters();
+    
+        expect($params[0]->getType()?->getName())->toBe(EntityQueryBuilderInterface::class);
+    }
+);

--- a/packages/database/tests/Repository/RepositoryBatchInsertTest.php
+++ b/packages/database/tests/Repository/RepositoryBatchInsertTest.php
@@ -120,14 +120,20 @@ function makeBatchSpyConnection(array &$sqlLog, int $firstId = 1): ConnectionInt
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             $this->sqlLog[] = ['type' => 'query', 'sql' => $sql, 'bindings' => $bindings];
 
             return [];
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             if ($this->shouldThrow) {
                 $this->shouldThrow = false;
@@ -174,12 +180,18 @@ function makeBatchTransactionConnection(array &$log, bool $failInsert = false): 
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             return [];
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             if ($this->failInsert && str_contains($sql, 'INSERT')) {
                 throw new RuntimeException('Simulated DB failure on INSERT');
@@ -281,7 +293,13 @@ it('fires Creating event for each entity before insert', function (): void {
     $sqlLog = [];
     $connection = makeBatchSpyConnection($sqlLog, 1);
     $dispatcher = new BatchFakeDispatcher();
-    $repository = new BatchUserRepository($connection, new EntityMetadataFactory(), new EntityHydrator(), null, $dispatcher);
+    $repository = new BatchUserRepository(
+        $connection,
+        new EntityMetadataFactory(),
+        new EntityHydrator(),
+        null,
+        $dispatcher
+    );
 
     $user1 = new BatchUser();
     $user1->name = 'Alice';
@@ -303,7 +321,13 @@ it('fires Created event for each entity after insert', function (): void {
     $sqlLog = [];
     $connection = makeBatchSpyConnection($sqlLog, 1);
     $dispatcher = new BatchFakeDispatcher();
-    $repository = new BatchUserRepository($connection, new EntityMetadataFactory(), new EntityHydrator(), null, $dispatcher);
+    $repository = new BatchUserRepository(
+        $connection,
+        new EntityMetadataFactory(),
+        new EntityHydrator(),
+        null,
+        $dispatcher
+    );
 
     $user1 = new BatchUser();
     $user1->name = 'Alice';
@@ -327,37 +351,42 @@ it('fires Created event for each entity after insert', function (): void {
     expect(max($creatingIdx) < min($createdIdx))->toBeTrue();
 });
 
-it('populates auto-generated primary keys back onto each entity when the driver supports it (MySQL: lastInsertId returns the FIRST id, increment by one per row assuming no gaps; PostgreSQL: use INSERT ... RETURNING id)', function (): void {
-    $sqlLog = [];
-    // Simulate MySQL: lastInsertId() returns first inserted ID = 10
+it(
+    'populates auto-generated primary keys back onto each entity when the driver supports it (MySQL: lastInsertId returns the FIRST id, increment by one per row assuming no gaps; PostgreSQL: use INSERT ... RETURNING id)',
+    function (): void {
+        $sqlLog = [];
+        // Simulate MySQL: lastInsertId() returns first inserted ID = 10
     $connection = makeBatchSpyConnection($sqlLog, 10);
-    $repository = new BatchUserRepository($connection, new EntityMetadataFactory(), new EntityHydrator());
+        $repository = new BatchUserRepository($connection, new EntityMetadataFactory(), new EntityHydrator());
+    
+        $user1 = new BatchUser();
+        $user1->name = 'Alice';
+        $user1->email = 'alice@example.com';
+    
+        $user2 = new BatchUser();
+        $user2->name = 'Bob';
+        $user2->email = 'bob@example.com';
+    
+        $user3 = new BatchUser();
+        $user3->name = 'Carol';
+        $user3->email = 'carol@example.com';
+    
+        expect($user1->id)->toBeNull()
+            ->and($user2->id)->toBeNull()
+            ->and($user3->id)->toBeNull();
+    
+        $repository->insertBatch([$user1, $user2, $user3]);
+    
+        expect($user1->id)->toBe(10)
+            ->and($user2->id)->toBe(11)
+            ->and($user3->id)->toBe(12);
+    }
+);
 
-    $user1 = new BatchUser();
-    $user1->name = 'Alice';
-    $user1->email = 'alice@example.com';
-
-    $user2 = new BatchUser();
-    $user2->name = 'Bob';
-    $user2->email = 'bob@example.com';
-
-    $user3 = new BatchUser();
-    $user3->name = 'Carol';
-    $user3->email = 'carol@example.com';
-
-    expect($user1->id)->toBeNull()
-        ->and($user2->id)->toBeNull()
-        ->and($user3->id)->toBeNull();
-
-    $repository->insertBatch([$user1, $user2, $user3]);
-
-    expect($user1->id)->toBe(10)
-        ->and($user2->id)->toBe(11)
-        ->and($user3->id)->toBe(12);
-});
-
-it('documents and tests that MySQL populated-id logic is correct only when innodb_autoinc_lock_mode permits sequential ids (contiguous block)', function (): void {
-    // MySQL innodb_autoinc_lock_mode=2 (interleaved, the default since MySQL 8.0) does NOT
+it(
+    'documents and tests that MySQL populated-id logic is correct only when innodb_autoinc_lock_mode permits sequential ids (contiguous block)',
+    function (): void {
+        // MySQL innodb_autoinc_lock_mode=2 (interleaved, the default since MySQL 8.0) does NOT
     // guarantee a contiguous block of IDs for a single multi-row INSERT in a concurrent
     // environment. The MySQL id-recovery strategy (LAST_INSERT_ID + row-count math) is
     // therefore only reliable under lock_mode=0 (traditional) or lock_mode=1 (consecutive),
@@ -366,30 +395,31 @@ it('documents and tests that MySQL populated-id logic is correct only when innod
     // This test verifies the documented contract: given a contiguous block starting at
     // firstId, each entity receives firstId + its zero-based index in the batch.
 
-    $sqlLog = [];
-    // firstId=5 simulates a scenario where rows 5, 6, 7 are a contiguous block
+        $sqlLog = [];
+        // firstId=5 simulates a scenario where rows 5, 6, 7 are a contiguous block
     $connection = makeBatchSpyConnection($sqlLog, 5);
-    $repository = new BatchUserRepository($connection, new EntityMetadataFactory(), new EntityHydrator());
-
-    $users = [];
-    for ($i = 0; $i < 3; $i++) {
-        $u = new BatchUser();
-        $u->name = "User $i";
-        $u->email = "user$i@example.com";
-        $users[] = $u;
-    }
-
-    $repository->insertBatch($users);
-
-    // Under contiguous-block assumption: IDs are 5, 6, 7
+        $repository = new BatchUserRepository($connection, new EntityMetadataFactory(), new EntityHydrator());
+    
+        $users = [];
+        for ($i = 0; $i < 3; $i++) {
+            $u = new BatchUser();
+            $u->name = "User $i";
+            $u->email = "user$i@example.com";
+            $users[] = $u;
+        }
+    
+        $repository->insertBatch($users);
+    
+        // Under contiguous-block assumption: IDs are 5, 6, 7
     expect($users[0]->id)->toBe(5)
-        ->and($users[1]->id)->toBe(6)
-        ->and($users[2]->id)->toBe(7);
-
-    // Verify that only a single INSERT statement was issued
+            ->and($users[1]->id)->toBe(6)
+            ->and($users[2]->id)->toBe(7);
+    
+        // Verify that only a single INSERT statement was issued
     $insertStmts = array_values(array_filter($sqlLog, fn ($e) => str_contains($e['sql'], 'INSERT')));
-    expect($insertStmts)->toHaveCount(1);
-});
+        expect($insertStmts)->toHaveCount(1);
+    }
+);
 
 it('throws a descriptive exception when the input array is empty', function (): void {
     $sqlLog = [];

--- a/packages/database/tests/Repository/RepositoryLifecycleEventTest.php
+++ b/packages/database/tests/Repository/RepositoryLifecycleEventTest.php
@@ -65,12 +65,18 @@ function makeInsertConnection(): ConnectionInterface
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             return [];
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             return 1;
         }
@@ -102,7 +108,10 @@ function makeUpdateConnection(): ConnectionInterface
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             if ($this->firstQuery) {
                 $this->firstQuery = false;
@@ -115,7 +124,10 @@ function makeUpdateConnection(): ConnectionInterface
             return [];
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             return 1;
         }
@@ -147,7 +159,10 @@ function makeDeleteConnection(): ConnectionInterface
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             if ($this->firstQuery) {
                 $this->firstQuery = false;
@@ -160,7 +175,10 @@ function makeDeleteConnection(): ConnectionInterface
             return [];
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             return 1;
         }

--- a/packages/database/tests/Repository/RepositoryMatchingTest.php
+++ b/packages/database/tests/Repository/RepositoryMatchingTest.php
@@ -91,7 +91,10 @@ function makeStubBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -246,7 +249,10 @@ function makeStubBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }

--- a/packages/database/tests/Repository/RepositoryQueryBuilderEnhancedTest.php
+++ b/packages/database/tests/Repository/RepositoryQueryBuilderEnhancedTest.php
@@ -141,8 +141,7 @@ function makeRqbStubBuilder(array $rows = []): QueryBuilderInterface
         public function whereJsonContains(
             string $path,
             mixed $value,
-        ): static
-        {
+        ): static {
             return $this;
         }
 
@@ -319,8 +318,7 @@ function makeRqbStubBuilder(array $rows = []): QueryBuilderInterface
         public function having(
             string $expression,
             array $bindings = [],
-        ): static
-        {
+        ): static {
             return $this;
         }
 
@@ -651,14 +649,14 @@ it(
     function (): void {
         $stub = makeRqbStubBuilder([]);
         $rqb = makeRqb($stub);
-    
+
         $result = $rqb
             ->select('id', 'name')
             ->selectRaw('COALESCE(a, b) AS resolved', [1])
             ->where('status', '=', 'active')
             ->whereRaw('score > ?', [50])
             ->orderBy('name', 'ASC');
-    
+
         expect($result)->toBeInstanceOf(RepositoryQueryBuilder::class)
             ->and($stub->selectRawCalled)->toBe([
                 ['expression' => 'COALESCE(a, b) AS resolved', 'bindings' => [1]],
@@ -668,7 +666,7 @@ it(
                 ['expression' => 'score > ?', 'bindings' => [50]],
             ])
             ->and($stub->orderByCalled)->toBe(['name ASC']);
-    }
+    },
 );
 
 it(
@@ -677,7 +675,7 @@ it(
         $rows = [['id' => 1, 'name' => 'Alice']];
         $stub = makeRqbStubBuilder($rows);
         $rqb = makeRqb($stub);
-    
+
         $spec = new class () implements QuerySpecification
         {
             public function apply(QueryBuilderInterface $builder): void
@@ -685,14 +683,14 @@ it(
                 $builder->selectRaw('COALESCE(a, b) AS resolved', [42]);
             }
         };
-    
+
         $collection = $rqb->matching($spec);
-    
+
         expect($collection)->toBeInstanceOf(EntityCollection::class)
             ->and($stub->selectRawCalled)->toBe([
                 ['expression' => 'COALESCE(a, b) AS resolved', 'bindings' => [42]],
             ]);
-    }
+    },
 );
 
 it(
@@ -701,7 +699,7 @@ it(
         $rows = [['id' => 1, 'name' => 'Alice']];
         $stub = makeRqbStubBuilder($rows);
         $rqb = makeRqb($stub);
-    
+
         $spec = new class () implements QuerySpecification
         {
             public function apply(QueryBuilderInterface $builder): void
@@ -709,12 +707,12 @@ it(
                 $builder->whereRaw('score > ?', [50]);
             }
         };
-    
+
         $collection = $rqb->matching($spec);
-    
+
         expect($collection)->toBeInstanceOf(EntityCollection::class)
             ->and($stub->whereRawCalled)->toBe([
                 ['expression' => 'score > ?', 'bindings' => [50]],
             ]);
-    }
+    },
 );

--- a/packages/database/tests/Repository/RepositoryReturnTypeTest.php
+++ b/packages/database/tests/Repository/RepositoryReturnTypeTest.php
@@ -52,12 +52,18 @@ function createReturnTypeMockConnection(array $queryResult = []): ConnectionInte
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             return $this->queryResult;
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             return 1;
         }

--- a/packages/database/tests/Repository/RepositoryTest.php
+++ b/packages/database/tests/Repository/RepositoryTest.php
@@ -1143,7 +1143,10 @@ function createMockQueryBuilder(
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -1309,7 +1312,10 @@ function createMockQueryBuilder(
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -1481,7 +1487,10 @@ function createSpyConnection(array &$sqlLog, array $queryResults = []): Connecti
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             $this->sqlLog[] = ['sql' => $sql, 'bindings' => $bindings];
             $result = $this->queryResults[$this->queryIndex] ?? [];
@@ -1490,7 +1499,10 @@ function createSpyConnection(array &$sqlLog, array $queryResults = []): Connecti
             return $result;
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             $this->sqlLog[] = ['sql' => $sql, 'bindings' => $bindings];
 
@@ -1524,7 +1536,11 @@ class OrderRepository extends Repository
 {
     protected const string ENTITY_CLASS = OrderWithCustomPk::class;
 
-    public function exposeIsColumnUnique(string $column, mixed $value, ?int $excludeId = null): bool
+    public function exposeIsColumnUnique(
+        string $column,
+        mixed $value,
+        ?int $excludeId = null,
+    ): bool
     {
         return $this->isColumnUnique($column, $value, $excludeId);
     }
@@ -1574,16 +1590,19 @@ it('it no longer falls back to the literal \'id\' column name in Repository::del
         ->and($deleteSql[0]['sql'])->not->toContain('WHERE order_id = ?');
 });
 
-it('it no longer hardcodes \'id\' in Repository::isColumnUnique exclude clause — uses the real PK column', function (): void {
-    $sqlLog = [];
-    $connection = createSpyConnection($sqlLog, [[]], [[]]);
-    $repository = new OrderRepository($connection, new EntityMetadataFactory(), new EntityHydrator());
-
-    $repository->exposeIsColumnUnique('status', 'shipped', 42);
-
-    expect($sqlLog[0]['sql'])->toContain('AND order_uuid != ?')
-        ->and($sqlLog[0]['sql'])->not->toContain('AND status != ?');
-});
+it(
+    'it no longer hardcodes \'id\' in Repository::isColumnUnique exclude clause — uses the real PK column',
+    function (): void {
+        $sqlLog = [];
+        $connection = createSpyConnection($sqlLog, [[]], [[]]);
+        $repository = new OrderRepository($connection, new EntityMetadataFactory(), new EntityHydrator());
+    
+        $repository->exposeIsColumnUnique('status', 'shipped', 42);
+    
+        expect($sqlLog[0]['sql'])->toContain('AND order_uuid != ?')
+            ->and($sqlLog[0]['sql'])->not->toContain('AND status != ?');
+    }
+);
 
 it('continues to work for entities that DO declare a primary key explicitly', function (): void {
     $connection = createMockConnection([
@@ -1699,12 +1718,18 @@ describe('companion insert and update', function (): void {
                 return true;
             }
 
-            public function query(string $sql, array $bindings = []): array
+            public function query(
+                string $sql,
+                array $bindings = [],
+            ): array
             {
                 return [];
             }
 
-            public function execute(string $sql, array $bindings = []): int
+            public function execute(
+                string $sql,
+                array $bindings = [],
+            ): int
             {
                 $this->sqlLog[] = ['sql' => $sql, 'bindings' => $bindings];
 
@@ -1742,29 +1767,32 @@ describe('companion insert and update', function (): void {
             ->and($sqlLog[0]['sql'])->not->toContain('website');
     });
 
-    it('inserts a parent entity with one attached companion using merged columns in a single INSERT', function (): void {
-        $sqlLog = [];
-        $connection = createAccountSpyConnection($sqlLog);
-        $metadataFactory = new EntityMetadataFactory();
-        $hydrator = new EntityHydrator($metadataFactory);
-        $repository = new AccountRepository($connection, $metadataFactory, $hydrator);
-
-        $account = new RepositoryTestAccount();
-        $account->username = 'bob';
-
-        $profile = new RepositoryTestAccountProfile();
-        $profile->bio = 'Hello';
-        $profile->website = 'https://example.com';
-        $account->attachCompanion($profile);
-
-        $repository->save($account);
-
-        expect($sqlLog)->toHaveCount(1)
-            ->and($sqlLog[0]['sql'])->toContain('INSERT INTO accounts')
-            ->and($sqlLog[0]['sql'])->toContain('username')
-            ->and($sqlLog[0]['sql'])->toContain('bio')
-            ->and($sqlLog[0]['sql'])->toContain('website');
-    });
+    it(
+        'inserts a parent entity with one attached companion using merged columns in a single INSERT',
+        function (): void {
+            $sqlLog = [];
+            $connection = createAccountSpyConnection($sqlLog);
+            $metadataFactory = new EntityMetadataFactory();
+            $hydrator = new EntityHydrator($metadataFactory);
+            $repository = new AccountRepository($connection, $metadataFactory, $hydrator);
+    
+            $account = new RepositoryTestAccount();
+            $account->username = 'bob';
+    
+            $profile = new RepositoryTestAccountProfile();
+            $profile->bio = 'Hello';
+            $profile->website = 'https://example.com';
+            $account->attachCompanion($profile);
+    
+            $repository->save($account);
+    
+            expect($sqlLog)->toHaveCount(1)
+                ->and($sqlLog[0]['sql'])->toContain('INSERT INTO accounts')
+                ->and($sqlLog[0]['sql'])->toContain('username')
+                ->and($sqlLog[0]['sql'])->toContain('bio')
+                ->and($sqlLog[0]['sql'])->toContain('website');
+        }
+    );
 
     it('inserts a parent entity with multiple attached companions using all merged columns', function (): void {
         $sqlLog = [];
@@ -2018,58 +2046,67 @@ describe('companion insert and update', function (): void {
         expect($sqlLog)->toBeEmpty();
     });
 
-    it('inserts a parent with a freshly-attached (never-hydrated) companion and registers original values on the companion after INSERT', function (): void {
-        $sqlLog = [];
-        $connection = createAccountSpyConnection($sqlLog, lastInsertId: 7);
-        $metadataFactory = new EntityMetadataFactory();
-        $hydrator = new EntityHydrator($metadataFactory);
-        $repository = new AccountRepository($connection, $metadataFactory, $hydrator);
-
-        $account = new RepositoryTestAccount();
-        $account->username = 'leo';
-
-        $profile = new RepositoryTestAccountProfile();
-        $profile->bio = 'Fresh bio';
-        $profile->website = 'https://leo.dev';
-        $account->attachCompanion($profile);
-
-        $repository->save($account);
-
-        // The companion was freshly constructed — after INSERT it must have
+    it(
+        'inserts a parent with a freshly-attached (never-hydrated) companion and registers original values on the companion after INSERT',
+        function (): void {
+            $sqlLog = [];
+            $connection = createAccountSpyConnection($sqlLog, lastInsertId: 7);
+            $metadataFactory = new EntityMetadataFactory();
+            $hydrator = new EntityHydrator($metadataFactory);
+            $repository = new AccountRepository($connection, $metadataFactory, $hydrator);
+    
+            $account = new RepositoryTestAccount();
+            $account->username = 'leo';
+    
+            $profile = new RepositoryTestAccountProfile();
+            $profile->bio = 'Fresh bio';
+            $profile->website = 'https://leo.dev';
+            $account->attachCompanion($profile);
+    
+            $repository->save($account);
+    
+            // The companion was freshly constructed — after INSERT it must have
         // originalValues so subsequent updates diff correctly.
         $originalValues = $hydrator->getOriginalValues($profile);
+    
+            expect($originalValues)->not->toBeEmpty()
+                ->and($originalValues['bio'])->toBe('Fresh bio')
+                ->and($originalValues['website'])->toBe('https://leo.dev');
+        }
+    );
 
-        expect($originalValues)->not->toBeEmpty()
-            ->and($originalValues['bio'])->toBe('Fresh bio')
-            ->and($originalValues['website'])->toBe('https://leo.dev');
-    });
+    it(
+        'throws RepositoryException when constructing a Repository whose ENTITY_CLASS is an extender',
+        function (): void {
+            $ignored = [];
+            $connection = createAccountSpyConnection($ignored);
+            $metadataFactory = new EntityMetadataFactory();
+            $hydrator = new EntityHydrator($metadataFactory);
+    
+            expect(fn () => new ExtenderRepository($connection, $metadataFactory, $hydrator))
+                ->toThrow(RepositoryException::class, 'has no primary key of its own');
+        }
+    );
 
-    it('throws RepositoryException when constructing a Repository whose ENTITY_CLASS is an extender', function (): void {
-        $ignored = [];
-        $connection = createAccountSpyConnection($ignored);
-        $metadataFactory = new EntityMetadataFactory();
-        $hydrator = new EntityHydrator($metadataFactory);
-
-        expect(fn () => new ExtenderRepository($connection, $metadataFactory, $hydrator))
-            ->toThrow(RepositoryException::class, 'has no primary key of its own');
-    });
-
-    it('throws BatchInsertException when insertBatch is called with entities that have companions attached', function (): void {
-        $ignored = [];
-        $connection = createAccountSpyConnection($ignored);
-        $metadataFactory = new EntityMetadataFactory();
-        $hydrator = new EntityHydrator($metadataFactory);
-        $repository = new AccountRepository($connection, $metadataFactory, $hydrator);
-
-        $account = new RepositoryTestAccount();
-        $account->username = 'mike';
-
-        $profile = new RepositoryTestAccountProfile();
-        $profile->bio = 'Bio';
-        $profile->website = 'https://mike.io';
-        $account->attachCompanion($profile);
-
-        expect(fn () => $repository->insertBatch([$account]))
-            ->toThrow(BatchInsertException::class, 'companions');
-    });
+    it(
+        'throws BatchInsertException when insertBatch is called with entities that have companions attached',
+        function (): void {
+            $ignored = [];
+            $connection = createAccountSpyConnection($ignored);
+            $metadataFactory = new EntityMetadataFactory();
+            $hydrator = new EntityHydrator($metadataFactory);
+            $repository = new AccountRepository($connection, $metadataFactory, $hydrator);
+    
+            $account = new RepositoryTestAccount();
+            $account->username = 'mike';
+    
+            $profile = new RepositoryTestAccountProfile();
+            $profile->bio = 'Bio';
+            $profile->website = 'https://mike.io';
+            $account->attachCompanion($profile);
+    
+            expect(fn () => $repository->insertBatch([$account]))
+                ->toThrow(BatchInsertException::class, 'companions');
+        }
+    );
 });

--- a/packages/database/tests/Repository/RepositoryWithTest.php
+++ b/packages/database/tests/Repository/RepositoryWithTest.php
@@ -140,7 +140,10 @@ function makeWithStubBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -295,7 +298,10 @@ function makeWithStubBuilder(array $rows = []): QueryBuilderInterface
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -608,7 +614,10 @@ describe('Eager Loading Integration', function (): void {
                 return $this;
             }
 
-            public function whereJsonContains(string $path, mixed $value): static
+            public function whereJsonContains(
+                string $path,
+                mixed $value,
+            ): static
             {
                 return $this;
             }
@@ -763,7 +772,10 @@ describe('Eager Loading Integration', function (): void {
                 return $this;
             }
 
-            public function having(string $expression, array $bindings = []): static
+            public function having(
+                string $expression,
+                array $bindings = [],
+            ): static
             {
                 return $this;
             }
@@ -871,7 +883,10 @@ describe('Eager Loading Integration', function (): void {
                 return $this;
             }
 
-            public function whereJsonContains(string $path, mixed $value): static
+            public function whereJsonContains(
+                string $path,
+                mixed $value,
+            ): static
             {
                 return $this;
             }
@@ -1026,7 +1041,10 @@ describe('Eager Loading Integration', function (): void {
                 return $this;
             }
 
-            public function having(string $expression, array $bindings = []): static
+            public function having(
+                string $expression,
+                array $bindings = [],
+            ): static
             {
                 return $this;
             }
@@ -1127,7 +1145,10 @@ describe('Eager Loading Integration', function (): void {
                 return $this;
             }
 
-            public function whereJsonContains(string $path, mixed $value): static
+            public function whereJsonContains(
+                string $path,
+                mixed $value,
+            ): static
             {
                 return $this;
             }
@@ -1282,7 +1303,10 @@ describe('Eager Loading Integration', function (): void {
                 return $this;
             }
 
-            public function having(string $expression, array $bindings = []): static
+            public function having(
+                string $expression,
+                array $bindings = [],
+            ): static
             {
                 return $this;
             }

--- a/packages/database/tests/Repository/StringPrimaryKeyTest.php
+++ b/packages/database/tests/Repository/StringPrimaryKeyTest.php
@@ -118,7 +118,10 @@ function makeStringPkConnection(array $queryResults = [], array &$executedSql = 
             return true;
         }
 
-        public function query(string $sql, array $bindings = []): array
+        public function query(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             $result = $this->queryResults[$this->queryIndex] ?? [];
             $this->queryIndex++;
@@ -126,7 +129,10 @@ function makeStringPkConnection(array $queryResults = [], array &$executedSql = 
             return $result;
         }
 
-        public function execute(string $sql, array $bindings = []): int
+        public function execute(
+            string $sql,
+            array $bindings = [],
+        ): int
         {
             $this->executedSql[] = $sql;
             $this->executedBindings[] = $bindings;
@@ -165,12 +171,19 @@ function makeStringPkQueryBuilder(array $rows, array &$capturedWhereIn = []): Qu
             return $this;
         }
 
-        public function where(string $column, string $operator, mixed $value): static
+        public function where(
+            string $column,
+            string $operator,
+            mixed $value,
+        ): static
         {
             return $this;
         }
 
-        public function whereIn(string $column, array $values): static
+        public function whereIn(
+            string $column,
+            array $values,
+        ): static
         {
             $this->capturedWhereIn[] = ['column' => $column, 'values' => $values];
 
@@ -187,7 +200,10 @@ function makeStringPkQueryBuilder(array $rows, array &$capturedWhereIn = []): Qu
             return $this;
         }
 
-        public function whereJsonContains(string $path, mixed $value): static
+        public function whereJsonContains(
+            string $path,
+            mixed $value,
+        ): static
         {
             return $this;
         }
@@ -202,42 +218,73 @@ function makeStringPkQueryBuilder(array $rows, array &$capturedWhereIn = []): Qu
             return $this;
         }
 
-        public function orWhere(string $column, string $operator, mixed $value): static
+        public function orWhere(
+            string $column,
+            string $operator,
+            mixed $value,
+        ): static
         {
             return $this;
         }
 
-        public function join(string $table, string $first, string $operator, string $second): static
+        public function join(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function leftJoin(string $table, string $first, string $operator, string $second): static
+        public function leftJoin(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function rightJoin(string $table, string $first, string $operator, string $second): static
+        public function rightJoin(
+            string $table,
+            string $first,
+            string $operator,
+            string $second,
+        ): static
         {
             return $this;
         }
 
-        public function orderBy(string $column, string $direction = 'ASC'): static
+        public function orderBy(
+            string $column,
+            string $direction = 'ASC',
+        ): static
         {
             return $this;
         }
 
-        public function orderByRaw(string $expression, string $direction = 'ASC'): static
+        public function orderByRaw(
+            string $expression,
+            string $direction = 'ASC',
+        ): static
         {
             return $this;
         }
 
-        public function selectRaw(string $expression, array $bindings = []): static
+        public function selectRaw(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
 
-        public function whereRaw(string $expression, array $bindings = []): static
+        public function whereRaw(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
@@ -332,12 +379,18 @@ function makeStringPkQueryBuilder(array $rows, array &$capturedWhereIn = []): Qu
             return $this;
         }
 
-        public function having(string $expression, array $bindings = []): static
+        public function having(
+            string $expression,
+            array $bindings = [],
+        ): static
         {
             return $this;
         }
 
-        public function raw(string $sql, array $bindings = []): array
+        public function raw(
+            string $sql,
+            array $bindings = [],
+        ): array
         {
             return [];
         }
@@ -467,9 +520,21 @@ it('loads a BelongsTo relationship when the foreign key is a string', function (
         tableName: 'orders',
         primaryKey: 'uuid',
         properties: [
-            'uuid' => new PropertyMetadata(name: 'uuid', columnName: 'uuid', type: 'string', nullable: true, isPrimaryKey: true, isAutoIncrement: false),
+            'uuid' => new PropertyMetadata(
+                name: 'uuid',
+                columnName: 'uuid',
+                type: 'string',
+                nullable: true,
+                isPrimaryKey: true,
+                isAutoIncrement: false
+            ),
             'status' => new PropertyMetadata(name: 'status', columnName: 'status', type: 'string'),
-            'productUuid' => new PropertyMetadata(name: 'productUuid', columnName: 'product_uuid', type: 'string', nullable: true),
+            'productUuid' => new PropertyMetadata(
+                name: 'productUuid',
+                columnName: 'product_uuid',
+                type: 'string',
+                nullable: true
+            ),
         ],
         relationships: [
             'product' => new RelationshipMetadata(
@@ -518,9 +583,21 @@ it('loads a HasMany relationship when the parent primary key is a string', funct
         tableName: 'orders',
         primaryKey: 'uuid',
         properties: [
-            'uuid' => new PropertyMetadata(name: 'uuid', columnName: 'uuid', type: 'string', nullable: true, isPrimaryKey: true, isAutoIncrement: false),
+            'uuid' => new PropertyMetadata(
+                name: 'uuid',
+                columnName: 'uuid',
+                type: 'string',
+                nullable: true,
+                isPrimaryKey: true,
+                isAutoIncrement: false
+            ),
             'status' => new PropertyMetadata(name: 'status', columnName: 'status', type: 'string'),
-            'productUuid' => new PropertyMetadata(name: 'productUuid', columnName: 'product_uuid', type: 'string', nullable: true),
+            'productUuid' => new PropertyMetadata(
+                name: 'productUuid',
+                columnName: 'product_uuid',
+                type: 'string',
+                nullable: true
+            ),
         ],
         relationships: [
             'lines' => new RelationshipMetadata(
@@ -574,9 +651,21 @@ it('batches WHERE IN queries correctly for string foreign keys without SQL injec
         tableName: 'orders',
         primaryKey: 'uuid',
         properties: [
-            'uuid' => new PropertyMetadata(name: 'uuid', columnName: 'uuid', type: 'string', nullable: true, isPrimaryKey: true, isAutoIncrement: false),
+            'uuid' => new PropertyMetadata(
+                name: 'uuid',
+                columnName: 'uuid',
+                type: 'string',
+                nullable: true,
+                isPrimaryKey: true,
+                isAutoIncrement: false
+            ),
             'status' => new PropertyMetadata(name: 'status', columnName: 'status', type: 'string'),
-            'productUuid' => new PropertyMetadata(name: 'productUuid', columnName: 'product_uuid', type: 'string', nullable: true),
+            'productUuid' => new PropertyMetadata(
+                name: 'productUuid',
+                columnName: 'product_uuid',
+                type: 'string',
+                nullable: true
+            ),
         ],
         relationships: [
             'lines' => new RelationshipMetadata(

--- a/packages/database/tests/Schema/SchemaRegistryTest.php
+++ b/packages/database/tests/Schema/SchemaRegistryTest.php
@@ -295,33 +295,42 @@ it('throws EntityException when two extenders declare an index with the same nam
     ]))->toThrow(EntityException::class);
 });
 
-it('updates the EntityMetadataFactory cache so that a subsequent parse(parentClass) returns metadata with extenders populated', function (): void {
-    $this->registry->registerEntities([ProductEntity::class, ProductExtenderEntity::class]);
+it(
+    'updates the EntityMetadataFactory cache so that a subsequent parse(parentClass) returns metadata with extenders populated',
+    function (): void {
+        $this->registry->registerEntities([ProductEntity::class, ProductExtenderEntity::class]);
+    
+        $cachedMetadata = $this->metadataFactory->parse(ProductEntity::class);
+    
+        expect($cachedMetadata->extenders)->toContain(ProductExtenderEntity::class);
+    }
+);
 
-    $cachedMetadata = $this->metadataFactory->parse(ProductEntity::class);
-
-    expect($cachedMetadata->extenders)->toContain(ProductExtenderEntity::class);
-});
-
-it('handles registration order independence when an extender appears before its parent in the input array', function (): void {
-    // Extender listed first, parent second — must still merge correctly
+it(
+    'handles registration order independence when an extender appears before its parent in the input array',
+    function (): void {
+        // Extender listed first, parent second — must still merge correctly
     $this->registry->registerEntities([ProductSecondExtenderEntity::class, ProductEntity::class]);
+    
+        $table = $this->registry->getTable('products');
+        $columnNames = array_map(fn ($c) => $c->name, $table->columns);
+    
+        expect($table)->not->toBeNull()
+            ->and($columnNames)->toContain('barcode');
+    }
+);
 
-    $table = $this->registry->getTable('products');
-    $columnNames = array_map(fn ($c) => $c->name, $table->columns);
-
-    expect($table)->not->toBeNull()
-        ->and($columnNames)->toContain('barcode');
-});
-
-it('includes a discovered extender from EntityDiscovery in the merged table (regression test for discovery integration)', function (): void {
-    // Both ProductEntity and ProductExtenderEntity extend Entity with #[Table],
+it(
+    'includes a discovered extender from EntityDiscovery in the merged table (regression test for discovery integration)',
+    function (): void {
+        // Both ProductEntity and ProductExtenderEntity extend Entity with #[Table],
     // so EntityDiscovery would find both. Simulate by passing both to registerEntities.
     $this->registry->registerEntities([ProductEntity::class, ProductExtenderEntity::class]);
-
-    $table = $this->registry->getTable('products');
-
-    expect($table)->not->toBeNull()
-        ->and($table->columns)->toHaveCount(3)
-        ->and($this->registry->getEntityClass('products'))->toBe(ProductEntity::class);
-});
+    
+        $table = $this->registry->getTable('products');
+    
+        expect($table)->not->toBeNull()
+            ->and($table->columns)->toHaveCount(3)
+            ->and($this->registry->getEntityClass('products'))->toBe(ProductEntity::class);
+    }
+);

--- a/packages/dev-server/src/Exceptions/DevServerException.php
+++ b/packages/dev-server/src/Exceptions/DevServerException.php
@@ -8,7 +8,10 @@ use Marko\Core\Exceptions\MarkoException;
 
 class DevServerException extends MarkoException
 {
-    public static function processFailedToStart(string $name, string $command): self
+    public static function processFailedToStart(
+        string $name,
+        string $command,
+    ): self
     {
         return new self(
             message: "Failed to start process '$name' with command: $command",

--- a/packages/encryption/tests/KnownDriversValidationTest.php
+++ b/packages/encryption/tests/KnownDriversValidationTest.php
@@ -7,9 +7,12 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all encryption drivers', function () use ($knownDriversPath, $skeletonComposerPath) {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all encryption drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath) {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every encryption driver follows marko slash prefix pattern', function () use ($knownDriversPath) {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);

--- a/packages/errors-advanced/tests/Unit/UrlLinkificationTest.php
+++ b/packages/errors-advanced/tests/Unit/UrlLinkificationTest.php
@@ -169,16 +169,19 @@ describe('URL Linkification - URL Detection and Rendering', function (): void {
             ->and($output)->toContain(' and read the docs.');
     });
 
-    it('does not linkify text that looks URL-ish but lacks a protocol (e.g., www.example.com without http)', function (): void {
-        [$formatter, $report] = createFormatterWithReport(
-            message: 'Visit www.example.com for help',
-        );
-
-        $output = $formatter->format($report);
-
-        expect($output)->not->toContain('<a href="')
-            ->and($output)->toContain('www.example.com');
-    });
+    it(
+        'does not linkify text that looks URL-ish but lacks a protocol (e.g., www.example.com without http)',
+        function (): void {
+            [$formatter, $report] = createFormatterWithReport(
+                message: 'Visit www.example.com for help',
+            );
+    
+            $output = $formatter->format($report);
+    
+            expect($output)->not->toContain('<a href="')
+                ->and($output)->toContain('www.example.com');
+        }
+    );
 
     it('trims trailing punctuation from URL matches (period, comma, etc.)', function (): void {
         [$formatter, $report] = createFormatterWithReport(

--- a/packages/errors/tests/KnownDriversValidationTest.php
+++ b/packages/errors/tests/KnownDriversValidationTest.php
@@ -23,9 +23,12 @@ test('it lists marko/errors-simple first as the recommended driver', function ()
     expect(array_key_first($drivers))->toBe('marko/errors-simple');
 });
 
-test('skeleton suggest block contains all errors drivers', function () use ($knownDriversPath, $skeletonComposerPath): void {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all errors drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath): void {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every errors driver follows marko slash prefix pattern', function () use ($knownDriversPath): void {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);

--- a/packages/filesystem/tests/KnownDriversValidationTest.php
+++ b/packages/filesystem/tests/KnownDriversValidationTest.php
@@ -7,9 +7,12 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all filesystem drivers', function () use ($knownDriversPath, $skeletonComposerPath) {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all filesystem drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath) {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every filesystem driver follows marko slash prefix pattern', function () use ($knownDriversPath) {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);

--- a/packages/framework/tests/ArchitectureDocTest.php
+++ b/packages/framework/tests/ArchitectureDocTest.php
@@ -40,14 +40,20 @@ it('the section explains when to use the pattern (reusable UI packages)', functi
         ->and($content)->toContain('UI');
 });
 
-it('the section explains when NOT to use the pattern (application-specific modules)', function () use ($architecturePath) {
-    $content = file_get_contents($architecturePath);
+it(
+    'the section explains when NOT to use the pattern (application-specific modules)',
+    function () use ($architecturePath) {
+        $content = file_get_contents($architecturePath);
+    
+        expect($content)->toContain('application-specific');
+    }
+);
 
-    expect($content)->toContain('application-specific');
-});
-
-it('the section mentions the CrossEngineTemplateParityTest as the enforcement mechanism', function () use ($architecturePath) {
-    $content = file_get_contents($architecturePath);
-
-    expect($content)->toContain('CrossEngineTemplateParityTest');
-});
+it(
+    'the section mentions the CrossEngineTemplateParityTest as the enforcement mechanism',
+    function () use ($architecturePath) {
+        $content = file_get_contents($architecturePath);
+    
+        expect($content)->toContain('CrossEngineTemplateParityTest');
+    }
+);

--- a/packages/framework/tests/PackagistPublishingTest.php
+++ b/packages/framework/tests/PackagistPublishingTest.php
@@ -21,7 +21,12 @@ it('removes repositories key from all 38 package composer.json files that have p
         }
     }
 
-    expect($withRepos)->toBeEmpty('These package composer.json files still contain a "repositories" key: ' . implode(', ', array_map('basename', array_map('dirname', $withRepos))));
+    expect($withRepos)->toBeEmpty(
+        'These package composer.json files still contain a "repositories" key: ' . implode(
+            ', ',
+            array_map('basename', array_map('dirname', $withRepos))
+        )
+    );
 });
 
 it('changes all internal marko/* require constraints from @dev to self.version', function (): void {
@@ -69,7 +74,9 @@ it('changes all internal marko/* require-dev constraints from @dev to self.versi
         }
     }
 
-    expect($violations)->toBeEmpty('These require-dev constraints are not self.version: ' . implode(', ', $violations));
+    expect($violations)->toBeEmpty(
+        'These require-dev constraints are not self.version: ' . implode(', ', $violations)
+    );
 });
 
 it('changes marko/dev-server wildcard constraints to self.version', function (): void {
@@ -83,7 +90,9 @@ it('changes marko/dev-server wildcard constraints to self.version', function ():
         }
     }
 
-    expect($violations)->toBeEmpty('dev-server has non-self.version marko/* constraints: ' . implode(', ', $violations));
+    expect($violations)->toBeEmpty(
+        'dev-server has non-self.version marko/* constraints: ' . implode(', ', $violations)
+    );
 });
 
 it('changes any remaining wildcard marko/* constraints to self.version', function (): void {
@@ -126,7 +135,9 @@ it('preserves all non-marko dependency constraints unchanged (php, psr/*, ext-*,
         }
     }
 
-    expect($violations)->toBeEmpty('These non-marko dependencies incorrectly use self.version: ' . implode(', ', $violations));
+    expect($violations)->toBeEmpty(
+        'These non-marko dependencies incorrectly use self.version: ' . implode(', ', $violations)
+    );
 });
 
 it('preserves all other composer.json keys (autoload, extra, config, suggest, etc.) unchanged', function (): void {
@@ -160,5 +171,7 @@ it('preserves all other composer.json keys (autoload, extra, config, suggest, et
         }
     }
 
-    expect($violations)->toBeEmpty('Structural violations in package composer.json files: ' . implode(', ', $violations));
+    expect($violations)->toBeEmpty(
+        'Structural violations in package composer.json files: ' . implode(', ', $violations)
+    );
 });

--- a/packages/framework/tests/RootComposerJsonTest.php
+++ b/packages/framework/tests/RootComposerJsonTest.php
@@ -81,38 +81,48 @@ $allPackages = [
     'marko/webhook',
 ];
 
-it('adds a require section entry for all 73 marko packages set to self.version', function () use ($rootComposer, $allPackages): void {
-    expect($rootComposer)->toHaveKey('require');
-
-    foreach ($allPackages as $package) {
-        expect($rootComposer['require'])->toHaveKey($package)
-            ->and($rootComposer['require'][$package])->toBe('self.version');
+it(
+    'adds a require section entry for all 73 marko packages set to self.version',
+    function () use ($rootComposer, $allPackages): void {
+        expect($rootComposer)->toHaveKey('require');
+    
+        foreach ($allPackages as $package) {
+            expect($rootComposer['require'])->toHaveKey($package)
+                ->and($rootComposer['require'][$package])->toBe('self.version');
+        }
     }
-});
+);
 
-it('does not have a replace section (path repos install as symlinks without it)', function () use ($rootComposer): void {
-    expect($rootComposer)->not->toHaveKey('replace');
-});
-
-it('adds repositories section with path repos for all 73 packages', function () use ($rootComposer, $allPackages): void {
-    expect($rootComposer)->toHaveKey('repositories');
-
-    $repoUrls = array_column($rootComposer['repositories'], 'url');
-
-    foreach ($allPackages as $package) {
-        $packageName = str_replace('marko/', '', $package);
-        expect(in_array("packages/$packageName", $repoUrls, true))->toBeTrue();
+it(
+    'does not have a replace section (path repos install as symlinks without it)',
+    function () use ($rootComposer): void {
+        expect($rootComposer)->not->toHaveKey('replace');
     }
+);
 
-    foreach ($rootComposer['repositories'] as $repo) {
-        expect($repo)->toHaveKey('type')
-            ->and($repo['type'])->toBe('path');
+it(
+    'adds repositories section with path repos for all 73 packages',
+    function () use ($rootComposer, $allPackages): void {
+        expect($rootComposer)->toHaveKey('repositories');
+    
+        $repoUrls = array_column($rootComposer['repositories'], 'url');
+    
+        foreach ($allPackages as $package) {
+            $packageName = str_replace('marko/', '', $package);
+            expect(in_array("packages/$packageName", $repoUrls, true))->toBeTrue();
+        }
+    
+        foreach ($rootComposer['repositories'] as $repo) {
+            expect($repo)->toHaveKey('type')
+                ->and($repo['type'])->toBe('path');
+        }
     }
-});
+);
 
 it('removes all manual PSR-4 autoload entries for marko packages', function () use ($rootComposer): void {
     if (!isset($rootComposer['autoload']['psr-4'])) {
         expect(true)->toBeTrue();
+
         return;
     }
 
@@ -121,20 +131,23 @@ it('removes all manual PSR-4 autoload entries for marko packages', function () u
     }
 });
 
-it('keeps autoload-dev entries for test namespaces (Composer does not merge autoload-dev from dependencies)', function () use ($rootComposer, $allPackages): void {
-    // autoload-dev must remain in root: Composer only applies a package's autoload-dev
+it(
+    'keeps autoload-dev entries for test namespaces (Composer does not merge autoload-dev from dependencies)',
+    function () use ($rootComposer, $allPackages): void {
+        // autoload-dev must remain in root: Composer only applies a package's autoload-dev
     // when it is the root package, so test namespaces for all monorepo packages must
     // be declared here to be discoverable when running the test suite.
     expect($rootComposer)->toHaveKey('autoload-dev')
-        ->and($rootComposer['autoload-dev'])->toHaveKey('psr-4');
-
-    $devPsr4 = $rootComposer['autoload-dev']['psr-4'];
-    $hasAtLeastOneTestNamespace = array_any(
-        array_keys($devPsr4),
-        fn (string $ns): bool => str_ends_with($ns, 'Tests\\'),
-    );
-    expect($hasAtLeastOneTestNamespace)->toBeTrue();
-});
+            ->and($rootComposer['autoload-dev'])->toHaveKey('psr-4');
+    
+        $devPsr4 = $rootComposer['autoload-dev']['psr-4'];
+        $hasAtLeastOneTestNamespace = array_any(
+            array_keys($devPsr4),
+            fn (string $ns): bool => str_ends_with($ns, 'Tests\\'),
+        );
+        expect($hasAtLeastOneTestNamespace)->toBeTrue();
+    }
+);
 
 it('removes the autoload files entry for packages/env/src/functions.php', function () use ($rootComposer): void {
     $files = $rootComposer['autoload']['files'] ?? [];
@@ -142,32 +155,35 @@ it('removes the autoload files entry for packages/env/src/functions.php', functi
     expect(in_array('packages/env/src/functions.php', $files, true))->toBeFalse();
 });
 
-it('preserves existing require (php, ext-*) and require-dev (third-party) entries', function () use ($rootComposer): void {
-    expect($rootComposer['require'])->toHaveKey('php')
-        ->and($rootComposer['require']['php'])->toBe('^8.5')
-        ->and($rootComposer['require'])->toHaveKey('ext-pdo')
-        ->and($rootComposer['require'])->toHaveKey('ext-fileinfo')
-        ->and($rootComposer['require'])->toHaveKey('ext-gd')
-        ->and($rootComposer['require'])->toHaveKey('ext-imagick');
-
-    $expectedDevPackages = [
-        'amphp/postgres',
-        'amphp/redis',
-        'aws/aws-sdk-php',
-        'friendsofphp/php-cs-fixer',
-        'guzzlehttp/guzzle',
-        'pestphp/pest',
-        'php-amqplib/php-amqplib',
-        'predis/predis',
-        'rector/rector',
-        'slevomat/coding-standard',
-        'squizlabs/php_codesniffer',
-    ];
-
-    foreach ($expectedDevPackages as $package) {
-        expect($rootComposer['require-dev'])->toHaveKey($package);
+it(
+    'preserves existing require (php, ext-*) and require-dev (third-party) entries',
+    function () use ($rootComposer): void {
+        expect($rootComposer['require'])->toHaveKey('php')
+            ->and($rootComposer['require']['php'])->toBe('^8.5')
+            ->and($rootComposer['require'])->toHaveKey('ext-pdo')
+            ->and($rootComposer['require'])->toHaveKey('ext-fileinfo')
+            ->and($rootComposer['require'])->toHaveKey('ext-gd')
+            ->and($rootComposer['require'])->toHaveKey('ext-imagick');
+    
+        $expectedDevPackages = [
+            'amphp/postgres',
+            'amphp/redis',
+            'aws/aws-sdk-php',
+            'friendsofphp/php-cs-fixer',
+            'guzzlehttp/guzzle',
+            'pestphp/pest',
+            'php-amqplib/php-amqplib',
+            'predis/predis',
+            'rector/rector',
+            'slevomat/coding-standard',
+            'squizlabs/php_codesniffer',
+        ];
+    
+        foreach ($expectedDevPackages as $package) {
+            expect($rootComposer['require-dev'])->toHaveKey($package);
+        }
     }
-});
+);
 
 it('preserves scripts, config, and other root-level settings', function () use ($rootComposer): void {
     expect($rootComposer)->toHaveKey('scripts')
@@ -181,10 +197,13 @@ it('preserves scripts, config, and other root-level settings', function () use (
         ->and($rootComposer['config'])->toHaveKey('allow-plugins');
 });
 
-it('keeps minimum-stability as stable (replace bypasses stability checks for replaced packages)', function () use ($rootComposer): void {
-    expect($rootComposer)->toHaveKey('minimum-stability')
-        ->and($rootComposer['minimum-stability'])->toBe('stable');
-});
+it(
+    'keeps minimum-stability as stable (replace bypasses stability checks for replaced packages)',
+    function () use ($rootComposer): void {
+        expect($rootComposer)->toHaveKey('minimum-stability')
+            ->and($rootComposer['minimum-stability'])->toBe('stable');
+    }
+);
 
 it('keeps prefer-stable as true', function () use ($rootComposer): void {
     expect($rootComposer)->toHaveKey('prefer-stable')

--- a/packages/health/tests/Unit/FilesystemHealthCheckTest.php
+++ b/packages/health/tests/Unit/FilesystemHealthCheckTest.php
@@ -44,19 +44,30 @@ it('checks filesystem writability via FilesystemHealthCheck', function () {
             throw new RuntimeException('Not implemented');
         }
 
-        public function write(string $path, string $contents, array $options = []): bool
+        public function write(
+            string $path,
+            string $contents,
+            array $options = [],
+        ): bool
         {
             $this->written[$path] = $contents;
 
             return true;
         }
 
-        public function writeStream(string $path, mixed $resource, array $options = []): bool
+        public function writeStream(
+            string $path,
+            mixed $resource,
+            array $options = [],
+        ): bool
         {
             return true;
         }
 
-        public function append(string $path, string $contents): bool
+        public function append(
+            string $path,
+            string $contents,
+        ): bool
         {
             return true;
         }
@@ -68,12 +79,18 @@ it('checks filesystem writability via FilesystemHealthCheck', function () {
             return true;
         }
 
-        public function copy(string $source, string $destination): bool
+        public function copy(
+            string $source,
+            string $destination,
+        ): bool
         {
             return true;
         }
 
-        public function move(string $source, string $destination): bool
+        public function move(
+            string $source,
+            string $destination,
+        ): bool
         {
             return true;
         }
@@ -108,7 +125,10 @@ it('checks filesystem writability via FilesystemHealthCheck', function () {
             return true;
         }
 
-        public function setVisibility(string $path, string $visibility): bool
+        public function setVisibility(
+            string $path,
+            string $visibility,
+        ): bool
         {
             return true;
         }
@@ -162,17 +182,28 @@ it('returns unhealthy status when filesystem write fails', function () {
             throw new RuntimeException('Not implemented');
         }
 
-        public function write(string $path, string $contents, array $options = []): bool
+        public function write(
+            string $path,
+            string $contents,
+            array $options = [],
+        ): bool
         {
             throw new RuntimeException('Filesystem not writable');
         }
 
-        public function writeStream(string $path, mixed $resource, array $options = []): bool
+        public function writeStream(
+            string $path,
+            mixed $resource,
+            array $options = [],
+        ): bool
         {
             return false;
         }
 
-        public function append(string $path, string $contents): bool
+        public function append(
+            string $path,
+            string $contents,
+        ): bool
         {
             return false;
         }
@@ -182,12 +213,18 @@ it('returns unhealthy status when filesystem write fails', function () {
             return false;
         }
 
-        public function copy(string $source, string $destination): bool
+        public function copy(
+            string $source,
+            string $destination,
+        ): bool
         {
             return false;
         }
 
-        public function move(string $source, string $destination): bool
+        public function move(
+            string $source,
+            string $destination,
+        ): bool
         {
             return false;
         }
@@ -222,7 +259,10 @@ it('returns unhealthy status when filesystem write fails', function () {
             return false;
         }
 
-        public function setVisibility(string $path, string $visibility): bool
+        public function setVisibility(
+            string $path,
+            string $visibility,
+        ): bool
         {
             return false;
         }

--- a/packages/http/tests/KnownDriversValidationTest.php
+++ b/packages/http/tests/KnownDriversValidationTest.php
@@ -7,5 +7,11 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all http drivers', fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath));
-test('every http driver follows marko slash prefix pattern', fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath));
+test(
+    'skeleton suggest block contains all http drivers',
+    fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath)
+);
+test(
+    'every http driver follows marko slash prefix pattern',
+    fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath)
+);

--- a/packages/inertia/tests/KnownDriversValidationTest.php
+++ b/packages/inertia/tests/KnownDriversValidationTest.php
@@ -7,9 +7,12 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all inertia drivers', function () use ($knownDriversPath, $skeletonComposerPath) {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all inertia drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath) {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every inertia driver follows marko slash prefix pattern', function () use ($knownDriversPath) {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);

--- a/packages/layout/src/ComponentCollection.php
+++ b/packages/layout/src/ComponentCollection.php
@@ -76,7 +76,11 @@ class ComponentCollection
     /**
      * @throws ComponentNotFoundException
      */
-    public function move(string $className, string $newSlot, ?int $newSortOrder = null): void
+    public function move(
+        string $className,
+        string $newSlot,
+        ?int $newSortOrder = null,
+    ): void
     {
         $definition = $this->get($className);
 
@@ -124,7 +128,10 @@ class ComponentCollection
      * @return array<int, ComponentDefinition>
      * @throws AmbiguousSortOrderException
      */
-    private function sort(array $components, string $slot): array
+    private function sort(
+        array $components,
+        string $slot,
+    ): array
     {
         // First pass: sort by sortOrder, detecting ambiguities
         usort($components, function (ComponentDefinition $a, ComponentDefinition $b) use ($slot): int {

--- a/packages/layout/src/ComponentCollector.php
+++ b/packages/layout/src/ComponentCollector.php
@@ -24,7 +24,10 @@ readonly class ComponentCollector implements ComponentCollectorInterface
      * @param array<int, class-string> $classNames
      * @throws Error|ReflectionException|Exceptions\DuplicateComponentException
      */
-    public function collect(array $classNames, string $handle): ComponentCollection
+    public function collect(
+        array $classNames,
+        string $handle,
+    ): ComponentCollection
     {
         $collection = new ComponentCollection();
 
@@ -136,7 +139,10 @@ readonly class ComponentCollector implements ComponentCollectorInterface
     /**
      * Resolve a class-reference handle to a string handle via RouteCollection.
      */
-    private function resolveClassReferenceHandle(string $controllerClass, string $action): ?string
+    private function resolveClassReferenceHandle(
+        string $controllerClass,
+        string $action,
+    ): ?string
     {
         foreach ($this->routeCollection->all() as $route) {
             if ($route->controller === $controllerClass && $route->action === $action) {

--- a/packages/layout/src/ComponentCollectorInterface.php
+++ b/packages/layout/src/ComponentCollectorInterface.php
@@ -11,7 +11,10 @@ interface ComponentCollectorInterface
      *
      * @param array<int, class-string> $classNames
      */
-    public function collect(array $classNames, string $handle): ComponentCollection;
+    public function collect(
+        array $classNames,
+        string $handle,
+    ): ComponentCollection;
 
     /**
      * Discover a ComponentDefinition from a single class.

--- a/packages/layout/src/ComponentDataResolver.php
+++ b/packages/layout/src/ComponentDataResolver.php
@@ -17,7 +17,11 @@ readonly class ComponentDataResolver
      * @return array<string, mixed>
      * @throws ReflectionException
      */
-    public function resolve(object $component, array $routeParams, Request $request): array
+    public function resolve(
+        object $component,
+        array $routeParams,
+        Request $request,
+    ): array
     {
         if (!method_exists($component, 'data')) {
             return [];
@@ -47,7 +51,10 @@ readonly class ComponentDataResolver
         return $component->data(...$parameters);
     }
 
-    private function castToType(mixed $value, ?ReflectionType $type): mixed
+    private function castToType(
+        mixed $value,
+        ?ReflectionType $type,
+    ): mixed
     {
         if (!$type instanceof ReflectionNamedType) {
             return $value;

--- a/packages/layout/src/DiscoveringComponentCollector.php
+++ b/packages/layout/src/DiscoveringComponentCollector.php
@@ -27,7 +27,10 @@ readonly class DiscoveringComponentCollector implements ComponentCollectorInterf
      * @param array<int, class-string> $classNames
      * @throws DuplicateComponentException|Error|ReflectionException
      */
-    public function collect(array $classNames, string $handle): ComponentCollection
+    public function collect(
+        array $classNames,
+        string $handle,
+    ): ComponentCollection
     {
         $discovered = $this->discoverComponentClasses();
         $merged = array_values(array_unique(array_merge($discovered, $classNames)));

--- a/packages/layout/src/Exceptions/AmbiguousSortOrderException.php
+++ b/packages/layout/src/Exceptions/AmbiguousSortOrderException.php
@@ -9,7 +9,11 @@ class AmbiguousSortOrderException extends LayoutException
     /**
      * @param array<string> $components
      */
-    public static function forComponents(string $slot, int $sortOrder, array $components): self
+    public static function forComponents(
+        string $slot,
+        int $sortOrder,
+        array $components,
+    ): self
     {
         $componentList = implode(', ', $components);
 

--- a/packages/layout/src/Exceptions/CircularSlotException.php
+++ b/packages/layout/src/Exceptions/CircularSlotException.php
@@ -9,7 +9,10 @@ class CircularSlotException extends LayoutException
     /**
      * @param array<string> $chain
      */
-    public static function forSlot(string $slot, array $chain): self
+    public static function forSlot(
+        string $slot,
+        array $chain,
+    ): self
     {
         $chainPath = implode(' -> ', $chain);
 

--- a/packages/layout/src/Exceptions/DuplicateComponentException.php
+++ b/packages/layout/src/Exceptions/DuplicateComponentException.php
@@ -6,7 +6,11 @@ namespace Marko\Layout\Exceptions;
 
 class DuplicateComponentException extends LayoutException
 {
-    public static function forComponent(string $name, string $moduleA, string $moduleB): self
+    public static function forComponent(
+        string $name,
+        string $moduleA,
+        string $moduleB,
+    ): self
     {
         return new self(
             message: "Component '$name' is registered in multiple modules.",

--- a/packages/layout/src/Exceptions/SlotNotFoundException.php
+++ b/packages/layout/src/Exceptions/SlotNotFoundException.php
@@ -6,7 +6,10 @@ namespace Marko\Layout\Exceptions;
 
 class SlotNotFoundException extends LayoutException
 {
-    public static function forSlot(string $slot, string $layout): self
+    public static function forSlot(
+        string $slot,
+        string $layout,
+    ): self
     {
         return new self(
             message: "Slot '$slot' not found in layout '$layout'.",

--- a/packages/layout/src/HandleResolver.php
+++ b/packages/layout/src/HandleResolver.php
@@ -6,7 +6,11 @@ namespace Marko\Layout;
 
 readonly class HandleResolver
 {
-    public function generate(string $path, string $controllerClass, string $action): string
+    public function generate(
+        string $path,
+        string $controllerClass,
+        string $action,
+    ): string
     {
         $segments = explode('/', trim($path, '/'));
         $routePart = $segments[0] !== '' ? $segments[0] : 'index';
@@ -17,7 +21,10 @@ readonly class HandleResolver
         return strtolower("{$routePart}_{$controllerPart}_$action");
     }
 
-    public function matches(string $componentHandle, string $pageHandle): bool
+    public function matches(
+        string $componentHandle,
+        string $pageHandle,
+    ): bool
     {
         if ($componentHandle === 'default') {
             return true;

--- a/packages/layout/src/LayoutProcessor.php
+++ b/packages/layout/src/LayoutProcessor.php
@@ -124,7 +124,10 @@ readonly class LayoutProcessor implements LayoutProcessorInterface
      * @param array<string> $topLevelSlots
      * @throws CircularSlotException
      */
-    private function detectCircularReferences(ComponentCollection $collection, array $topLevelSlots): void
+    private function detectCircularReferences(
+        ComponentCollection $collection,
+        array $topLevelSlots,
+    ): void
     {
         // Build a map: slot name -> sub-slots it leads to (via components in that slot)
         /** @var array<string, array<string>> $slotToSubSlots */

--- a/packages/layout/src/LayoutResolver.php
+++ b/packages/layout/src/LayoutResolver.php
@@ -23,7 +23,10 @@ readonly class LayoutResolver
      * @return array{componentClass: class-string, attribute: Component}
      * @throws LayoutNotFoundException|ReflectionException
      */
-    public function resolve(string $controllerClass, string $method): array
+    public function resolve(
+        string $controllerClass,
+        string $method,
+    ): array
     {
         $classReflection = new ReflectionClass($controllerClass);
         $methodReflection = new ReflectionMethod($controllerClass, $method);

--- a/packages/layout/tests/Exceptions/AmbiguousSortOrderExceptionTest.php
+++ b/packages/layout/tests/Exceptions/AmbiguousSortOrderExceptionTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 use Marko\Layout\Exceptions\AmbiguousSortOrderException;
 use Marko\Layout\Exceptions\LayoutException;
 
-it('has an AmbiguousSortOrderException with a static factory method providing message, context, and suggestion', function (): void {
-    $exception = AmbiguousSortOrderException::forComponents('header', 10, ['ComponentA', 'ComponentB']);
-
-    expect($exception)->toBeInstanceOf(LayoutException::class)
-        ->and($exception->getMessage())->toContain('header')
-        ->and($exception->getContext())->not->toBeEmpty()
-        ->and($exception->getSuggestion())->not->toBeEmpty();
-});
+it(
+    'has an AmbiguousSortOrderException with a static factory method providing message, context, and suggestion',
+    function (): void {
+        $exception = AmbiguousSortOrderException::forComponents('header', 10, ['ComponentA', 'ComponentB']);
+    
+        expect($exception)->toBeInstanceOf(LayoutException::class)
+            ->and($exception->getMessage())->toContain('header')
+            ->and($exception->getContext())->not->toBeEmpty()
+            ->and($exception->getSuggestion())->not->toBeEmpty();
+    }
+);

--- a/packages/layout/tests/Exceptions/CircularSlotExceptionTest.php
+++ b/packages/layout/tests/Exceptions/CircularSlotExceptionTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 use Marko\Layout\Exceptions\CircularSlotException;
 use Marko\Layout\Exceptions\LayoutException;
 
-it('has a CircularSlotException with a static factory method providing message, context, and suggestion', function (): void {
-    $exception = CircularSlotException::forSlot('main', ['main', 'nested', 'main']);
-
-    expect($exception)->toBeInstanceOf(LayoutException::class)
-        ->and($exception->getMessage())->toContain('main')
-        ->and($exception->getContext())->not->toBeEmpty()
-        ->and($exception->getSuggestion())->not->toBeEmpty();
-});
+it(
+    'has a CircularSlotException with a static factory method providing message, context, and suggestion',
+    function (): void {
+        $exception = CircularSlotException::forSlot('main', ['main', 'nested', 'main']);
+    
+        expect($exception)->toBeInstanceOf(LayoutException::class)
+            ->and($exception->getMessage())->toContain('main')
+            ->and($exception->getContext())->not->toBeEmpty()
+            ->and($exception->getSuggestion())->not->toBeEmpty();
+    }
+);

--- a/packages/layout/tests/Exceptions/ComponentNotFoundExceptionTest.php
+++ b/packages/layout/tests/Exceptions/ComponentNotFoundExceptionTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 use Marko\Layout\Exceptions\ComponentNotFoundException;
 use Marko\Layout\Exceptions\LayoutException;
 
-it('has a ComponentNotFoundException with a static factory method providing message, context, and suggestion', function (): void {
-    $exception = ComponentNotFoundException::forComponent('alert');
-
-    expect($exception)->toBeInstanceOf(LayoutException::class)
-        ->and($exception->getMessage())->toContain('alert')
-        ->and($exception->getContext())->not->toBeEmpty()
-        ->and($exception->getSuggestion())->not->toBeEmpty();
-});
+it(
+    'has a ComponentNotFoundException with a static factory method providing message, context, and suggestion',
+    function (): void {
+        $exception = ComponentNotFoundException::forComponent('alert');
+    
+        expect($exception)->toBeInstanceOf(LayoutException::class)
+            ->and($exception->getMessage())->toContain('alert')
+            ->and($exception->getContext())->not->toBeEmpty()
+            ->and($exception->getSuggestion())->not->toBeEmpty();
+    }
+);

--- a/packages/layout/tests/Exceptions/DuplicateComponentExceptionTest.php
+++ b/packages/layout/tests/Exceptions/DuplicateComponentExceptionTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 use Marko\Layout\Exceptions\DuplicateComponentException;
 use Marko\Layout\Exceptions\LayoutException;
 
-it('has a DuplicateComponentException with a static factory method providing message, context, and suggestion', function (): void {
-    $exception = DuplicateComponentException::forComponent('header', 'ModuleA', 'ModuleB');
-
-    expect($exception)->toBeInstanceOf(LayoutException::class)
-        ->and($exception->getMessage())->toContain('header')
-        ->and($exception->getContext())->not->toBeEmpty()
-        ->and($exception->getSuggestion())->not->toBeEmpty();
-});
+it(
+    'has a DuplicateComponentException with a static factory method providing message, context, and suggestion',
+    function (): void {
+        $exception = DuplicateComponentException::forComponent('header', 'ModuleA', 'ModuleB');
+    
+        expect($exception)->toBeInstanceOf(LayoutException::class)
+            ->and($exception->getMessage())->toContain('header')
+            ->and($exception->getContext())->not->toBeEmpty()
+            ->and($exception->getSuggestion())->not->toBeEmpty();
+    }
+);

--- a/packages/layout/tests/Exceptions/LayoutNotFoundExceptionTest.php
+++ b/packages/layout/tests/Exceptions/LayoutNotFoundExceptionTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 use Marko\Layout\Exceptions\LayoutException;
 use Marko\Layout\Exceptions\LayoutNotFoundException;
 
-it('has a LayoutNotFoundException with a static factory method providing message, context, and suggestion', function (): void {
-    $exception = LayoutNotFoundException::forLayout('admin');
-
-    expect($exception)->toBeInstanceOf(LayoutException::class)
-        ->and($exception->getMessage())->toContain('admin')
-        ->and($exception->getContext())->not->toBeEmpty()
-        ->and($exception->getSuggestion())->not->toBeEmpty();
-});
+it(
+    'has a LayoutNotFoundException with a static factory method providing message, context, and suggestion',
+    function (): void {
+        $exception = LayoutNotFoundException::forLayout('admin');
+    
+        expect($exception)->toBeInstanceOf(LayoutException::class)
+            ->and($exception->getMessage())->toContain('admin')
+            ->and($exception->getContext())->not->toBeEmpty()
+            ->and($exception->getSuggestion())->not->toBeEmpty();
+    }
+);

--- a/packages/layout/tests/Exceptions/SlotNotFoundExceptionTest.php
+++ b/packages/layout/tests/Exceptions/SlotNotFoundExceptionTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 use Marko\Layout\Exceptions\LayoutException;
 use Marko\Layout\Exceptions\SlotNotFoundException;
 
-it('has a SlotNotFoundException with a static factory method providing message, context, and suggestion', function (): void {
-    $exception = SlotNotFoundException::forSlot('sidebar', 'main-layout');
-
-    expect($exception)->toBeInstanceOf(LayoutException::class)
-        ->and($exception->getMessage())->toContain('sidebar')
-        ->and($exception->getContext())->not->toBeEmpty()
-        ->and($exception->getSuggestion())->not->toBeEmpty();
-});
+it(
+    'has a SlotNotFoundException with a static factory method providing message, context, and suggestion',
+    function (): void {
+        $exception = SlotNotFoundException::forSlot('sidebar', 'main-layout');
+    
+        expect($exception)->toBeInstanceOf(LayoutException::class)
+            ->and($exception->getMessage())->toContain('sidebar')
+            ->and($exception->getContext())->not->toBeEmpty()
+            ->and($exception->getSuggestion())->not->toBeEmpty();
+    }
+);

--- a/packages/layout/tests/Unit/ComponentCollectionTest.php
+++ b/packages/layout/tests/Unit/ComponentCollectionTest.php
@@ -146,16 +146,19 @@ it('respects after constraint over sortOrder when sorting', function (): void {
         ->and($result[1]->className)->toBe('App\Components\BComponent');
 });
 
-it('throws AmbiguousSortOrderException when two components have same sortOrder with no before or after constraints', function (): void {
-    $collection = new ComponentCollection();
-    $a = makeDefinition('App\Components\AComponent', 'header', sortOrder: 10);
-    $b = makeDefinition('App\Components\BComponent', 'header', sortOrder: 10);
-    $collection->add($a);
-    $collection->add($b);
-
-    expect(fn () => $collection->forSlot('header'))
-        ->toThrow(AmbiguousSortOrderException::class);
-});
+it(
+    'throws AmbiguousSortOrderException when two components have same sortOrder with no before or after constraints',
+    function (): void {
+        $collection = new ComponentCollection();
+        $a = makeDefinition('App\Components\AComponent', 'header', sortOrder: 10);
+        $b = makeDefinition('App\Components\BComponent', 'header', sortOrder: 10);
+        $collection->add($a);
+        $collection->add($b);
+    
+        expect(fn () => $collection->forSlot('header'))
+            ->toThrow(AmbiguousSortOrderException::class);
+    }
+);
 
 it('moves a component to a different slot', function (): void {
     $collection = new ComponentCollection();

--- a/packages/layout/tests/Unit/ComponentCollectorTest.php
+++ b/packages/layout/tests/Unit/ComponentCollectorTest.php
@@ -25,7 +25,11 @@ class CatalogPrefixComponent {}
 #[Component(template: 'other/page.phtml', slot: 'content', handle: 'checkout_cart')]
 class OtherPageComponent {}
 
-#[Component(template: 'multi/component.phtml', slot: 'content', handle: ['catalog_product_show', 'catalog_category_view'])]
+#[Component(
+    template: 'multi/component.phtml',
+    slot: 'content',
+    handle: ['catalog_product_show', 'catalog_category_view']
+)]
 class MultiHandleComponent {}
 
 #[Component(template: 'root/layout.phtml', slots: ['content', 'sidebar'], handle: 'default')]

--- a/packages/layout/tests/Unit/Helpers.php
+++ b/packages/layout/tests/Unit/Helpers.php
@@ -25,7 +25,10 @@ final class Helpers
 
             public function singleton(string $id): void {}
 
-            public function instance(string $id, object $instance): void {}
+            public function instance(
+                string $id,
+                object $instance,
+            ): void {}
 
             public function call(Closure $callable): mixed
             {

--- a/packages/layout/tests/Unit/LayoutProcessorNestedTest.php
+++ b/packages/layout/tests/Unit/LayoutProcessorNestedTest.php
@@ -30,7 +30,13 @@ class LpnFixtureController
 class LpnFixtureRootComponent {}
 
 // A component that lives in "content" slot but defines sub-slots: tab.details and tab.reviews
-#[Component(template: 'components/tabs.html', slot: 'content', handle: 'default', sortOrder: 10, slots: ['tab.details', 'tab.reviews'])]
+#[Component(
+    template: 'components/tabs.html',
+    slot: 'content',
+    handle: 'default',
+    sortOrder: 10,
+    slots: ['tab.details', 'tab.reviews']
+)]
 class LpnFixtureTabsComponent {}
 
 // Components targeting sub-slots
@@ -53,7 +59,13 @@ class LpnFixtureTwoSlotRootComponent {}
 #[Component(template: 'components/nav.html', slot: 'header', handle: 'default', sortOrder: 10)]
 class LpnFixtureNavComponent {}
 
-#[Component(template: 'components/body.html', slot: 'main', handle: 'default', sortOrder: 10, slots: ['body.sidebar', 'body.content'])]
+#[Component(
+    template: 'components/body.html',
+    slot: 'main',
+    handle: 'default',
+    sortOrder: 10,
+    slots: ['body.sidebar', 'body.content']
+)]
 class LpnFixtureBodyComponent {}
 
 #[Component(template: 'components/sidebar.html', slot: 'body.sidebar', handle: 'default', sortOrder: 10)]
@@ -63,16 +75,33 @@ class LpnFixtureSidebarNestedComponent {}
 class LpnFixtureMainContentComponent {}
 
 // Deep nesting: tab.details itself defines sub-slots
-#[Component(template: 'components/tabs-deep.html', slot: 'content', handle: 'default', sortOrder: 10, slots: ['tab.details'])]
+#[Component(
+    template: 'components/tabs-deep.html',
+    slot: 'content',
+    handle: 'default',
+    sortOrder: 10,
+    slots: ['tab.details']
+)]
 class LpnFixtureDeepTabsComponent {}
 
-#[Component(template: 'components/deep-details.html', slot: 'tab.details', handle: 'default', sortOrder: 10, slots: ['detail.images', 'detail.description'])]
+#[Component(
+    template: 'components/deep-details.html',
+    slot: 'tab.details',
+    handle: 'default',
+    sortOrder: 10,
+    slots: ['detail.images', 'detail.description']
+)]
 class LpnFixtureDeepDetailsComponent {}
 
 #[Component(template: 'components/detail-images.html', slot: 'detail.images', handle: 'default', sortOrder: 10)]
 class LpnFixtureDetailImagesComponent {}
 
-#[Component(template: 'components/detail-description.html', slot: 'detail.description', handle: 'default', sortOrder: 20)]
+#[Component(
+    template: 'components/detail-description.html',
+    slot: 'detail.description',
+    handle: 'default',
+    sortOrder: 20
+)]
 class LpnFixtureDetailDescriptionComponent {}
 
 // Circular reference fixtures
@@ -80,10 +109,22 @@ class LpnFixtureDetailDescriptionComponent {}
 // B is in cycle.b, B defines sub-slot: content (pointing back to layout's top-level!)
 // Actually: circular means slot graph has a cycle. Let's use:
 // X defines sub-slot: cycle.y; Y defines sub-slot: cycle.x; X is in cycle.x; Y is in cycle.y
-#[Component(template: 'components/cycle-x.html', slot: 'content', handle: 'default', sortOrder: 10, slots: ['cycle.y'])]
+#[Component(
+    template: 'components/cycle-x.html',
+    slot: 'content',
+    handle: 'default',
+    sortOrder: 10,
+    slots: ['cycle.y']
+)]
 class LpnFixtureCycleXComponent {}
 
-#[Component(template: 'components/cycle-y.html', slot: 'cycle.y', handle: 'default', sortOrder: 10, slots: ['cycle.x'])]
+#[Component(
+    template: 'components/cycle-y.html',
+    slot: 'cycle.y',
+    handle: 'default',
+    sortOrder: 10,
+    slots: ['cycle.x']
+)]
 class LpnFixtureCycleYComponent {}
 
 #[Component(template: 'components/cycle-filler.html', slot: 'cycle.x', handle: 'default', sortOrder: 10)]
@@ -97,7 +138,10 @@ function lpnStubCollector(ComponentCollection $collection): ComponentCollectorIn
     {
         public function __construct(private readonly ComponentCollection $stub) {}
 
-        public function collect(array $classNames, string $handle): ComponentCollection
+        public function collect(
+            array $classNames,
+            string $handle,
+        ): ComponentCollection
         {
             return $this->stub;
         }
@@ -115,12 +159,18 @@ function lpnStubView(callable $renderFn): ViewInterface
     {
         public function __construct(private readonly mixed $renderFn) {}
 
-        public function render(string $template, array $data = []): Response
+        public function render(
+            string $template,
+            array $data = [],
+        ): Response
         {
             return Response::html(($this->renderFn)($template, $data));
         }
 
-        public function renderToString(string $template, array $data = []): string
+        public function renderToString(
+            string $template,
+            array $data = [],
+        ): string
         {
             return ($this->renderFn)($template, $data);
         }

--- a/packages/layout/tests/Unit/LayoutProcessorTest.php
+++ b/packages/layout/tests/Unit/LayoutProcessorTest.php
@@ -93,7 +93,10 @@ function stubCollector(ComponentCollection $collection): ComponentCollectorInter
     {
         public function __construct(private readonly ComponentCollection $stub) {}
 
-        public function collect(array $classNames, string $handle): ComponentCollection
+        public function collect(
+            array $classNames,
+            string $handle,
+        ): ComponentCollection
         {
             return $this->stub;
         }
@@ -112,12 +115,18 @@ function stubView(callable $renderFn): ViewInterface
     {
         public function __construct(private readonly mixed $renderFn) {}
 
-        public function render(string $template, array $data = []): Response
+        public function render(
+            string $template,
+            array $data = [],
+        ): Response
         {
             return Response::html(($this->renderFn)($template, $data));
         }
 
-        public function renderToString(string $template, array $data = []): string
+        public function renderToString(
+            string $template,
+            array $data = [],
+        ): string
         {
             return ($this->renderFn)($template, $data);
         }
@@ -196,6 +205,7 @@ describe('LayoutProcessor', function (): void {
 
         $view = stubView(function (string $template, array $data) use (&$rendered): string {
             $rendered[$template] = $data;
+
             return '<div/>';
         });
 
@@ -214,6 +224,7 @@ describe('LayoutProcessor', function (): void {
             if ($template === 'layouts/root.html') {
                 $slotsPassed = $data['slots'] ?? null;
             }
+
             return '<div/>';
         });
 
@@ -232,6 +243,7 @@ describe('LayoutProcessor', function (): void {
             if ($template === 'layouts/root.html') {
                 $layoutTemplateCalled = true;
             }
+
             return '<div/>';
         });
 
@@ -284,6 +296,7 @@ describe('LayoutProcessor', function (): void {
             if ($template !== 'layouts/root.html') {
                 $renderOrder[] = $template;
             }
+
             return '<div/>';
         });
 
@@ -311,6 +324,7 @@ describe('LayoutProcessor', function (): void {
 
         $view = stubView(function (string $template, array $data) use (&$renderedData): string {
             $renderedData[$template] = $data;
+
             return '<div/>';
         });
 

--- a/packages/layout/tests/Unit/Middleware/LayoutMiddlewareTest.php
+++ b/packages/layout/tests/Unit/Middleware/LayoutMiddlewareTest.php
@@ -23,6 +23,7 @@ class LmFixtureController
     public function index(): string
     {
         $this->actionInvoked = true;
+
         return 'controller response';
     }
 }
@@ -68,7 +69,10 @@ function stubMatcher(?MatchedRoute $matched): RouteMatcherInterface
     {
         public function __construct(private readonly ?MatchedRoute $stub) {}
 
-        public function match(string $method, string $path): ?MatchedRoute
+        public function match(
+            string $method,
+            string $path,
+        ): ?MatchedRoute
         {
             return $this->stub;
         }

--- a/packages/mail/tests/Unit/Exceptions/NoDriverExceptionTest.php
+++ b/packages/mail/tests/Unit/Exceptions/NoDriverExceptionTest.php
@@ -60,7 +60,9 @@ describe('NoDriverException', function (): void {
     it('includes context about resolving mail interfaces', function (): void {
         $exception = NoDriverException::noDriverInstalled();
 
-        expect($exception->getContext())->toBe('Attempted to resolve a mail interface but no implementation is bound.');
+        expect($exception->getContext())->toBe(
+            'Attempted to resolve a mail interface but no implementation is bound.'
+        );
     });
 
     it('extends MarkoException', function (): void {

--- a/packages/notification/tests/KnownDriversValidationTest.php
+++ b/packages/notification/tests/KnownDriversValidationTest.php
@@ -7,9 +7,12 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all notification drivers', function () use ($knownDriversPath, $skeletonComposerPath) {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all notification drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath) {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every notification driver follows marko slash prefix pattern', function () use ($knownDriversPath) {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);

--- a/packages/page-cache/tests/KnownDriversValidationTest.php
+++ b/packages/page-cache/tests/KnownDriversValidationTest.php
@@ -7,5 +7,11 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all page-cache drivers', fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath));
-test('every page-cache driver follows marko slash prefix pattern', fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath));
+test(
+    'skeleton suggest block contains all page-cache drivers',
+    fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath)
+);
+test(
+    'every page-cache driver follows marko slash prefix pattern',
+    fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath)
+);

--- a/packages/page-cache/tests/Unit/Exceptions/NoDriverExceptionTest.php
+++ b/packages/page-cache/tests/Unit/Exceptions/NoDriverExceptionTest.php
@@ -13,9 +13,12 @@ it('page-cache NoDriverException reads from known-drivers.php and includes docs 
         ->and($exception->getSuggestion())->toContain('https://marko.build/docs/packages/page-cache-file/');
 });
 
-it('page-cache NoDriverException exposes a noDriverInstalled() factory (renamed from noBinding for consistency)', function (): void {
-    $exception = NoDriverException::noDriverInstalled();
-
-    expect($exception)->toBeInstanceOf(NoDriverException::class)
-        ->and($exception)->toBeInstanceOf(PageCacheException::class);
-});
+it(
+    'page-cache NoDriverException exposes a noDriverInstalled() factory (renamed from noBinding for consistency)',
+    function (): void {
+        $exception = NoDriverException::noDriverInstalled();
+    
+        expect($exception)->toBeInstanceOf(NoDriverException::class)
+            ->and($exception)->toBeInstanceOf(PageCacheException::class);
+    }
+);

--- a/packages/pubsub-pgsql/src/Driver/PgSqlPublisher.php
+++ b/packages/pubsub-pgsql/src/Driver/PgSqlPublisher.php
@@ -16,7 +16,10 @@ readonly class PgSqlPublisher implements PublisherInterface
         private PubSubConfig $config,
     ) {}
 
-    public function publish(string $channel, Message $message): void
+    public function publish(
+        string $channel,
+        Message $message,
+    ): void
     {
         $prefixed = $this->config->prefix() . $channel;
         $this->connection->connection()->notify($prefixed, $message->payload);

--- a/packages/pubsub-pgsql/tests/Driver/PgSqlPublisherTest.php
+++ b/packages/pubsub-pgsql/tests/Driver/PgSqlPublisherTest.php
@@ -24,7 +24,10 @@ class PublisherStubPostgresConnection implements PostgresConnection
     /** @var array<int, array{channel: string, payload: string}> */
     public array $notifyCalls = [];
 
-    public function notify(string $channel, string $payload = ''): PostgresResult
+    public function notify(
+        string $channel,
+        string $payload = '',
+    ): PostgresResult
     {
         $this->notifyCalls[] = ['channel' => $channel, 'payload' => $payload];
 
@@ -51,7 +54,10 @@ class PublisherStubPostgresConnection implements PostgresConnection
         throw new RuntimeException('Not implemented in stub');
     }
 
-    public function execute(string $sql, array $params = []): PostgresResult
+    public function execute(
+        string $sql,
+        array $params = [],
+    ): PostgresResult
     {
         throw new RuntimeException('Not implemented in stub');
     }

--- a/packages/pubsub-pgsql/tests/Driver/PgSqlSubscriberTest.php
+++ b/packages/pubsub-pgsql/tests/Driver/PgSqlSubscriberTest.php
@@ -30,7 +30,10 @@ class MockPostgresListener implements PostgresListener, IteratorAggregate
     private string $channel;
 
     /** @param PostgresNotification[] $notifications */
-    public function __construct(string $channel, array $notifications = [])
+    public function __construct(
+        string $channel,
+        array $notifications = [],
+    )
     {
         $this->channel = $channel;
         $this->notifications = $notifications;
@@ -82,7 +85,10 @@ class SubscriberStubPostgresConnection implements PostgresConnection
         return $listener;
     }
 
-    public function notify(string $channel, string $payload = ''): PostgresResult
+    public function notify(
+        string $channel,
+        string $payload = '',
+    ): PostgresResult
     {
         throw new RuntimeException('Not implemented in stub');
     }
@@ -102,7 +108,10 @@ class SubscriberStubPostgresConnection implements PostgresConnection
         throw new RuntimeException('Not implemented in stub');
     }
 
-    public function execute(string $sql, array $params = []): PostgresResult
+    public function execute(
+        string $sql,
+        array $params = [],
+    ): PostgresResult
     {
         throw new RuntimeException('Not implemented in stub');
     }

--- a/packages/pubsub-pgsql/tests/Driver/PgSqlSubscriptionTest.php
+++ b/packages/pubsub-pgsql/tests/Driver/PgSqlSubscriptionTest.php
@@ -18,7 +18,10 @@ class SubscriptionMockPostgresListener implements PostgresListener, IteratorAggr
     private string $channel;
 
     /** @param PostgresNotification[] $notifications */
-    public function __construct(string $channel, array $notifications = [])
+    public function __construct(
+        string $channel,
+        array $notifications = [],
+    )
     {
         $this->channel = $channel;
         $this->notifications = $notifications;

--- a/packages/pubsub-pgsql/tests/PgSqlPubSubConnectionTest.php
+++ b/packages/pubsub-pgsql/tests/PgSqlPubSubConnectionTest.php
@@ -16,7 +16,10 @@ use Marko\PubSub\PgSql\PgSqlPubSubConnection;
  */
 class ConnectionStubPostgresConnection implements PostgresConnection
 {
-    public function notify(string $channel, string $payload = ''): PostgresResult
+    public function notify(
+        string $channel,
+        string $payload = '',
+    ): PostgresResult
     {
         throw new RuntimeException('Not implemented in stub');
     }
@@ -41,7 +44,10 @@ class ConnectionStubPostgresConnection implements PostgresConnection
         throw new RuntimeException('Not implemented in stub');
     }
 
-    public function execute(string $sql, array $params = []): PostgresResult
+    public function execute(
+        string $sql,
+        array $params = [],
+    ): PostgresResult
     {
         throw new RuntimeException('Not implemented in stub');
     }

--- a/packages/pubsub-redis/src/Driver/RedisPublisher.php
+++ b/packages/pubsub-redis/src/Driver/RedisPublisher.php
@@ -16,7 +16,10 @@ readonly class RedisPublisher implements PublisherInterface
         private PubSubConfig $config,
     ) {}
 
-    public function publish(string $channel, Message $message): void
+    public function publish(
+        string $channel,
+        Message $message,
+    ): void
     {
         $prefixed = $this->config->prefix() . $channel;
         $this->connection->client()->publish($prefixed, $message->payload);

--- a/packages/pubsub-redis/tests/Driver/RedisPublisherTest.php
+++ b/packages/pubsub-redis/tests/Driver/RedisPublisherTest.php
@@ -29,7 +29,10 @@ class PublisherTestStubRedisLink implements RedisLink
     /** @var array<int, array{command: string, parameters: array<int|float|string>}> */
     public array $calls = [];
 
-    public function execute(string $command, array $parameters): RedisResponse
+    public function execute(
+        string $command,
+        array $parameters,
+    ): RedisResponse
     {
         $this->calls[] = ['command' => $command, 'parameters' => $parameters];
 

--- a/packages/pubsub-redis/tests/Driver/RedisSubscriberTest.php
+++ b/packages/pubsub-redis/tests/Driver/RedisSubscriberTest.php
@@ -30,7 +30,10 @@ class SpyAmphpRedisSubscriber implements AmphpRedisSubscriberInterface
      * @param array<string, AmphpRedisSubscription> $channelSubscriptions
      * @param array<string, AmphpRedisSubscription> $patternSubscriptions
      */
-    public function __construct(array $channelSubscriptions = [], array $patternSubscriptions = [])
+    public function __construct(
+        array $channelSubscriptions = [],
+        array $patternSubscriptions = [],
+    )
     {
         $this->channelSubscriptions = $channelSubscriptions;
         $this->patternSubscriptions = $patternSubscriptions;

--- a/packages/pubsub-redis/tests/RedisPubSubConnectionTest.php
+++ b/packages/pubsub-redis/tests/RedisPubSubConnectionTest.php
@@ -27,7 +27,10 @@ class StubRedisLink implements RedisLink
     /** @var array<int, array{command: string, parameters: array<int|float|string>}> */
     public array $calls = [];
 
-    public function execute(string $command, array $parameters): RedisResponse
+    public function execute(
+        string $command,
+        array $parameters,
+    ): RedisResponse
     {
         $this->calls[] = ['command' => $command, 'parameters' => $parameters];
 

--- a/packages/pubsub/src/Exceptions/PubSubException.php
+++ b/packages/pubsub/src/Exceptions/PubSubException.php
@@ -8,7 +8,10 @@ use Marko\Core\Exceptions\MarkoException;
 
 class PubSubException extends MarkoException
 {
-    public static function connectionFailed(string $driver, string $reason): self
+    public static function connectionFailed(
+        string $driver,
+        string $reason,
+    ): self
     {
         return new self(
             message: "Failed to connect to pub/sub driver '$driver'.",
@@ -17,7 +20,10 @@ class PubSubException extends MarkoException
         );
     }
 
-    public static function subscriptionFailed(string $channel, string $reason): self
+    public static function subscriptionFailed(
+        string $channel,
+        string $reason,
+    ): self
     {
         return new self(
             message: "Failed to subscribe to channel '$channel'.",
@@ -26,7 +32,10 @@ class PubSubException extends MarkoException
         );
     }
 
-    public static function publishFailed(string $channel, string $reason): self
+    public static function publishFailed(
+        string $channel,
+        string $reason,
+    ): self
     {
         return new self(
             message: "Failed to publish to channel '$channel'.",

--- a/packages/pubsub/src/PublisherInterface.php
+++ b/packages/pubsub/src/PublisherInterface.php
@@ -9,5 +9,8 @@ interface PublisherInterface
     /**
      * Publish a message to a channel.
      */
-    public function publish(string $channel, Message $message): void;
+    public function publish(
+        string $channel,
+        Message $message,
+    ): void;
 }

--- a/packages/pubsub/tests/KnownDriversValidationTest.php
+++ b/packages/pubsub/tests/KnownDriversValidationTest.php
@@ -7,5 +7,11 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all pubsub drivers', fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath));
-test('every pubsub driver follows marko slash prefix pattern', fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath));
+test(
+    'skeleton suggest block contains all pubsub drivers',
+    fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath)
+);
+test(
+    'every pubsub driver follows marko slash prefix pattern',
+    fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath)
+);

--- a/packages/pubsub/tests/MessageTest.php
+++ b/packages/pubsub/tests/MessageTest.php
@@ -5,23 +5,26 @@ declare(strict_types=1);
 use Marko\PubSub\Message;
 
 describe('Message', function (): void {
-    it('creates readonly Message value object with channel, payload, and optional pattern properties', function (): void {
-        $reflection = new ReflectionClass(Message::class);
-
-        expect($reflection->isReadOnly())->toBeTrue();
-
-        $channelProp = $reflection->getProperty('channel');
-        $payloadProp = $reflection->getProperty('payload');
-        $patternProp = $reflection->getProperty('pattern');
-
-        expect($channelProp->isPublic())->toBeTrue()
-            ->and($channelProp->getType()?->getName())->toBe('string')
-            ->and($payloadProp->isPublic())->toBeTrue()
-            ->and($payloadProp->getType()?->getName())->toBe('string')
-            ->and($patternProp->isPublic())->toBeTrue()
-            ->and($patternProp->getType()?->allowsNull())->toBeTrue()
-            ->and($patternProp->getType()?->getName())->toBe('string');
-    });
+    it(
+        'creates readonly Message value object with channel, payload, and optional pattern properties',
+        function (): void {
+            $reflection = new ReflectionClass(Message::class);
+    
+            expect($reflection->isReadOnly())->toBeTrue();
+    
+            $channelProp = $reflection->getProperty('channel');
+            $payloadProp = $reflection->getProperty('payload');
+            $patternProp = $reflection->getProperty('pattern');
+    
+            expect($channelProp->isPublic())->toBeTrue()
+                ->and($channelProp->getType()?->getName())->toBe('string')
+                ->and($payloadProp->isPublic())->toBeTrue()
+                ->and($payloadProp->getType()?->getName())->toBe('string')
+                ->and($patternProp->isPublic())->toBeTrue()
+                ->and($patternProp->getType()?->allowsNull())->toBeTrue()
+                ->and($patternProp->getType()?->getName())->toBe('string');
+        }
+    );
 
     it('creates Message with all properties accessible', function (): void {
         $message = new Message(

--- a/packages/pubsub/tests/SubscriberInterfaceTest.php
+++ b/packages/pubsub/tests/SubscriberInterfaceTest.php
@@ -6,41 +6,47 @@ use Marko\PubSub\SubscriberInterface;
 use Marko\PubSub\Subscription;
 
 describe('SubscriberInterface', function (): void {
-    it('defines SubscriberInterface with subscribe method accepting variadic channels returning Subscription', function (): void {
-        $reflection = new ReflectionClass(SubscriberInterface::class);
+    it(
+        'defines SubscriberInterface with subscribe method accepting variadic channels returning Subscription',
+        function (): void {
+            $reflection = new ReflectionClass(SubscriberInterface::class);
+    
+            expect($reflection->isInterface())->toBeTrue()
+                ->and($reflection->hasMethod('subscribe'))->toBeTrue();
+    
+            $method = $reflection->getMethod('subscribe');
+    
+            expect($method->isPublic())->toBeTrue()
+                ->and($method->getReturnType()?->getName())->toBe(Subscription::class)
+                ->and($method->getParameters())->toHaveCount(1);
+    
+            $channelsParam = $method->getParameters()[0];
+    
+            expect($channelsParam->getName())->toBe('channels')
+                ->and($channelsParam->getType()?->getName())->toBe('string')
+                ->and($channelsParam->isVariadic())->toBeTrue();
+        }
+    );
 
-        expect($reflection->isInterface())->toBeTrue()
-            ->and($reflection->hasMethod('subscribe'))->toBeTrue();
-
-        $method = $reflection->getMethod('subscribe');
-
-        expect($method->isPublic())->toBeTrue()
-            ->and($method->getReturnType()?->getName())->toBe(Subscription::class)
-            ->and($method->getParameters())->toHaveCount(1);
-
-        $channelsParam = $method->getParameters()[0];
-
-        expect($channelsParam->getName())->toBe('channels')
-            ->and($channelsParam->getType()?->getName())->toBe('string')
-            ->and($channelsParam->isVariadic())->toBeTrue();
-    });
-
-    it('defines SubscriberInterface with psubscribe method accepting variadic patterns returning Subscription', function (): void {
-        $reflection = new ReflectionClass(SubscriberInterface::class);
-
-        expect($reflection->isInterface())->toBeTrue()
-            ->and($reflection->hasMethod('psubscribe'))->toBeTrue();
-
-        $method = $reflection->getMethod('psubscribe');
-
-        expect($method->isPublic())->toBeTrue()
-            ->and($method->getReturnType()?->getName())->toBe(Subscription::class)
-            ->and($method->getParameters())->toHaveCount(1);
-
-        $patternsParam = $method->getParameters()[0];
-
-        expect($patternsParam->getName())->toBe('patterns')
-            ->and($patternsParam->getType()?->getName())->toBe('string')
-            ->and($patternsParam->isVariadic())->toBeTrue();
-    });
+    it(
+        'defines SubscriberInterface with psubscribe method accepting variadic patterns returning Subscription',
+        function (): void {
+            $reflection = new ReflectionClass(SubscriberInterface::class);
+    
+            expect($reflection->isInterface())->toBeTrue()
+                ->and($reflection->hasMethod('psubscribe'))->toBeTrue();
+    
+            $method = $reflection->getMethod('psubscribe');
+    
+            expect($method->isPublic())->toBeTrue()
+                ->and($method->getReturnType()?->getName())->toBe(Subscription::class)
+                ->and($method->getParameters())->toHaveCount(1);
+    
+            $patternsParam = $method->getParameters()[0];
+    
+            expect($patternsParam->getName())->toBe('patterns')
+                ->and($patternsParam->getType()?->getName())->toBe('string')
+                ->and($patternsParam->isVariadic())->toBeTrue();
+        }
+    );
 });

--- a/packages/queue/tests/KnownDriversValidationTest.php
+++ b/packages/queue/tests/KnownDriversValidationTest.php
@@ -19,12 +19,21 @@ test('it ships a known-drivers.php file listing all three queue drivers', functi
         ->and($drivers)->toHaveCount(3);
 });
 
-test('it lists marko/queue-sync first as the recommended development default', function () use ($knownDriversPath): void {
-    $drivers = require $knownDriversPath;
+test(
+    'it lists marko/queue-sync first as the recommended development default',
+    function () use ($knownDriversPath): void {
+        $drivers = require $knownDriversPath;
+    
+        expect(array_key_first($drivers))->toBe('marko/queue-sync');
+    }
+);
 
-    expect(array_key_first($drivers))->toBe('marko/queue-sync');
-});
+test(
+    'skeleton suggest block contains all queue drivers',
+    fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath)
+);
 
-test('skeleton suggest block contains all queue drivers', fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath));
-
-test('every queue driver follows marko slash prefix pattern', fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath));
+test(
+    'every queue driver follows marko slash prefix pattern',
+    fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath)
+);

--- a/packages/routing/src/RouteMatcherInterface.php
+++ b/packages/routing/src/RouteMatcherInterface.php
@@ -6,5 +6,8 @@ namespace Marko\Routing;
 
 interface RouteMatcherInterface
 {
-    public function match(string $method, string $path): ?MatchedRoute;
+    public function match(
+        string $method,
+        string $path,
+    ): ?MatchedRoute;
 }

--- a/packages/session/tests/KnownDriversValidationTest.php
+++ b/packages/session/tests/KnownDriversValidationTest.php
@@ -7,9 +7,12 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all session drivers', function () use ($knownDriversPath, $skeletonComposerPath) {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all session drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath) {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every session driver follows marko slash prefix pattern', function () use ($knownDriversPath) {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);

--- a/packages/session/tests/Unit/Middleware/SessionMiddlewareTest.php
+++ b/packages/session/tests/Unit/Middleware/SessionMiddlewareTest.php
@@ -141,12 +141,18 @@ function createFakeSession(
             }
         }
 
-        public function get(string $key, mixed $default = null): mixed
+        public function get(
+            string $key,
+            mixed $default = null,
+        ): mixed
         {
             return $default;
         }
 
-        public function set(string $key, mixed $value): void {}
+        public function set(
+            string $key,
+            mixed $value,
+        ): void {}
 
         public function has(string $key): bool
         {

--- a/packages/skeleton/tests/KnownDriversSuggestParityTest.php
+++ b/packages/skeleton/tests/KnownDriversSuggestParityTest.php
@@ -40,7 +40,9 @@ test('it includes marko/database-readwrite as an optional add-on', function (): 
     )['suggest'] ?? [];
 
     expect($skeletonSuggest)->toHaveKey('marko/database-readwrite')
-        ->and($skeletonSuggest['marko/database-readwrite'])->toBe('Read/write connection splitting decorator (optional — works alongside a base driver)');
+        ->and($skeletonSuggest['marko/database-readwrite'])->toBe(
+            'Read/write connection splitting decorator (optional — works alongside a base driver)'
+        );
 });
 
 test('it includes marko/page-cache-entity as an optional add-on', function (): void {
@@ -50,7 +52,9 @@ test('it includes marko/page-cache-entity as an optional add-on', function (): v
     )['suggest'] ?? [];
 
     expect($skeletonSuggest)->toHaveKey('marko/page-cache-entity')
-        ->and($skeletonSuggest['marko/page-cache-entity'])->toBe('Auto-purges page-cache tags on entity save/delete (optional add-on)');
+        ->and($skeletonSuggest['marko/page-cache-entity'])->toBe(
+            'Auto-purges page-cache tags on entity save/delete (optional add-on)'
+        );
 });
 
 test('it does not move any view, database, cache, etc. drivers into require or require-dev', function (): void {

--- a/packages/sse/src/SseStream.php
+++ b/packages/sse/src/SseStream.php
@@ -45,6 +45,7 @@ readonly class SseStream implements IteratorAggregate
     {
         if ($this->subscription !== null) {
             yield from $this->iterateSubscription();
+
             return;
         }
 
@@ -60,7 +61,7 @@ readonly class SseStream implements IteratorAggregate
         $startTime = time();
 
         foreach ($this->subscription as $message) {
-            if ((time() - $startTime) >= $this->timeout) {
+            if (time() - $startTime >= $this->timeout) {
                 return;
             }
 
@@ -96,7 +97,7 @@ readonly class SseStream implements IteratorAggregate
                 $lastHeartbeat = time();
             }
 
-            if ((time() - $startTime) >= $this->timeout) {
+            if (time() - $startTime >= $this->timeout) {
                 return;
             }
 

--- a/packages/sse/tests/SseStreamTest.php
+++ b/packages/sse/tests/SseStreamTest.php
@@ -141,6 +141,7 @@ describe('SseStream', function (): void {
         $stream = new SseStream(
             dataProvider: function () use (&$callCount): array {
                 $callCount++;
+
                 return [new SseEvent(data: "event-$callCount")];
             },
             timeout: 0,
@@ -157,6 +158,7 @@ describe('SseStream', function (): void {
         $stream = new SseStream(
             dataProvider: function () use (&$callCount): array {
                 $callCount++;
+
                 return $callCount <= 2
                     ? [new SseEvent(data: "event-$callCount")]
                     : [];

--- a/packages/testing/src/KnownDrivers/KnownDriversValidator.php
+++ b/packages/testing/src/KnownDrivers/KnownDriversValidator.php
@@ -28,8 +28,7 @@ class KnownDriversValidator
     }
 
     /**
-     * @throws InvalidArgumentException
-     * @throws AssertionFailedError
+     * @throws InvalidArgumentException|AssertionFailedError
      */
     public static function assertDocsUrlsResolveToValidPattern(string $knownDriversPath): void
     {
@@ -45,9 +44,7 @@ class KnownDriversValidator
     }
 
     /**
-     * @throws InvalidArgumentException
-     * @throws SkippedWithMessageException
-     * @throws AssertionFailedError
+     * @throws InvalidArgumentException|SkippedWithMessageException|AssertionFailedError
      */
     public static function assertSkeletonSuggestContainsAll(
         string $knownDriversPath,

--- a/packages/testing/tests/Unit/Exceptions/AssertionFailedExceptionTest.php
+++ b/packages/testing/tests/Unit/Exceptions/AssertionFailedExceptionTest.php
@@ -5,18 +5,21 @@ declare(strict_types=1);
 use Marko\Core\Exceptions\MarkoException;
 use Marko\Testing\Exceptions\AssertionFailedException;
 
-it('creates AssertionFailedException extending MarkoException with message, context, and suggestion', function (): void {
-    $exception = new AssertionFailedException(
-        message: 'Test assertion failed',
-        context: 'some context',
-        suggestion: 'some suggestion',
-    );
-
-    expect($exception)->toBeInstanceOf(MarkoException::class)
-        ->and($exception->getMessage())->toBe('Test assertion failed')
-        ->and($exception->getContext())->toBe('some context')
-        ->and($exception->getSuggestion())->toBe('some suggestion');
-});
+it(
+    'creates AssertionFailedException extending MarkoException with message, context, and suggestion',
+    function (): void {
+        $exception = new AssertionFailedException(
+            message: 'Test assertion failed',
+            context: 'some context',
+            suggestion: 'some suggestion',
+        );
+    
+        expect($exception)->toBeInstanceOf(MarkoException::class)
+            ->and($exception->getMessage())->toBe('Test assertion failed')
+            ->and($exception->getContext())->toBe('some context')
+            ->and($exception->getSuggestion())->toBe('some suggestion');
+    }
+);
 
 it('creates AssertionFailedException with static factory methods for common assertion failures', function (): void {
     expect(AssertionFailedException::expectedDispatched('MyEvent'))

--- a/packages/translation/tests/Exceptions/NoDriverExceptionTest.php
+++ b/packages/translation/tests/Exceptions/NoDriverExceptionTest.php
@@ -66,7 +66,9 @@ describe('NoDriverException', function (): void {
     it('includes context about resolving translation interfaces', function (): void {
         $exception = NoDriverException::noDriverInstalled();
 
-        expect($exception->getContext())->toContain('Attempted to resolve a translation interface but no implementation is bound.');
+        expect($exception->getContext())->toContain(
+            'Attempted to resolve a translation interface but no implementation is bound.'
+        );
     });
 
     it('extends TranslationException', function (): void {

--- a/packages/translation/tests/KnownDriversValidationTest.php
+++ b/packages/translation/tests/KnownDriversValidationTest.php
@@ -7,5 +7,11 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all translation drivers', fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath));
-test('every translation driver follows marko slash prefix pattern', fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath));
+test(
+    'skeleton suggest block contains all translation drivers',
+    fn () => KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath)
+);
+test(
+    'every translation driver follows marko slash prefix pattern',
+    fn () => KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath)
+);

--- a/packages/view-latte/src/Extensions/SlotExtension.php
+++ b/packages/view-latte/src/Extensions/SlotExtension.php
@@ -30,6 +30,7 @@ class SlotNode extends StatementNode
         $node = $tag->node = new static();
         $node->name = $tag->parser->stream->consume()->text;
         yield;
+
         return $node;
     }
 

--- a/packages/view-latte/tests/LatteViewConfigTest.php
+++ b/packages/view-latte/tests/LatteViewConfigTest.php
@@ -24,5 +24,5 @@ it(
         $latteViewConfig = new LatteViewConfig($config);
 
         $latteViewConfig->strictTypes();
-    }
+    },
 )->throws(ConfigNotFoundException::class);

--- a/packages/view-twig/src/ModuleLoader.php
+++ b/packages/view-twig/src/ModuleLoader.php
@@ -23,8 +23,7 @@ class ModuleLoader implements LoaderInterface
     ) {}
 
     /**
-     * @throws LoaderError When $name does not use module namespace format or file cannot be read
-     * @throws TemplateNotFoundException When template cannot be found
+     * @throws LoaderError|TemplateNotFoundException
      */
     public function getSourceContext(string $name): Source
     {
@@ -46,8 +45,7 @@ class ModuleLoader implements LoaderInterface
     }
 
     /**
-     * @throws LoaderError When $name does not use module namespace format
-     * @throws TemplateNotFoundException When template cannot be found
+     * @throws LoaderError|TemplateNotFoundException
      */
     public function getCacheKey(string $name): string
     {
@@ -59,7 +57,10 @@ class ModuleLoader implements LoaderInterface
     /**
      * @throws TemplateNotFoundException When template cannot be found
      */
-    public function isFresh(string $name, int $time): bool
+    public function isFresh(
+        string $name,
+        int $time,
+    ): bool
     {
         $path = $this->resolvePath($name);
 

--- a/packages/view-twig/src/TwigView.php
+++ b/packages/view-twig/src/TwigView.php
@@ -8,6 +8,9 @@ use Marko\Routing\Http\Response;
 use Marko\View\TemplateResolverInterface;
 use Marko\View\ViewInterface;
 use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 
 class TwigView implements ViewInterface
 {
@@ -21,9 +24,7 @@ class TwigView implements ViewInterface
 
     /**
      * @param array<string, mixed> $data
-     * @throws \Twig\Error\LoaderError
-     * @throws \Twig\Error\RuntimeError
-     * @throws \Twig\Error\SyntaxError
+     * @throws LoaderError|RuntimeError|SyntaxError
      */
     public function render(
         string $template,
@@ -36,9 +37,7 @@ class TwigView implements ViewInterface
 
     /**
      * @param array<string, mixed> $data
-     * @throws \Twig\Error\LoaderError
-     * @throws \Twig\Error\RuntimeError
-     * @throws \Twig\Error\SyntaxError
+     * @throws LoaderError|RuntimeError|SyntaxError
      */
     public function renderToString(
         string $template,

--- a/packages/view-twig/tests/TwigEngineFactoryTest.php
+++ b/packages/view-twig/tests/TwigEngineFactoryTest.php
@@ -6,6 +6,7 @@ use Marko\Testing\Fake\FakeConfigRepository;
 use Marko\View\Twig\TwigEngineFactory;
 use Marko\View\Twig\TwigViewConfig;
 use Twig\Environment;
+use Twig\Extension\EscaperExtension;
 
 function makeTwigViewConfig(array $overrides = []): TwigViewConfig
 {
@@ -55,7 +56,7 @@ describe('TwigEngineFactory', function (): void {
         $factory = new TwigEngineFactory(makeTwigViewConfig(['view.autoescape' => 'js']));
         $env = $factory->create();
 
-        $escaper = $env->getExtension(\Twig\Extension\EscaperExtension::class);
+        $escaper = $env->getExtension(EscaperExtension::class);
         expect($escaper->getDefaultStrategy('template.html.twig'))->toBe('js');
     });
 

--- a/packages/view/tests/Exceptions/NoDriverExceptionTest.php
+++ b/packages/view/tests/Exceptions/NoDriverExceptionTest.php
@@ -77,7 +77,9 @@ describe('NoDriverException', function (): void {
     it('includes context about resolving ViewInterface', function (): void {
         $exception = NoDriverException::noDriverInstalled();
 
-        expect($exception->getContext())->toContain('Attempted to resolve ViewInterface but no implementation is bound.');
+        expect($exception->getContext())->toContain(
+            'Attempted to resolve ViewInterface but no implementation is bound.'
+        );
     });
 
     it('extends ViewException', function (): void {

--- a/packages/view/tests/Feature/CrossEngineTemplateParityTest.php
+++ b/packages/view/tests/Feature/CrossEngineTemplateParityTest.php
@@ -24,7 +24,9 @@ test('it asserts every template provider has a sibling for every registered engi
     }
 
     if (!is_dir($packagesDir) || basename($packagesDir) !== 'packages') {
-        $this->markTestSkipped('Not running inside the monorepo packages directory — skipping cross-engine parity check.');
+        $this->markTestSkipped(
+            'Not running inside the monorepo packages directory — skipping cross-engine parity check.'
+        );
     }
 
     $engines = require $enginesPath;
@@ -60,7 +62,10 @@ test('it asserts every template provider has a sibling for every registered engi
     foreach ($providers as $parent => $foundEngines) {
         foreach ($engines as $engineName => $engineMeta) {
             $description = $engineMeta['description'] ?? $engineName;
-            $message = "Parent module '$parent' has template providers for [" . implode(', ', array_keys($foundEngines))
+            $message = "Parent module '$parent' has template providers for [" . implode(
+                ', ',
+                array_keys($foundEngines)
+            )
                 . "] but is missing a provider for engine '$engineName' ($description). "
                 . "Expected a package like 'marko/" . basename($parent) . "-$engineName' declaring "
                 . "extra.marko.templates_for: '$parent'.";
@@ -165,17 +170,20 @@ test('it ignores packages whose names do not follow the marko/{parent}-{engine} 
         ->and(extractEngineSuffix('marko/admin', 'marko/admin-panel'))->toBeNull();
 });
 
-test('it ignores packages whose extracted suffix is not in known-engines (e.g., admin-panel-twig-extra produces suffix twig-extra and is skipped if not registered)', function () {
-    $enginesPath = dirname(__DIR__, 2) . '/known-engines.php';
-
-    if (!file_exists($enginesPath)) {
-        $this->markTestSkipped('known-engines.php not found — marko/view not installed standalone?');
+test(
+    'it ignores packages whose extracted suffix is not in known-engines (e.g., admin-panel-twig-extra produces suffix twig-extra and is skipped if not registered)',
+    function () {
+        $enginesPath = dirname(__DIR__, 2) . '/known-engines.php';
+    
+        if (!file_exists($enginesPath)) {
+            $this->markTestSkipped('known-engines.php not found — marko/view not installed standalone?');
+        }
+    
+        $engines = require $enginesPath;
+    
+        $suffix = extractEngineSuffix('marko/admin-panel-twig-extra', 'marko/admin-panel');
+    
+        expect($suffix)->toBe('twig-extra')
+            ->and(isset($engines[$suffix]))->toBeFalse();
     }
-
-    $engines = require $enginesPath;
-
-    $suffix = extractEngineSuffix('marko/admin-panel-twig-extra', 'marko/admin-panel');
-
-    expect($suffix)->toBe('twig-extra')
-        ->and(isset($engines[$suffix]))->toBeFalse();
-});
+);

--- a/packages/view/tests/KnownDriversValidationTest.php
+++ b/packages/view/tests/KnownDriversValidationTest.php
@@ -7,9 +7,12 @@ use Marko\Testing\KnownDrivers\KnownDriversValidator;
 $knownDriversPath = __DIR__ . '/../known-drivers.php';
 $skeletonComposerPath = __DIR__ . '/../../skeleton/composer.json';
 
-test('skeleton suggest block contains all view drivers', function () use ($knownDriversPath, $skeletonComposerPath): void {
-    KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
-});
+test(
+    'skeleton suggest block contains all view drivers',
+    function () use ($knownDriversPath, $skeletonComposerPath): void {
+        KnownDriversValidator::assertSkeletonSuggestContainsAll($knownDriversPath, $skeletonComposerPath);
+    }
+);
 
 test('every view driver follows marko slash prefix pattern', function () use ($knownDriversPath): void {
     KnownDriversValidator::assertDocsUrlsResolveToValidPattern($knownDriversPath);

--- a/packages/view/tests/PackageStructureTest.php
+++ b/packages/view/tests/PackageStructureTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 it('composer.json exists with correct namespace', function (): void {
     $composerPath = dirname(__DIR__) . '/composer.json';
 

--- a/packages/webhook/tests/Jobs/DispatchWebhookJobRetryTest.php
+++ b/packages/webhook/tests/Jobs/DispatchWebhookJobRetryTest.php
@@ -27,32 +27,51 @@ describe('DispatchWebhookJob retry', function (): void {
 
         $httpClient = new class () implements HttpClientInterface
         {
-            public function request(string $method, string $url, array $options = []): HttpResponse
+            public function request(
+                string $method,
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function get(string $url, array $options = []): HttpResponse
+            public function get(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function post(string $url, array $options = []): HttpResponse
+            public function post(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function put(string $url, array $options = []): HttpResponse
+            public function put(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function patch(string $url, array $options = []): HttpResponse
+            public function patch(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function delete(string $url, array $options = []): HttpResponse
+            public function delete(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
@@ -108,32 +127,51 @@ describe('DispatchWebhookJob retry', function (): void {
 
         $httpClient = new class () implements HttpClientInterface
         {
-            public function request(string $method, string $url, array $options = []): HttpResponse
+            public function request(
+                string $method,
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function get(string $url, array $options = []): HttpResponse
+            public function get(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function post(string $url, array $options = []): HttpResponse
+            public function post(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function put(string $url, array $options = []): HttpResponse
+            public function put(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function patch(string $url, array $options = []): HttpResponse
+            public function patch(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }
 
-            public function delete(string $url, array $options = []): HttpResponse
+            public function delete(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 throw new RuntimeException('Connection timed out');
             }

--- a/packages/webhook/tests/Jobs/DispatchWebhookJobTest.php
+++ b/packages/webhook/tests/Jobs/DispatchWebhookJobTest.php
@@ -29,34 +29,53 @@ describe('DispatchWebhookJob', function (): void {
         {
             public bool $postCalled = false;
 
-            public function request(string $method, string $url, array $options = []): HttpResponse
+            public function request(
+                string $method,
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 return new HttpResponse(200, 'OK');
             }
 
-            public function get(string $url, array $options = []): HttpResponse
+            public function get(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 return new HttpResponse(200, 'OK');
             }
 
-            public function post(string $url, array $options = []): HttpResponse
+            public function post(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 $this->postCalled = true;
 
                 return new HttpResponse(200, 'OK');
             }
 
-            public function put(string $url, array $options = []): HttpResponse
+            public function put(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 return new HttpResponse(200, 'OK');
             }
 
-            public function patch(string $url, array $options = []): HttpResponse
+            public function patch(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 return new HttpResponse(200, 'OK');
             }
 
-            public function delete(string $url, array $options = []): HttpResponse
+            public function delete(
+                string $url,
+                array $options = [],
+            ): HttpResponse
             {
                 return new HttpResponse(200, 'OK');
             }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,8 +3,6 @@
     <description>Marko Framework Coding Standard</description>
 
     <file>packages</file>
-    <file>demo/app</file>
-    <file>demo/modules</file>
 
     <!-- Exclude vendor directories -->
     <exclude-pattern>*/vendor/*</exclude-pattern>

--- a/tests/SplitWorkflowTest.php
+++ b/tests/SplitWorkflowTest.php
@@ -35,9 +35,9 @@ it('pushes branch updates to split repos on branch push', function () use ($work
     expect($workflowContent)->toContain('refs/heads/${BRANCH}');
 });
 
-it('uses SPLIT_TOKEN secret for authentication', function () use ($workflowContent): void {
-    expect($workflowContent)->toContain('secrets.SPLIT_TOKEN')
-        ->toContain('SPLIT_TOKEN');
+it('uses MARKO_BUILD_PAT secret for authentication', function () use ($workflowContent): void {
+    expect($workflowContent)->toContain('secrets.MARKO_BUILD_PAT')
+        ->toContain('MARKO_BUILD_PAT');
 });
 
 it('configures the target organization as an environment variable for easy changes', function () use ($workflowContent): void {


### PR DESCRIPTION
## Summary

Pre-flight hardening for the 0.7.0 release. Three test failures and a broken lint config were uncovered while auditing changes since 0.6.1. All fixes are mechanical and non-behavioral.

### Fixes

- **`phpcs.xml`** — removed stale `demo/app` and `demo/modules` file entries (those directories no longer exist; lint was erroring out before scanning anything).
- **`tests/SplitWorkflowTest.php`** — updated `SPLIT_TOKEN` → `MARKO_BUILD_PAT` to match #84.
- **`packages/database-mysql/tests/Connection/`** — hoisted `createTestDatabaseConfig()` and `connectAndCapturePdoOptions()` into a dedicated `Helpers.php` autoloaded via `composer.json` `autoload-dev.files`. Previously defined inline in `MySqlConnectionTest.php`, so they vanished whenever pest ran the factory test in isolation.
- **`composer.json`** — refreshed lock to sync admin-panel-latte/twig path repos and pick up develop-tracking marko/* updates. No external library version bumps (only `predis 3.x` is available and would need its own evaluation).
- **`CHANGELOG.md`** — removed stale `[Unreleased]` block (page-cache entry had already shipped in 0.6.0); `release.sh` regenerates from gh PR data at tag time.
- **`phpcbf` auto-fix** — once lint was unblocked, ~360 pre-existing violations across 114 files surfaced (trailing commas, multiline method signatures, blank lines). All purely cosmetic, all tests still pass.

### Verification

- `composer test` — 5616 passed, 0 failed (3 consecutive runs)
- `vendor/bin/phpcs` — clean

## Test plan

- [x] `composer test` green
- [x] `vendor/bin/phpcs` green
- [x] Manual review of phpcbf-touched src files (Application.php, EntityHydrator.php, MySqlQueryBuilder.php) — only whitespace/formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)