### PR TITLE
feat: add marko/claude-plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace.json",
+  "name": "marko",
+  "description": "Official Marko framework Claude Code plugins.",
+  "owner": {
+    "name": "Mark Shust",
+    "email": "mark@shust.com"
+  },
+  "plugins": [
+    {
+      "name": "marko-skills",
+      "source": "./packages/claude-plugins/plugins/marko-skills",
+      "description": "Marko-specific skills (create-module, create-plugin) for Claude Code.",
+      "author": {
+        "name": "Mark Shust",
+        "email": "mark@shust.com"
+      },
+      "category": "development"
+    },
+    {
+      "name": "marko-lsp",
+      "source": "./packages/claude-plugins/plugins/marko-lsp",
+      "description": "Marko LSP bundle (PHP intelephense) for Claude Code.",
+      "author": {
+        "name": "Mark Shust",
+        "email": "mark@shust.com"
+      },
+      "category": "development"
+    },
+    {
+      "name": "marko-mcp",
+      "source": "./packages/claude-plugins/plugins/marko-mcp",
+      "description": "Marko MCP server (codeindexer, docs-fts) for Claude Code.",
+      "author": {
+        "name": "Mark Shust",
+        "email": "mark@shust.com"
+      },
+      "category": "development"
+    }
+  ]
+}

--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -230,6 +230,13 @@ When your code depends on `marko/log` (interface) instead of `marko/log-file` (d
 | `marko/validation` | Feature | Input validation |
 | `marko/framework` | Metapackage | Bundles common packages |
 
+### AI Development Tooling
+
+| Package | Type | Description |
+|---------|------|-------------|
+| `marko/codeindexer` | Tool | Static analysis indexer — attributes, configs, templates, translations into a cached symbol table |
+| `marko/claude-plugins` | Tool | Claude Code marketplace and plugins (marko-skills, marko-lsp, marko-mcp) for AI-assisted development |
+
 ---
 
 ## Naming Conventions

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,6 +60,7 @@ body:
         - cache-array
         - cache-file
         - cache-redis
+        - claude-plugins
         - cli
         - codeindexer
         - config

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -48,6 +48,7 @@ body:
         - cache-array
         - cache-file
         - cache-redis
+        - claude-plugins
         - cli
         - codeindexer
         - config

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,10 @@
         },
         {
             "type": "path",
+            "url": "packages/claude-plugins"
+        },
+        {
+            "type": "path",
             "url": "packages/cli"
         },
         {
@@ -366,6 +370,7 @@
         "marko/cache-array": "self.version",
         "marko/cache-file": "self.version",
         "marko/cache-redis": "self.version",
+        "marko/claude-plugins": "self.version",
         "marko/cli": "self.version",
         "marko/codeindexer": "self.version",
         "marko/config": "self.version",
@@ -485,6 +490,7 @@
             "Marko\\Cache\\File\\Tests\\": "packages/cache-file/tests/",
             "Marko\\Cache\\Memory\\Tests\\": "packages/cache-array/tests/",
             "Marko\\Cache\\Redis\\Tests\\": "packages/cache-redis/tests/",
+            "Marko\\ClaudePlugins\\Tests\\": "packages/claude-plugins/tests/",
             "Marko\\Cli\\Tests\\": "packages/cli/tests/",
             "Marko\\CodeIndexer\\Tests\\": "packages/codeindexer/tests/",
             "Marko\\Config\\Tests\\": "packages/config/tests/",

--- a/packages/claude-plugins/.gitattributes
+++ b/packages/claude-plugins/.gitattributes
@@ -1,0 +1,5 @@
+/tests              export-ignore
+/.github             export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/phpunit.xml.dist   export-ignore

--- a/packages/claude-plugins/LICENSE
+++ b/packages/claude-plugins/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Devtomic LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/claude-plugins/README.md
+++ b/packages/claude-plugins/README.md
@@ -1,0 +1,26 @@
+# marko/claude-plugins
+
+A Claude Code plugin marketplace shipping three plugins (`marko-skills`, `marko-lsp`, `marko-mcp`) that provide AI-assisted Marko development. This package is not a Marko runtime module --- it is a content and asset container for Claude Code; it ships no PHP classes and is not loaded by the Marko module system.
+
+## Installation
+
+Users typically do not install this package directly. Running `marko devai:install --agents=claude-code` writes the marketplace registration into the project's `.claude/settings.json` and Claude Code prompts to install on first trust.
+
+For manual installation inside Claude Code:
+
+```shell
+/plugin marketplace add marko-php/marko
+/plugin install marko-skills@marko marko-lsp@marko marko-mcp@marko
+```
+
+## What's Included
+
+| Plugin | Description |
+|---|---|
+| `marko-skills` | Scaffolding skills for generating modules, commands, services, and other Marko artefacts |
+| `marko-lsp` | Marko-aware language server providing completions, diagnostics, and hover docs in editors |
+| `marko-mcp` | Codebase introspection MCP server exposing module graph, routes, and config to AI agents |
+
+## Documentation
+
+Full setup, plugin reference, and configuration options: [marko/claude-plugins](https://marko.build/docs/ai-assisted-development/)

--- a/packages/claude-plugins/composer.json
+++ b/packages/claude-plugins/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "marko/claude-plugins",
+    "description": "Claude Code marketplace manifest and plugin assets (marko-skills, marko-lsp, marko-mcp) for AI-assisted Marko development",
+    "license": "MIT",
+    "require": {
+        "php": "^8.5"
+    },
+    "require-dev": {
+        "pestphp/pest": "^4.0",
+        "marko/testing": "self.version"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Marko\\ClaudePlugins\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    }
+}

--- a/packages/claude-plugins/plugins/marko-lsp/.claude-plugin/plugin.json
+++ b/packages/claude-plugins/plugins/marko-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "marko-lsp",
+  "description": "Marko LSP bundle (PHP intelephense) for Claude Code.",
+  "author": {
+    "name": "Marko Framework",
+    "email": "mark@shust.com"
+  },
+  "homepage": "https://marko.dev",
+  "repository": "https://github.com/marko-php/marko",
+  "license": "MIT",
+  "keywords": ["marko", "lsp", "php", "intelephense"]
+}

--- a/packages/claude-plugins/plugins/marko-lsp/.lsp.json
+++ b/packages/claude-plugins/plugins/marko-lsp/.lsp.json
@@ -1,0 +1,9 @@
+{
+  "marko-lsp": {
+    "command": "${CLAUDE_PLUGIN_ROOT}/bin/marko-lsp",
+    "args": [],
+    "extensionToLanguage": {
+      ".php": "php"
+    }
+  }
+}

--- a/packages/claude-plugins/plugins/marko-lsp/README.md
+++ b/packages/claude-plugins/plugins/marko-lsp/README.md
@@ -1,0 +1,50 @@
+# marko-lsp
+
+Marko-aware PHP language server for Claude Code. Wraps [intelephense](https://intelephense.com/) with Marko-tuned initialization options that make Claude Code understand Marko's module system, service providers, and routing conventions.
+
+## What marko-lsp adds beyond plain intelephense
+
+- **Live diagnostics via `textDocument/publishDiagnostics`**: as you open or edit a PHP file, marko-lsp pushes diagnostics to the client immediately — no poll or manual request needed. Unknown config keys (`config('not.real.key')`) and unknown translation keys are flagged in real time with `source: marko-lsp`.
+- Framework-aware completions: suggests correct namespaces and class names based on module structure
+- Navigation tied to Marko semantics: go-to-definition follows Preferences (interface → concrete) rather than raw PHP class hierarchy
+
+`marko devai:install` automatically installs the `intelephense` npm package (required by `php-lsp@claude-plugins-official`) if it is not already on `PATH`. Pass `--skip-lsp-deps` to opt out.
+
+## Coexistence with php-lsp@claude-plugins-official
+
+Claude Code loads all registered LSP servers simultaneously. If you have both `php-lsp@claude-plugins-official` (Anthropic's intelephense plugin) and `marko-lsp` installed, both run and both deliver diagnostics for every `.php` file.
+
+**Recommendation**: uninstall `php-lsp@claude-plugins-official` after installing marko-lsp. Since marko-lsp wraps the same intelephense binary with Marko-tuned init options, keeping both active produces duplicate diagnostics. This is a UX preference — both plugins work correctly together at a technical level.
+
+To uninstall the official PHP LSP plugin:
+
+```
+/plugin uninstall php-lsp@claude-plugins-official
+```
+
+## Installation
+
+Install via the Marko marketplace:
+
+```
+/plugin install marko-lsp@marko
+```
+
+If the Marko marketplace is not yet registered, add it first:
+
+```
+/plugin marketplace add marko-php/marko
+```
+
+## Verify installation
+
+```
+claude plugin list
+```
+
+You should see `marko-lsp` in the output with status `enabled`.
+
+## Requirements
+
+- `marko/devai` installed in your project (`composer require marko/devai`)
+- The `vendor/bin/marko` binary must be present, or `marko` must be on your `PATH`

--- a/packages/claude-plugins/plugins/marko-lsp/bin/marko-lsp
+++ b/packages/claude-plugins/plugins/marko-lsp/bin/marko-lsp
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+if [ -x "./vendor/bin/marko" ]; then
+    exec ./vendor/bin/marko lsp:serve "$@"
+elif command -v marko >/dev/null 2>&1; then
+    exec marko lsp:serve "$@"
+else
+    echo "marko-lsp: No marko binary found in vendor/bin/marko or on PATH." >&2
+    echo "marko-lsp: Run \`composer require marko/devai\` in this project." >&2
+    exit 1
+fi

--- a/packages/claude-plugins/plugins/marko-mcp/.claude-plugin/plugin.json
+++ b/packages/claude-plugins/plugins/marko-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "marko-mcp",
+  "description": "Marko MCP server (codeindexer, docs-fts) for Claude Code.",
+  "author": {
+    "name": "Marko Framework",
+    "email": "mark@shust.com"
+  },
+  "homepage": "https://marko.dev",
+  "repository": "https://github.com/marko-php/marko",
+  "license": "MIT",
+  "keywords": ["marko", "mcp", "php"]
+}

--- a/packages/claude-plugins/plugins/marko-mcp/.mcp.json
+++ b/packages/claude-plugins/plugins/marko-mcp/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "marko": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/marko-mcp",
+      "args": []
+    }
+  }
+}

--- a/packages/claude-plugins/plugins/marko-mcp/README.md
+++ b/packages/claude-plugins/plugins/marko-mcp/README.md
@@ -1,0 +1,36 @@
+# marko-mcp
+
+Registers the Marko MCP server with Claude Code so the `marko mcp:serve` command is available as a tool provider inside Claude Code sessions.
+
+## What this plugin registers
+
+A single MCP server (`marko-mcp`) that delegates to `marko mcp:serve`. The server is invoked via a POSIX shim at `bin/marko-mcp` that locates the `marko` binary — first checking `./vendor/bin/marko` (project-local Composer install), then falling back to a globally-installed `marko` on PATH.
+
+If no `marko` binary is found, the shim exits with a helpful error directing you to run `composer require marko/devai`.
+
+## Install
+
+Add the Marko marketplace once, then install the plugin:
+
+```
+/plugin marketplace add marko-php/marko
+/plugin install marko-mcp@marko
+```
+
+## Verify
+
+After installation, confirm the MCP server is registered:
+
+```
+claude mcp list
+```
+
+You should see `marko-mcp` in the list.
+
+## Requirements
+
+- `marko/devai` must be installed in the project (`composer require marko/devai`) or `marko` must be available globally on PATH.
+
+## Docs
+
+https://marko.dev

--- a/packages/claude-plugins/plugins/marko-mcp/bin/marko-mcp
+++ b/packages/claude-plugins/plugins/marko-mcp/bin/marko-mcp
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+if [ -x "./vendor/bin/marko" ]; then
+    exec ./vendor/bin/marko mcp:serve "$@"
+elif command -v marko >/dev/null 2>&1; then
+    exec marko mcp:serve "$@"
+else
+    echo "marko-mcp: No marko binary found in vendor/bin/marko or on PATH." >&2
+    echo "marko-mcp: Run \`composer require marko/devai\` in this project." >&2
+    exit 1
+fi

--- a/packages/claude-plugins/plugins/marko-skills/.claude-plugin/plugin.json
+++ b/packages/claude-plugins/plugins/marko-skills/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "marko-skills",
+  "description": "Marko-specific skills (create-module, create-plugin) for Claude Code.",
+  "author": {
+    "name": "Marko Framework",
+    "email": "mark@shust.com"
+  },
+  "homepage": "https://marko.dev",
+  "repository": "https://github.com/marko-php/marko",
+  "license": "MIT",
+  "keywords": ["marko", "skills", "php"]
+}

--- a/packages/claude-plugins/plugins/marko-skills/README.md
+++ b/packages/claude-plugins/plugins/marko-skills/README.md
@@ -1,0 +1,29 @@
+# marko-skills
+
+Claude Code plugin providing scaffolding skills for Marko modules and plugins.
+
+## Skills
+
+- `create-module` — scaffold a new Marko module
+- `create-plugin` — scaffold a new Marko Claude Code plugin
+
+## Usage
+
+Skills are invoked with the plugin namespace prefix:
+
+```
+/marko-skills:create-module
+/marko-skills:create-plugin
+```
+
+## Install
+
+Install via the marko marketplace:
+
+```
+/plugin install marko-skills@marko
+```
+
+## Skill content
+
+Each skill's full description lives in `skills/<skill-name>/SKILL.md` once populated by the build process.

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-module/SKILL.md
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-module/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: create-module
+description: >
+  Scaffold a new Marko module — a self-contained Composer package with composer.json, namespaced src/, and Pest tests.
+  **Use this skill whenever the user asks to create, add, or scaffold a new Marko module or package.**
+  Concrete triggers: 'create a module named payment', 'scaffold an acme/blog package', 'add a new module for X',
+  'break this code out into its own package', 'I need a new module', 'make me a Marko module'.
+  Marko makes no distinction between core and third-party modules: layout is identical.
+---
+
+# Create a Marko module
+
+A Marko module is a Composer package that the framework auto-discovers via the `extra.marko.module` flag. Modules can live anywhere — `packages/{name}/` in the monorepo, `vendor/{vendor}/{package}/` once installed from Packagist, or `app/{Module}/` inside a project. The layout is identical in every case.
+
+**This skill is the canonical specification for a Marko module. Do not inspect existing modules in this project to infer layout — siblings may have drifted from spec. Copy the templates from `assets/` verbatim, substitute placeholders, and stop.**
+
+## Step 1 — Pick a location and name
+
+- Monorepo package: `packages/{name}/` (e.g. `packages/payment/`)
+- Vendor package: standalone repo, resolves to `vendor/{vendor}/{name}/`
+- App-local module: `app/{Module}/` inside the host project
+
+The composer name is `{vendor}/{name}` (e.g. `marko/payment`, `acme/payment`). The PHP namespace is the StudlyCase form: `Marko\Payment`, `Acme\Payment`.
+
+## Step 2 — Write composer.json
+
+Copy `assets/composer.json.tmpl` (or `assets/composer.json.monorepo.tmpl` if working in the marko monorepo) to `<module-root>/composer.json` and substitute `{{vendor}}` and `{{name}}` (lowercase) and `{{Vendor}}` and `{{Name}}` (StudlyCase) placeholders.
+
+Required keys: `name`, `type: marko-module`, `require.marko/core`, psr-4 autoload, and `extra.marko.module: true` to flag it for the code indexer. **Never set a `version` field** — let Composer infer it from the branch.
+
+In the monorepo, use `assets/composer.json.monorepo.tmpl` which uses `self.version` for all `marko/*` requirements.
+
+## Step 3 — Create the directory layout
+
+```
+{module-root}/
+  composer.json
+  src/                      # PSR-4 source
+  tests/
+    Pest.php                # Pest bootstrap
+    Unit/
+    Feature/
+  README.md                 # Slim pointer per docs/DOCS-STANDARDS.md
+```
+
+Copy `assets/Pest.php.tmpl` to `tests/Pest.php`. No placeholder substitution needed.
+
+## Step 4 — Decide whether you need module.php
+
+`module.php` is **optional**. Only create it if the module needs explicit DI bindings (interface → concrete class wiring), singleton declarations, or boot callbacks for lifecycle hooks.
+
+If the module is just classes that auto-resolve, **omit `module.php` entirely**. Do not create an empty manifest.
+
+When you do need it, copy `assets/module.php.tmpl` to `<module-root>/module.php` and substitute `{{Vendor}}` and `{{Name}}` placeholders.
+
+## Step 5 — Add a slim README
+
+Copy `assets/README.md.tmpl` to `<module-root>/README.md` and substitute `{{vendor}}` and `{{name}}` placeholders.
+
+Per `docs/DOCS-STANDARDS.md`, package READMEs are slim pointers — title, install command, one quick example, and a link to the full docs page. Substantive documentation belongs in `docs/src/content/docs/packages/{name}.md`, not the README.
+
+## Step 6 — Verify the module is discovered
+
+After installing or registering the module, call the MCP tool `list_modules`. The new module should appear in the list. If not, check that:
+
+- `composer.json` has `extra.marko.module: true`
+- Composer has run (`composer dump-autoload` or `composer update`)
+- The module's psr-4 namespace resolves correctly
+
+## Verification
+
+After writing files, expect LSP diagnostics from `marko-lsp` to surface in the same turn. Resolve all diagnostics before declaring the module complete — diagnostics are the verification gate, not optional warnings. Then call the `list_modules` MCP tool to confirm the module is discovered by the framework.
+
+## Conventions to enforce
+
+- Every PHP file: `declare(strict_types=1);`
+- Constructor property promotion always
+- Type declarations on every parameter, return, and property
+- No `final` classes (blocks Preferences extensibility)
+- No magic methods — be explicit
+- Use `readonly` where immutability is appropriate, not as a blanket rule
+
+## What this skill does not cover
+
+- Authoring plugins for the new module — see the `marko-create-plugin` skill
+- Adding routes, observers, commands — see the relevant Marko docs pages
+- Database migrations — see the `marko/database` package docs
+
+## See also
+
+- [Marko docs: modularity](https://marko.build/docs/concepts/modularity/)
+- [`marko/core` README](https://github.com/markshust/marko/tree/develop/packages/core)

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/Pest.php.tmpl
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/Pest.php.tmpl
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Testing\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/README.md.tmpl
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/README.md.tmpl
@@ -1,0 +1,19 @@
+# {{vendor}}/{{name}}
+
+> **Part of the [Marko framework](https://marko.build).** Full documentation: [marko.build/docs/packages/{{name}}](https://marko.build/docs/packages/{{name}})
+
+## Install
+
+```bash
+composer require {{vendor}}/{{name}}
+```
+
+## Quick example
+
+```php
+// Usage example here
+```
+
+---
+
+See the [full docs](https://marko.build/docs/packages/{{name}}) for configuration, extension points, and API reference.

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/composer.json.monorepo.tmpl
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/composer.json.monorepo.tmpl
@@ -1,0 +1,35 @@
+{
+    "name": "{{vendor}}/{{name}}",
+    "description": "{{Name}} module for Marko",
+    "license": "MIT",
+    "type": "marko-module",
+    "require": {
+        "php": "^8.5",
+        "marko/core": "self.version",
+        "marko/config": "self.version"
+    },
+    "require-dev": {
+        "marko/testing": "self.version",
+        "pestphp/pest": "^4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "{{Vendor}}\\{{Name}}\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "{{Vendor}}\\{{Name}}\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
+    "extra": {
+        "marko": {
+            "module": true
+        }
+    }
+}

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/composer.json.tmpl
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/composer.json.tmpl
@@ -1,0 +1,35 @@
+{
+    "name": "{{vendor}}/{{name}}",
+    "description": "{{Name}} module for Marko",
+    "license": "MIT",
+    "type": "marko-module",
+    "require": {
+        "php": "^8.5",
+        "marko/core": "^1.0",
+        "marko/config": "^1.0"
+    },
+    "require-dev": {
+        "marko/testing": "^1.0",
+        "pestphp/pest": "^4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "{{Vendor}}\\{{Name}}\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "{{Vendor}}\\{{Name}}\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
+    "extra": {
+        "marko": {
+            "module": true
+        }
+    }
+}

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/module.php.tmpl
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-module/assets/module.php.tmpl
@@ -1,0 +1,22 @@
+<?php
+
+// module.php — optional manifest. Only create this file if the module needs
+// explicit DI bindings, singleton declarations, or boot callbacks.
+// If the module is just classes that auto-resolve, omit this file entirely.
+
+declare(strict_types=1);
+
+use {{Vendor}}\{{Name}}\Contracts\ExampleInterface;
+use {{Vendor}}\{{Name}}\ExampleImplementation;
+use Marko\Core\Container\ContainerInterface;
+
+return [
+    'bindings' => [
+        ExampleInterface::class => function (ContainerInterface $container): ExampleInterface {
+            return new ExampleImplementation();
+        },
+    ],
+    'singletons' => [
+        // Class names registered as shared instances
+    ],
+];

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-plugin/SKILL.md
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-plugin/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: create-plugin
+description: >
+  Create a Marko plugin — a class that intercepts methods on another class to modify
+  behavior without subclassing. **Use this skill whenever the user wants to add a
+  plugin, intercept a method, or extend a class's behavior.** Concrete triggers:
+  "add a plugin for the OrderService", "intercept the save method on User", "extend
+  the behavior of X without changing it", "modify Y's return value before it's
+  returned", "I need a plugin", "create a Before/After plugin". Plugins use the
+  #[Plugin], #[Before], #[After] attributes.
+---
+
+# Create a Marko Plugin
+
+> **This skill is the canonical specification for a Marko plugin. Do not inspect existing plugins in this project to infer structure — siblings may have drifted from spec. Copy the templates from `assets/` verbatim, substitute placeholders, and stop.**
+
+A plugin is a class that intercepts the input or output of a public method on any
+other class — without replacing that class. Plugins are Marko's fine-grained
+extensibility primitive. They are auto-discovered from any module's `src/`
+directory; **no manual registration is needed**.
+
+## When to use
+
+Use a plugin when the user wants to modify arguments to, or the result from, a
+public method on a class without rewriting or subclassing it. Common cases:
+
+- Enrich a return value
+- Validate or transform inputs before the method runs
+- Short-circuit (cache hit, guard, redirect)
+- Log or observe calls
+- Chain transformations across modules
+
+For **total replacement** of a class, use a Preference instead — that is a separate
+skill (`marko-create-preference`). Plugins and Preferences are complementary; only
+Preferences swap entire implementations.
+
+## Plugin model — two timings only
+
+Marko supports exactly **two** plugin types. A third type that wraps the call is
+**intentionally absent** — anything it could do is expressed as a Before
+(short-circuit) or After (result transformation), keeping the call stack
+debuggable.
+
+| Attribute   | When                       | What it does                                  |
+|-------------|----------------------------|-----------------------------------------------|
+| `#[Before]` | Before the target method   | Modify args, short-circuit, or pass through   |
+| `#[After]`  | After the target method    | Receive and modify the return value           |
+
+### Before return semantics
+
+| Return value            | Effect                                                    |
+|-------------------------|-----------------------------------------------------------|
+| `null`                  | Pass-through — original method runs with original args    |
+| `array`                 | Replace arguments — original method runs with these args  |
+| Any other non-null value| Short-circuit — original method is NOT called             |
+
+### After return semantics
+
+After plugins receive `$result` (the return value of the original method or a
+prior After plugin) as their first parameter, followed by the (possibly modified)
+original arguments. Each After plugin's return value feeds the next After plugin
+in sort order — always return the (possibly modified) result.
+
+### sortOrder
+
+`sortOrder` is defined on the method-level attribute, **not** the class. Lower
+numbers run first; negatives are valid; default is `0`.
+
+```php
+#[Before(sortOrder: -10)]   // runs before plugins at default 0
+#[After(sortOrder: 100)]    // runs after lower-priority Afters
+```
+
+## Runbook
+
+### Step 1 — Identify the target
+
+Determine which class and public method to intercept. Plugins cannot intercept
+`protected` or `private` methods, and the target class must not be `final`.
+
+### Step 2 — Copy the plugin class template
+
+Copy `assets/PluginClass.php.tmpl` verbatim. Substitute:
+
+| Placeholder       | Value                                  |
+|-------------------|----------------------------------------|
+| `{{Vendor}}`      | Composer vendor namespace (e.g., `App`) |
+| `{{Name}}`        | Module name (e.g., `Blog`)             |
+| `{{TargetClass}}` | Unqualified class name (e.g., `PostRepository`) |
+
+Place the file at `src/Plugins/{{TargetClass}}Plugin.php` inside the module.
+
+Add the correct `use` statement for the fully-qualified target class.
+
+Remove any `#[Before]` or `#[After]` methods that are not needed for this plugin —
+the template shows both for illustration.
+
+### Step 3 — Implement the interceptor methods
+
+Name each plugin method identically to the target method it intercepts (or use the
+`method:` argument on the attribute to override when names would collide).
+
+Apply the correct return semantics from the table above.
+
+### Step 4 — Copy the test template
+
+Copy `assets/PluginTest.php.tmpl` verbatim. Substitute the same placeholders.
+
+Adjust test cases to reflect the actual behavior being intercepted (pass-through,
+argument modification, short-circuit, result enrichment).
+
+### Step 5 — Verify placement
+
+- The plugin class lives anywhere under `src/` — `src/Plugins/` is conventional.
+- Do **not** register it in `module.php` — discovery is automatic.
+
+### Step 6 — LSP and MCP verification gate
+
+After writing files, expect LSP diagnostics from `marko-lsp`. Resolve all
+diagnostics before declaring the plugin complete — diagnostics are the verification
+gate. Then call the `find_plugins_targeting` MCP tool with the target class to
+confirm the new plugin is discovered.
+
+## Constraints
+
+- Targeted methods must be `public` on the target class
+- Target class must not be `final` (Marko avoids `final` for this reason)
+- Plugin classes should be `readonly` when they have no mutable state
+- Constructor property promotion always
+- `declare(strict_types=1)` always
+- No magic methods
+- No traits
+
+## What this skill does not cover
+
+- Creating a new module to host the plugin — see `marko-create-module`
+- Replacing an entire class — that is a Preference, not a Plugin (use
+  `marko-create-preference`)
+- Listening to events — that is `#[Observer]`, a different mechanism
+
+## See also
+
+- [Marko docs: plugins](https://marko.build/docs/concepts/plugins/)
+- [Marko docs: preferences](https://marko.build/docs/concepts/preferences/)
+- [`marko/core` README](https://github.com/markshust/marko/tree/develop/packages/core)

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-plugin/assets/PluginClass.php.tmpl
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-plugin/assets/PluginClass.php.tmpl
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{Vendor}}\{{Name}}\Plugins;
+
+use {{TargetClass}};
+use Marko\Core\Attributes\After;
+use Marko\Core\Attributes\Before;
+use Marko\Core\Attributes\Plugin;
+
+#[Plugin(target: {{TargetClass}}::class)]
+class {{TargetClass}}Plugin
+{
+    /**
+     * Before interceptor: runs before the target method.
+     *
+     * Return semantics:
+     *   null            → pass-through: original method runs with original arguments
+     *   array           → argument modification: original method runs with these values
+     *   any other value → short-circuit: original method is NOT called; this value is returned
+     */
+    #[Before(sortOrder: 10)]
+    public function methodName(/* same signature as target method */): null
+    {
+        // Observe, validate, or log without changing behavior — return null to pass through.
+        return null;
+    }
+
+    /**
+     * After interceptor: runs after the target method (or after a Before short-circuit).
+     *
+     * $result holds the return value of the original method (or the short-circuit value).
+     * Chain: when multiple After plugins target the same method, each one's return value
+     * feeds the next as $result. Always return the (possibly modified) result.
+     */
+    #[After(sortOrder: 10)]
+    public function methodName(mixed $result /* , ...same args as target */): mixed
+    {
+        // Transform or enrich the result, then return it.
+        return $result;
+    }
+}

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-plugin/assets/PluginTest.php.tmpl
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-plugin/assets/PluginTest.php.tmpl
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace {{Vendor}}\{{Name}}\Tests\Plugins;
+
+use {{Vendor}}\{{Name}}\Plugins\{{TargetClass}}Plugin;
+use {{TargetClass}};
+
+describe('{{TargetClass}}Plugin', function (): void {
+    beforeEach(function (): void {
+        $this->plugin = new {{TargetClass}}Plugin();
+    });
+
+    it('before methodName returns null to pass through when no interception is needed', function (): void {
+        $result = $this->plugin->methodName(/* test arguments */);
+
+        expect($result)->toBeNull();
+    });
+
+    it('before methodName returns array to modify arguments', function (): void {
+        // Example: return [$modifiedArg1, $modifiedArg2] to replace the original arguments
+        $result = $this->plugin->methodName(/* original arguments */);
+
+        expect($result)->toBeArray();
+    });
+
+    it('before methodName short-circuits when condition is met', function (): void {
+        // Example: return a non-null, non-array value to skip the original method
+        $result = $this->plugin->methodName(/* triggering arguments */);
+
+        expect($result)->not->toBeNull()
+            ->and($result)->not->toBeArray();
+    });
+
+    it('after methodName returns the (possibly modified) result', function (): void {
+        $originalResult = /* sample return value from target */null;
+
+        $result = $this->plugin->methodName($originalResult /* , ...args */);
+
+        expect($result)->toBe($originalResult);
+    });
+
+    it('after methodName enriches the result', function (): void {
+        $originalResult = /* sample input result */[];
+
+        $result = $this->plugin->methodName($originalResult /* , ...args */);
+
+        // Assert that the returned result contains the expected enrichment
+        expect($result)->toBeArray();
+    });
+});

--- a/packages/claude-plugins/tests/Pest.php
+++ b/packages/claude-plugins/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->in(__DIR__);

--- a/packages/claude-plugins/tests/Unit/MarketplaceTest.php
+++ b/packages/claude-plugins/tests/Unit/MarketplaceTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+describe('composer.json', function (): void {
+    beforeEach(function (): void {
+        $this->composerPath = dirname(__DIR__, 2) . '/composer.json';
+        $this->composer = json_decode(file_get_contents($this->composerPath), true);
+    });
+
+    it('declares package name marko/claude-plugins', function (): void {
+        expect($this->composer['name'])->toBe('marko/claude-plugins');
+    });
+
+    it('type field is "library" or omitted (defaulting to library)', function (): void {
+        $type = $this->composer['type'] ?? 'library';
+        expect($type)->toBe('library');
+    });
+
+    it('does not set extra.marko.module', function (): void {
+        $module = $this->composer['extra']['marko']['module'] ?? null;
+        expect($module)->toBeNull();
+    });
+
+    it('does not include a version field', function (): void {
+        expect(array_key_exists('version', $this->composer))->toBeFalse();
+    });
+
+    it('does not declare a Marko\\ClaudePlugins\\ autoload namespace (no PHP code shipped)', function (): void {
+        $autoload = $this->composer['autoload'] ?? [];
+        $psr4 = $autoload['psr-4'] ?? [];
+        expect(array_key_exists('Marko\\ClaudePlugins\\', $psr4))->toBeFalse();
+    });
+
+    it('module discovery in marko/core does not register marko/claude-plugins as a Marko module', function (): void {
+        // Module discovery in marko/core reads extra.marko.module from composer.json.
+        // Without that flag set to true the package is invisible to the loader.
+        $isModule = ($this->composer['extra']['marko']['module'] ?? false) === true;
+        expect($isModule)->toBeFalse();
+    });
+
+    it('no module.php file exists at the package root', function (): void {
+        $modulePath = dirname(__DIR__, 2) . '/module.php';
+        expect(file_exists($modulePath))->toBeFalse();
+    });
+});
+
+describe('marketplace.json', function (): void {
+    beforeEach(function (): void {
+        // Marketplace lives at the monorepo root, not inside packages/claude-plugins/
+        $this->repoRoot = dirname(__DIR__, 4);
+        $this->marketplacePath = $this->repoRoot . '/.claude-plugin/marketplace.json';
+        $this->marketplace = file_exists($this->marketplacePath)
+            ? json_decode(file_get_contents($this->marketplacePath), true)
+            : null;
+    });
+
+    it(
+        'marketplace.json lives at the monorepo repo root at .claude-plugin/marketplace.json (NOT inside packages/claude-plugins/)',
+        function (): void {
+            $insidePackage = dirname(__DIR__, 2) . '/.claude-plugin/marketplace.json';
+    
+            expect(file_exists($this->marketplacePath))->toBeTrue()
+                ->and(file_exists($insidePackage))->toBeFalse();
+        }
+    );
+
+    it('marketplace.json references the official schema URL via $schema', function (): void {
+        expect($this->marketplace)->toHaveKey('$schema')
+            ->and($this->marketplace['$schema'])->toBe(
+                'https://json.schemastore.org/claude-code-plugin-marketplace.json'
+            );
+    });
+
+    it('architecture.md AI Development Tooling table includes a row for marko/claude-plugins', function (): void {
+        $archPath = dirname(__DIR__, 4) . '/.claude/architecture.md';
+        $contents = file_get_contents($archPath);
+
+        expect(str_contains($contents, 'marko/claude-plugins'))->toBeTrue()
+            ->and(str_contains($contents, 'AI Development Tooling'))->toBeTrue();
+    });
+
+    it(
+        'marketplace.json each plugin entry includes name, description, author, category fields per Task 001\'s required-fields finding',
+        function (): void {
+            foreach ($this->marketplace['plugins'] as $plugin) {
+                expect($plugin)->toHaveKey('name')
+                    ->and($plugin)->toHaveKey('source')
+                    ->and($plugin)->toHaveKey('description')
+                    ->and($plugin)->toHaveKey('author')
+                    ->and($plugin['author'])->toHaveKey('name')
+                    ->and($plugin)->toHaveKey('category');
+            }
+        }
+    );
+
+    it(
+        'marketplace.json plugins array lists three entries (marko-skills, marko-lsp, marko-mcp) with relative-path source values',
+        function (): void {
+            $plugins = $this->marketplace['plugins'];
+            $names = array_column($plugins, 'name');
+            $sources = array_column($plugins, 'source');
+    
+            expect(count($plugins))->toBe(3)
+                ->and($names)->toContain('marko-skills')
+                ->and($names)->toContain('marko-lsp')
+                ->and($names)->toContain('marko-mcp');
+    
+            // Sources must be explicit relative paths from marketplace root.
+        // Anthropic's marketplace schema rejects bare-name sources with metadata.pluginRoot.
+        foreach ($sources as $source) {
+                expect($source)->toStartWith('./packages/claude-plugins/plugins/');
+            }
+        }
+    );
+
+    it(
+        'marketplace.json plugin sources point at the actual plugin directories under packages/claude-plugins/plugins/',
+        function (): void {
+            $plugins = $this->marketplace['plugins'];
+    
+            $expected = [
+                'marko-skills' => './packages/claude-plugins/plugins/marko-skills',
+                'marko-lsp' => './packages/claude-plugins/plugins/marko-lsp',
+                'marko-mcp' => './packages/claude-plugins/plugins/marko-mcp',
+            ];
+    
+            foreach ($plugins as $plugin) {
+                expect($plugin['source'])->toBe($expected[$plugin['name']]);
+            }
+        }
+    );
+
+    it(
+        'marketplace.json declares marketplace name "marko" and owner field per Task 001\'s required-fields finding',
+        function (): void {
+            expect($this->marketplace['name'])->toBe('marko')
+                ->and($this->marketplace['owner'])->toHaveKey('name')
+                ->and($this->marketplace['owner']['name'])->toBeString()
+                ->and(strlen($this->marketplace['owner']['name']))->toBeGreaterThan(0);
+        }
+    );
+
+    it(
+        'marketplace.json conforms to the schema captured in Task 001\'s schemas/marketplace.json artifact',
+        function (): void {
+            // Required fields per Task 001 finding F7: name (string), owner (object with name), plugins (array)
+        expect($this->marketplace)->toBeArray()
+                ->and($this->marketplace)->toHaveKey('name')
+                ->and($this->marketplace['name'])->toBeString()
+                ->and($this->marketplace)->toHaveKey('owner')
+                ->and($this->marketplace['owner'])->toBeArray()
+                ->and($this->marketplace['owner'])->toHaveKey('name')
+                ->and($this->marketplace)->toHaveKey('plugins')
+                ->and($this->marketplace['plugins'])->toBeArray();
+        }
+    );
+});

--- a/packages/claude-plugins/tests/Unit/MarkoLspPluginTest.php
+++ b/packages/claude-plugins/tests/Unit/MarkoLspPluginTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+describe('marko-lsp plugin', function (): void {
+    beforeEach(function (): void {
+        $this->pluginRoot = dirname(__DIR__, 2) . '/plugins/marko-lsp';
+        $this->pluginJsonPath = $this->pluginRoot . '/.claude-plugin/plugin.json';
+        $this->lspJsonPath = $this->pluginRoot . '/.lsp.json';
+        $this->shimPath = $this->pluginRoot . '/bin/marko-lsp';
+        $this->readmePath = $this->pluginRoot . '/README.md';
+    });
+
+    it(
+        'plugin.json declares name "marko-lsp" and a description matching the marketplace.json entry',
+        function (): void {
+            $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+    
+            expect(file_exists($this->pluginJsonPath))->toBeTrue()
+                ->and($manifest['name'])->toBe('marko-lsp')
+                ->and($manifest['description'])->toBe('Marko LSP bundle (PHP intelephense) for Claude Code.');
+        }
+    );
+
+    it('plugin.json includes author with name "Marko Framework"', function (): void {
+        $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+
+        expect($manifest['author'])->toBeArray()
+            ->and($manifest['author']['name'])->toBe('Marko Framework');
+    });
+
+    it('plugin.json does not include a version field', function (): void {
+        $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+
+        expect(array_key_exists('version', $manifest))->toBeFalse();
+    });
+
+    it(
+        '.lsp.json top-level structure is an object keyed by server name (not wrapped in lspServers per Task 001 F1 verbatim)',
+        function (): void {
+            $lsp = json_decode(file_get_contents($this->lspJsonPath), true);
+    
+            expect(file_exists($this->lspJsonPath))->toBeTrue()
+                ->and(array_key_exists('marko-lsp', $lsp))->toBeTrue()
+                ->and(array_key_exists('lspServers', $lsp))->toBeFalse();
+        }
+    );
+
+    it('.lsp.json marko-lsp.command is "${CLAUDE_PLUGIN_ROOT}/bin/marko-lsp"', function (): void {
+        $lsp = json_decode(file_get_contents($this->lspJsonPath), true);
+
+        expect($lsp['marko-lsp']['command'])->toBe('${CLAUDE_PLUGIN_ROOT}/bin/marko-lsp');
+    });
+
+    it('.lsp.json marko-lsp.args is an empty array (subcommand hardcoded inside the shim)', function (): void {
+        $lsp = json_decode(file_get_contents($this->lspJsonPath), true);
+
+        expect($lsp['marko-lsp']['args'])->toBeArray()
+            ->and($lsp['marko-lsp']['args'])->toHaveCount(0);
+    });
+
+    it(
+        '.lsp.json marko-lsp.extensionToLanguage maps only .php to php (no .latte for v1, per Task 001 F9)',
+        function (): void {
+            $lsp = json_decode(file_get_contents($this->lspJsonPath), true);
+            $ext = $lsp['marko-lsp']['extensionToLanguage'];
+    
+            expect($ext)->toBeArray()
+                ->and($ext)->toHaveCount(1)
+                ->and(array_key_exists('.php', $ext))->toBeTrue()
+                ->and($ext['.php'])->toBe('php')
+                ->and(array_key_exists('.latte', $ext))->toBeFalse();
+        }
+    );
+
+    it('.lsp.json each extensionToLanguage key starts with a leading dot', function (): void {
+        $lsp = json_decode(file_get_contents($this->lspJsonPath), true);
+        $ext = $lsp['marko-lsp']['extensionToLanguage'];
+
+        foreach (array_keys($ext) as $key) {
+            expect(str_starts_with($key, '.'))->toBeTrue();
+        }
+    });
+
+    it('bin/marko-lsp shim script exists, has POSIX shebang, is committed with executable bit set', function (): void {
+        $contents = file_exists($this->shimPath) ? file_get_contents($this->shimPath) : '';
+
+        expect(file_exists($this->shimPath))->toBeTrue()
+            ->and(str_starts_with($contents, '#!/bin/sh'))->toBeTrue()
+            ->and(is_executable($this->shimPath))->toBeTrue();
+    });
+
+    it('bin/marko-lsp searches for marko binary in order: ./vendor/bin/marko then marko on PATH', function (): void {
+        $contents = file_get_contents($this->shimPath);
+
+        expect(str_contains($contents, './vendor/bin/marko'))->toBeTrue()
+            ->and(str_contains($contents, 'command -v marko'))->toBeTrue();
+    });
+
+    it('bin/marko-lsp execs the discovered binary with "lsp:serve" plus any forwarded args', function (): void {
+        $contents = file_get_contents($this->shimPath);
+
+        expect(str_contains($contents, 'lsp:serve'))->toBeTrue()
+            ->and(str_contains($contents, '"$@"'))->toBeTrue();
+    });
+
+    it('bin/marko-lsp prints a loud error to stderr and exits 1 when no marko binary is found', function (): void {
+        $contents = file_get_contents($this->shimPath);
+
+        expect(str_contains($contents, '>&2'))->toBeTrue()
+            ->and(str_contains($contents, 'exit 1'))->toBeTrue();
+    });
+
+    it(
+        'README.md explains marko-lsp coexists with php-lsp (intelephense), what marko-lsp adds beyond it, the recommendation to uninstall php-lsp@claude-plugins-official to avoid duplication, and how to verify with claude plugin list',
+        function (): void {
+            $contents = file_exists($this->readmePath) ? file_get_contents($this->readmePath) : '';
+    
+            expect(file_exists($this->readmePath))->toBeTrue()
+                ->and(str_contains($contents, 'intelephense'))->toBeTrue()
+                ->and(str_contains($contents, 'php-lsp@claude-plugins-official'))->toBeTrue()
+                ->and(str_contains($contents, 'uninstall'))->toBeTrue()
+                ->and(str_contains($contents, 'claude plugin list'))->toBeTrue();
+        }
+    );
+});

--- a/packages/claude-plugins/tests/Unit/MarkoMcpPluginTest.php
+++ b/packages/claude-plugins/tests/Unit/MarkoMcpPluginTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+describe('marko-mcp plugin', function (): void {
+    beforeEach(function (): void {
+        $this->pluginRoot = dirname(__DIR__, 2) . '/plugins/marko-mcp';
+        $this->pluginJsonPath = $this->pluginRoot . '/.claude-plugin/plugin.json';
+    });
+
+    it(
+        'plugin.json declares name "marko-mcp" and a description matching the marketplace.json entry',
+        function (): void {
+            $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+    
+            expect(file_exists($this->pluginJsonPath))->toBeTrue()
+                ->and($manifest['name'])->toBe('marko-mcp')
+                ->and($manifest['description'])->toBe('Marko MCP server (codeindexer, docs-fts) for Claude Code.');
+        }
+    );
+
+    it('plugin.json includes author with name "Marko Framework"', function (): void {
+        $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+
+        expect($manifest)->toHaveKey('author')
+            ->and($manifest['author'])->toHaveKey('name')
+            ->and($manifest['author']['name'])->toBe('Marko Framework');
+    });
+
+    it('plugin.json does not include a version field, allowing git-commit-based versioning', function (): void {
+        $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+
+        expect(array_key_exists('version', $manifest))->toBeFalse();
+    });
+
+    it(
+        '.mcp.json top-level structure is { "mcpServers": { "marko": {...} } } — server key is "marko" not "marko-mcp" to avoid the `plugin:marko-mcp:marko-mcp` doubled-name display in Claude Code',
+        function (): void {
+            $mcpPath = $this->pluginRoot . '/.mcp.json';
+            $mcp = json_decode(file_get_contents($mcpPath), true);
+    
+            expect(file_exists($mcpPath))->toBeTrue()
+                ->and($mcp)->toHaveKey('mcpServers')
+                ->and($mcp['mcpServers'])->toBeArray()
+                ->and($mcp['mcpServers'])->toHaveKey('marko')
+                ->and($mcp['mcpServers'])->not->toHaveKey('marko-mcp')
+                ->and($mcp['mcpServers']['marko'])->toBeArray();
+        }
+    );
+
+    it('.mcp.json marko.command is "${CLAUDE_PLUGIN_ROOT}/bin/marko-mcp"', function (): void {
+        $mcp = json_decode(file_get_contents($this->pluginRoot . '/.mcp.json'), true);
+
+        expect($mcp['mcpServers']['marko']['command'])->toBe('${CLAUDE_PLUGIN_ROOT}/bin/marko-mcp');
+    });
+
+    it('.mcp.json marko.args is an empty array (subcommand is hardcoded inside the shim)', function (): void {
+        $mcp = json_decode(file_get_contents($this->pluginRoot . '/.mcp.json'), true);
+
+        expect($mcp['mcpServers']['marko'])->toHaveKey('args')
+            ->and($mcp['mcpServers']['marko']['args'])->toBeArray()
+            ->and($mcp['mcpServers']['marko']['args'])->toHaveCount(0);
+    });
+
+    it(
+        'bin/marko-mcp shim script exists, has POSIX shebang (#!/bin/sh), is committed with executable bit set',
+        function (): void {
+            $shimPath = $this->pluginRoot . '/bin/marko-mcp';
+            $contents = file_exists($shimPath) ? file_get_contents($shimPath) : '';
+    
+            expect(file_exists($shimPath))->toBeTrue()
+                ->and(str_starts_with($contents, '#!/bin/sh'))->toBeTrue()
+                ->and(is_executable($shimPath))->toBeTrue();
+        }
+    );
+
+    it('bin/marko-mcp searches for marko binary in order: ./vendor/bin/marko then marko on PATH', function (): void {
+        $contents = file_get_contents($this->pluginRoot . '/bin/marko-mcp');
+
+        // vendor/bin/marko must appear before global marko PATH check
+        $vendorPos = strpos($contents, './vendor/bin/marko');
+        $pathPos = strpos($contents, 'command -v marko');
+
+        expect($vendorPos)->not->toBeFalse()
+            ->and($pathPos)->not->toBeFalse()
+            ->and($vendorPos)->toBeLessThan($pathPos);
+    });
+
+    it('bin/marko-mcp execs the discovered binary with "mcp:serve" plus any forwarded args', function (): void {
+        $contents = file_get_contents($this->pluginRoot . '/bin/marko-mcp');
+
+        expect(str_contains($contents, 'exec ./vendor/bin/marko mcp:serve "$@"'))->toBeTrue()
+            ->and(str_contains($contents, 'exec marko mcp:serve "$@"'))->toBeTrue();
+    });
+
+    it(
+        'bin/marko-mcp prints a loud error to stderr and exits 1 when no marko binary is found, suggesting "composer require marko/devai"',
+        function (): void {
+            $contents = file_get_contents($this->pluginRoot . '/bin/marko-mcp');
+    
+            expect(str_contains($contents, '>&2'))->toBeTrue()
+                ->and(str_contains($contents, 'composer require marko/devai'))->toBeTrue()
+                ->and(str_contains($contents, 'exit 1'))->toBeTrue();
+        }
+    );
+
+    it(
+        'README.md explains what the plugin registers, how to install via the marko marketplace, and how to verify with claude mcp list',
+        function (): void {
+            $readmePath = $this->pluginRoot . '/README.md';
+            $contents = file_exists($readmePath) ? file_get_contents($readmePath) : '';
+    
+            expect(file_exists($readmePath))->toBeTrue()
+                // What the plugin registers
+            ->and(str_contains($contents, 'mcp:serve') || str_contains($contents, 'MCP server'))->toBeTrue()
+                // How to install via marketplace
+            ->and(str_contains($contents, '/plugin install marko-mcp@marko'))->toBeTrue()
+                // How to verify
+            ->and(str_contains($contents, 'claude mcp list'))->toBeTrue();
+        }
+    );
+});

--- a/packages/claude-plugins/tests/Unit/MarkoSkillsPluginTest.php
+++ b/packages/claude-plugins/tests/Unit/MarkoSkillsPluginTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+describe('marko-skills plugin', function (): void {
+    beforeEach(function (): void {
+        $this->pluginRoot = dirname(__DIR__, 2) . '/plugins/marko-skills';
+        $this->pluginJsonPath = $this->pluginRoot . '/.claude-plugin/plugin.json';
+    });
+
+    it('plugin.json declares name "marko-skills"', function (): void {
+        $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+
+        expect(file_exists($this->pluginJsonPath))->toBeTrue()
+            ->and($manifest['name'])->toBe('marko-skills');
+    });
+
+    it(
+        'plugin.json description states the plugin provides scaffolding skills for Marko modules and plugins',
+        function (): void {
+            $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+    
+            expect($manifest)->toHaveKey('description')
+                ->and($manifest['description'])->toBe(
+                    'Marko-specific skills (create-module, create-plugin) for Claude Code.'
+                );
+        }
+    );
+
+    it('plugin.json includes author with name "Marko Framework"', function (): void {
+        $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+
+        expect($manifest)->toHaveKey('author')
+            ->and($manifest['author'])->toHaveKey('name')
+            ->and($manifest['author']['name'])->toBe('Marko Framework');
+    });
+
+    it('plugin.json does not include a version field', function (): void {
+        $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
+
+        expect($manifest)->not->toHaveKey('version');
+    });
+
+    it('skills/ directory exists at the plugin root (not inside .claude-plugin/)', function (): void {
+        expect(is_dir($this->pluginRoot . '/skills'))->toBeTrue()
+            ->and(is_dir($this->pluginRoot . '/.claude-plugin/skills'))->toBeFalse();
+    });
+
+    it(
+        'README.md lists the included skills (create-module, create-plugin), how they\'re invoked with the plugin namespace, and how to install via the marko marketplace',
+        function (): void {
+            $readmePath = $this->pluginRoot . '/README.md';
+            $content = file_exists($readmePath) ? file_get_contents($readmePath) : '';
+    
+            expect(file_exists($readmePath))->toBeTrue()
+                ->and($content)->toContain('create-module')
+                ->and($content)->toContain('create-plugin')
+                ->and($content)->toContain('/marko-skills:create-module')
+                ->and($content)->toContain('/marko-skills:create-plugin')
+                ->and($content)->toContain('/plugin install marko-skills@marko');
+        }
+    );
+});

--- a/packages/claude-plugins/tests/Unit/ReadmeTest.php
+++ b/packages/claude-plugins/tests/Unit/ReadmeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+describe('README.md', function (): void {
+    beforeEach(function (): void {
+        $this->readmePath = dirname(__DIR__, 2) . '/README.md';
+        $this->contents = file_exists($this->readmePath)
+            ? file_get_contents($this->readmePath)
+            : null;
+    });
+
+    it('README.md starts with the package title (# marko/claude-plugins or similar)', function (): void {
+        expect($this->contents)->not->toBeNull()
+            ->and($this->contents)->toStartWith('# marko/claude-plugins');
+    });
+
+    it('README.md includes a one-paragraph description of what the package provides', function (): void {
+        expect($this->contents)->not->toBeNull()
+            ->and($this->contents)->toContain('Claude Code')
+            ->and($this->contents)->toContain('marketplace');
+    });
+
+    it(
+        'README.md lists all three plugins (marko-skills, marko-lsp, marko-mcp) with one-line descriptions',
+        function (): void {
+            expect($this->contents)->not->toBeNull()
+                ->and($this->contents)->toContain('marko-skills')
+                ->and($this->contents)->toContain('marko-lsp')
+                ->and($this->contents)->toContain('marko-mcp');
+        }
+    );
+
+    it('README.md includes the install command via marko devai:install', function (): void {
+        expect($this->contents)->not->toBeNull()
+            ->and($this->contents)->toContain('devai:install');
+    });
+
+    it('README.md links to the full docs page in the docs site', function (): void {
+        expect($this->contents)->not->toBeNull()
+            ->and($this->contents)->toContain('https://marko.build/docs/ai-assisted-development/');
+    });
+
+    it(
+        'README.md follows the slim-pointer convention from docs/DOCS-STANDARDS.md (no exhaustive feature lists, no inline code samples beyond a quick install example)',
+        function (): void {
+            expect($this->contents)->not->toBeNull();
+    
+            // Slim-pointer: file should be short (under 80 lines)
+        $lines = substr_count($this->contents, "\n") + 1;
+            expect($lines)->toBeLessThan(80)
+                // Must have a Documentation section
+            ->and($this->contents)->toContain('## Documentation');
+        }
+    );
+});

--- a/packages/claude-plugins/tests/Unit/Skills/CreateModuleSkillTest.php
+++ b/packages/claude-plugins/tests/Unit/Skills/CreateModuleSkillTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+describe('create-module skill', function (): void {
+    beforeEach(function (): void {
+        $this->skillRoot = dirname(__DIR__, 3) . '/plugins/marko-skills/skills/create-module';
+        $this->skillMd = $this->skillRoot . '/SKILL.md';
+        $this->assetsDir = $this->skillRoot . '/assets';
+    });
+
+    it(
+        'SKILL.md frontmatter has name "create-module" and a non-empty description with concrete trigger examples',
+        function (): void {
+            $content = file_exists($this->skillMd) ? file_get_contents($this->skillMd) : '';
+    
+            // Parse YAML frontmatter between the two --- delimiters
+        preg_match('/^---\n(.*?)\n---/s', $content, $matches);
+    
+            $frontmatter = $matches[1] ?? '';
+    
+            expect(file_exists($this->skillMd))->toBeTrue()
+                ->and($matches)->not->toBeEmpty()
+                ->and($frontmatter)->toContain('name: create-module')
+                // description key must be present (may be a YAML block scalar starting with >)
+            ->and($frontmatter)->toContain('description:')
+                // Must contain concrete trigger examples (in the body — YAML block scalar or inline)
+            ->and($content)->toContain('create a module named');
+        }
+    );
+
+    it('SKILL.md is under 500 lines', function (): void {
+        $lines = file_exists($this->skillMd) ? count(file($this->skillMd)) : 0;
+
+        expect(file_exists($this->skillMd))->toBeTrue()
+            ->and($lines)->toBeLessThan(500);
+    });
+
+    it('SKILL.md contains the anti-pattern directive forbidding inference from sibling modules', function (): void {
+        $content = file_get_contents($this->skillMd);
+
+        expect($content)->toContain('Do not inspect existing modules');
+    });
+
+    it('SKILL.md contains the LSP verification gate directive', function (): void {
+        $content = file_get_contents($this->skillMd);
+
+        expect($content)->toContain('marko-lsp')
+            ->and($content)->toContain('diagnostics');
+    });
+
+    it(
+        'SKILL.md instructs the agent to copy templates from assets/ rather than inlining file content',
+        function (): void {
+            $content = file_get_contents($this->skillMd);
+    
+            expect($content)->toContain('assets/');
+        }
+    );
+
+    it(
+        'composer.json.tmpl contains {{vendor}} and {{name}} placeholders and is valid JSON when placeholders are substituted with literal strings',
+        function (): void {
+            $tmplPath = $this->assetsDir . '/composer.json.tmpl';
+            $content = file_exists($tmplPath) ? file_get_contents($tmplPath) : '';
+    
+            // Substitute placeholders with literal strings and validate JSON
+        $substituted = str_replace(
+                ['{{vendor}}', '{{name}}', '{{Vendor}}', '{{Name}}'],
+                ['acme', 'payment', 'Acme', 'Payment'],
+                $content,
+            );
+            $decoded = json_decode($substituted, true);
+    
+            expect(file_exists($tmplPath))->toBeTrue()
+                ->and($content)->toContain('{{vendor}}')
+                ->and($content)->toContain('{{name}}')
+                ->and($decoded)->not->toBeNull()
+                ->and($decoded)->toHaveKey('name')
+                ->and($decoded)->toHaveKey('type')
+                ->and($decoded)->toHaveKey('require')
+                ->and($decoded)->toHaveKey('autoload')
+                ->and($decoded)->toHaveKey('extra')
+                ->and($decoded['extra']['marko']['module'])->toBeTrue();
+        }
+    );
+
+    it('composer.json.monorepo.tmpl uses self.version constraints for marko/* requirements', function (): void {
+        $tmplPath = $this->assetsDir . '/composer.json.monorepo.tmpl';
+        $content = file_exists($tmplPath) ? file_get_contents($tmplPath) : '';
+
+        // Confirm marko/* packages use self.version, not ^1.0
+        $substituted = str_replace(
+            ['{{vendor}}', '{{name}}', '{{Vendor}}', '{{Name}}'],
+            ['acme', 'payment', 'Acme', 'Payment'],
+            $content,
+        );
+        $decoded = json_decode($substituted, true);
+
+        expect(file_exists($tmplPath))->toBeTrue()
+            ->and($content)->toContain('self.version')
+            ->and($decoded)->not->toBeNull();
+
+        // All marko/* keys in require should have "self.version"
+        foreach ($decoded['require'] as $pkg => $version) {
+            if (str_starts_with($pkg, 'marko/')) {
+                expect($version)->toBe('self.version');
+            }
+        }
+    });
+
+    it('Pest.php.tmpl contains the Marko\\\\Testing\\\\TestCase reference', function (): void {
+        $tmplPath = $this->assetsDir . '/Pest.php.tmpl';
+        $content = file_exists($tmplPath) ? file_get_contents($tmplPath) : '';
+
+        expect(file_exists($tmplPath))->toBeTrue()
+            ->and($content)->toContain('Marko\\Testing\\TestCase');
+    });
+
+    it('module.php.tmpl is documented as optional and only created when DI bindings are needed', function (): void {
+        $tmplPath = $this->assetsDir . '/module.php.tmpl';
+        $skillContent = file_get_contents($this->skillMd);
+
+        expect(file_exists($tmplPath))->toBeTrue()
+            // SKILL.md must document module.php as optional
+            ->and($skillContent)->toContain('optional')
+            ->and($skillContent)->toContain('module.php');
+    });
+
+    it('README.md.tmpl follows the slim-pointer convention from docs/DOCS-STANDARDS.md', function (): void {
+        $tmplPath = $this->assetsDir . '/README.md.tmpl';
+        $content = file_exists($tmplPath) ? file_get_contents($tmplPath) : '';
+
+        // Slim pointer: must have vendor/name placeholder, an install section, and a docs link
+        expect(file_exists($tmplPath))->toBeTrue()
+            ->and($content)->toContain('{{vendor}}')
+            ->and($content)->toContain('{{name}}')
+            ->and($content)->toContain('composer require');
+    });
+
+    it(
+        'the original SKILL.md at packages/devai/resources/ai/skills/marko-create-module/ is deleted',
+        function (): void {
+            $originalPath = dirname(__DIR__, 4) . '/devai/resources/ai/skills/marko-create-module/SKILL.md';
+    
+            expect(file_exists($originalPath))->toBeFalse();
+        }
+    );
+});

--- a/packages/claude-plugins/tests/Unit/Skills/CreatePluginSkillTest.php
+++ b/packages/claude-plugins/tests/Unit/Skills/CreatePluginSkillTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+describe('create-plugin skill', function (): void {
+    beforeEach(function (): void {
+        $this->skillRoot = dirname(__DIR__, 3) . '/plugins/marko-skills/skills/create-plugin';
+        $this->skillPath = $this->skillRoot . '/SKILL.md';
+        $this->skillContent = file_exists($this->skillPath) ? file_get_contents($this->skillPath) : '';
+    });
+
+    it(
+        'SKILL.md frontmatter has name "create-plugin" and a description with concrete trigger examples (e.g., "add a plugin for X", "intercept Y method", "extend Z class behavior")',
+        function (): void {
+            expect(file_exists($this->skillPath))->toBeTrue()
+                ->and($this->skillContent)->toContain('name: create-plugin')
+                // Description must be "pushy" with concrete trigger examples
+                ->and($this->skillContent)->toContain('add a plugin')
+                ->and($this->skillContent)->toContain('intercept')
+                ->and($this->skillContent)->toContain('extend');
+        },
+    );
+
+    it('SKILL.md is under 500 lines', function (): void {
+        $lineCount = file_exists($this->skillPath) ? count(file($this->skillPath)) : 0;
+
+        expect(file_exists($this->skillPath))->toBeTrue()
+            ->and($lineCount)->toBeLessThan(500);
+    });
+
+    it('SKILL.md contains the anti-pattern directive forbidding inference from sibling plugins', function (): void {
+        expect($this->skillContent)->toContain('Do not inspect existing plugins in this project');
+    });
+
+    it('SKILL.md contains the LSP verification gate directive', function (): void {
+        expect($this->skillContent)->toContain('marko-lsp')
+            ->and($this->skillContent)->toContain('find_plugins_targeting');
+    });
+
+    it(
+        'SKILL.md correctly distinguishes Before vs After plugin types per architecture.md (no around plugins; use Preference for total replacement)',
+        function (): void {
+            expect($this->skillContent)->toContain('#[Before]')
+                ->and($this->skillContent)->toContain('#[After]')
+                ->and($this->skillContent)->not->toContain('Around')
+                ->and($this->skillContent)->toContain('Preference');
+        },
+    );
+
+    it(
+        'SKILL.md instructs the agent to copy templates from assets/ rather than inlining file content',
+        function (): void {
+            expect($this->skillContent)->toContain('assets/')
+                ->and($this->skillContent)->toContain('PluginClass.php.tmpl')
+                ->and($this->skillContent)->toContain('PluginTest.php.tmpl');
+        },
+    );
+
+    it(
+        'PluginClass.php.tmpl uses #[Plugin] attribute on the class and #[Before] or #[After] on methods, with sortOrder argument shown',
+        function (): void {
+            $tmplPath = $this->skillRoot . '/assets/PluginClass.php.tmpl';
+            $content = file_exists($tmplPath) ? file_get_contents($tmplPath) : '';
+
+            expect(file_exists($tmplPath))->toBeTrue()
+                ->and($content)->toContain('#[Plugin')
+                ->and($content)->toContain('#[Before')
+                ->and($content)->toContain('#[After')
+                ->and($content)->toContain('sortOrder');
+        },
+    );
+
+    it('PluginClass.php.tmpl includes strict_types=1 declaration', function (): void {
+        $tmplPath = $this->skillRoot . '/assets/PluginClass.php.tmpl';
+        $content = file_exists($tmplPath) ? file_get_contents($tmplPath) : '';
+
+        expect(file_exists($tmplPath))->toBeTrue()
+            ->and($content)->toContain('declare(strict_types=1)');
+    });
+
+    it(
+        'the original SKILL.md at packages/devai/resources/ai/skills/marko-create-plugin/ is deleted',
+        function (): void {
+            $originalPath = dirname(__DIR__, 4) . '/devai/resources/ai/skills/marko-create-plugin/SKILL.md';
+
+            expect(file_exists($originalPath))->toBeFalse();
+        },
+    );
+});


### PR DESCRIPTION
Third of **8 split PRs** from #41. Adds `marko/claude-plugins` — the Claude Code plugin marketplace manifest and assets (`marko-skills`, `marko-lsp`, `marko-mcp`).

## No subtraction
This package ships **no PHP runtime code** — it is not a Marko module, just a content/asset container that Claude Code consumes. Verified by its own tests (no `extra.marko.module`, no autoload namespace, no `module.php`).

## Cross-cutting pieces (required by the package's tests)
- **`.claude-plugin/marketplace.json`** at the **repo root** (by design — Claude Code reads the marketplace manifest from the monorepo root, not from inside the package). My initial `packages/` pull missed it; the package's `MarketplaceTest` caught the omission.
- **`.claude/architecture.md`** — new "AI Development Tooling" inventory section (also backfills the `codeindexer` row missed in #97).
- GitHub issue-template dropdown + root `composer.json` wiring.

## End-user docs
The README documents the key fact an end-user needs: **this is installed via `marko devai:install`, not directly**, and lists the three bundled plugins. Because the package is devai-managed (meaningful only once `marko/devai` lands), its full reference belongs in the `ai-assisted-development` guide section that ships with the devai phase — rather than a standalone `packages/` page that would point at not-yet-existent tooling.

## Verification
- ✅ claude-plugins suite: 71 passed
- ✅ Full suite: **5773 passed**, 0 failed
- ✅ phpcs clean (4 pre-existing violations in pulled files auto-fixed)
- ✅ marketplace.json tracked; lives at repo root, plugin sources resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)