### PR TITLE
feat: add marko/docs (documentation search contract)

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -237,6 +237,12 @@ When your code depends on `marko/log` (interface) instead of `marko/log-file` (d
 | `marko/codeindexer` | Tool | Static analysis indexer — attributes, configs, templates, translations into a cached symbol table |
 | `marko/claude-plugins` | Tool | Claude Code marketplace and plugins (marko-skills, marko-lsp, marko-mcp) for AI-assisted development |
 
+### Documentation Search
+
+| Package | Type | Description |
+|---------|------|-------------|
+| `marko/docs` | Interface | `DocsSearchInterface` — contract for searching Marko documentation; ships no driver |
+
 ---
 
 ## Naming Conventions

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,6 +72,7 @@ body:
         - database-readwrite
         - debugbar
         - devserver
+        - docs
         - encryption
         - encryption-openssl
         - env

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -60,6 +60,7 @@ body:
         - database-readwrite
         - debugbar
         - devserver
+        - docs
         - encryption
         - encryption-openssl
         - env

--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,10 @@
         },
         {
             "type": "path",
+            "url": "packages/docs"
+        },
+        {
+            "type": "path",
             "url": "packages/encryption"
         },
         {
@@ -381,6 +385,7 @@
         "marko/database-pgsql": "self.version",
         "marko/database-readwrite": "self.version",
         "marko/devserver": "self.version",
+        "marko/docs": "self.version",
         "marko/encryption": "self.version",
         "marko/encryption-openssl": "self.version",
         "marko/env": "self.version",
@@ -502,6 +507,7 @@
             "Marko\\Database\\ReadWrite\\Tests\\": "packages/database-readwrite/tests/",
             "Marko\\Debugbar\\Tests\\": "packages/debugbar/tests/",
             "Marko\\DevServer\\Tests\\": "packages/devserver/tests/",
+            "Marko\\Docs\\Tests\\": "packages/docs/tests/",
             "Marko\\Encryption\\Tests\\": "packages/encryption/tests/",
             "Marko\\Encryption\\OpenSsl\\Tests\\": "packages/encryption-openssl/tests/",
             "Marko\\Env\\Tests\\": "packages/env/tests/",

--- a/docs/src/content/docs/packages/docs.md
+++ b/docs/src/content/docs/packages/docs.md
@@ -1,0 +1,92 @@
+---
+title: marko/docs
+description: Documentation search contract — the interface for querying Marko documentation, with interchangeable drivers.
+---
+
+Documentation search contract for Marko — defines the interface for querying Marko documentation, with interchangeable driver implementations. `marko/docs` ships **no search implementation**; it defines `DocsSearchInterface` and the value objects that drivers return. Install a driver to get a working search backend.
+
+**This package defines a contract only.** Install a driver for implementation:
+
+- `marko/docs-fts` — lightweight lexical search (SQLite FTS5)
+- `marko/docs-vec` — hybrid semantic + lexical search (FTS5 + sqlite-vec)
+
+Both drivers implement the same `DocsSearchInterface`, so switching is a one-line dependency change.
+
+## Installation
+
+Install a driver (which pulls in this contract automatically):
+
+```bash
+# Lightweight lexical search
+composer require marko/docs-fts
+
+# Hybrid semantic + lexical search
+composer require marko/docs-vec
+```
+
+Or install the contract alone if you are building a custom driver:
+
+```bash
+composer require marko/docs
+```
+
+## Usage
+
+Type-hint `DocsSearchInterface` and let the installed driver handle the backend:
+
+```php
+use Marko\Docs\Contract\DocsSearchInterface;
+use Marko\Docs\ValueObject\DocsQuery;
+
+class DocsController
+{
+    public function __construct(
+        private DocsSearchInterface $docs,
+    ) {}
+
+    public function search(string $term): array
+    {
+        // Returns list<DocsResult>
+        return $this->docs->search(new DocsQuery($term, limit: 10));
+    }
+}
+```
+
+## Customization
+
+Implement `DocsSearchInterface` and register your implementation as a `#[Preference]`:
+
+```php
+#[Preference(DocsSearchInterface::class)]
+class MyDocsSearch implements DocsSearchInterface
+{
+    public function search(DocsQuery $query): array { /* ... */ }
+    public function getPage(string $id): DocsPage { /* ... */ }
+    public function listNav(): array { /* ... */ }
+    public function driverName(): string { return 'custom'; }
+}
+```
+
+## API Reference
+
+### `DocsSearchInterface`
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `search(DocsQuery $query)` | `list<DocsResult>` | Run a search; throws `DocsException` on failure |
+| `getPage(string $id)` | `DocsPage` | Fetch a single page by id |
+| `listNav()` | `list<DocsNavEntry>` | The documentation navigation tree |
+| `driverName()` | `string` | Identifier of the active driver (e.g. `fts`, `vec`) |
+
+### Value objects
+
+- **`DocsQuery`** — `query: string`, `limit: int = 10`
+- **`DocsResult`** — `pageId: string`, `title: string`, `excerpt: string`, `score: float`
+- **`DocsPage`** — `id: string`, `title: string`, `content: string`, `path: string`
+- **`DocsNavEntry`** — `id: string`, `title: string`, `path: string`, `depth: int = 0`
+
+## Related Packages
+
+- [`marko/docs-fts`](/docs/packages/docs-fts/) — lexical search driver
+- [`marko/docs-vec`](/docs/packages/docs-vec/) — hybrid semantic search driver
+- `marko/docs-markdown` — the canonical documentation content the drivers index

--- a/packages/docs/.gitattributes
+++ b/packages/docs/.gitattributes
@@ -1,0 +1,5 @@
+/tests              export-ignore
+/.github             export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/phpunit.xml.dist   export-ignore

--- a/packages/docs/LICENSE
+++ b/packages/docs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Devtomic LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,0 +1,63 @@
+# marko/docs
+
+Documentation search contract for Marko — defines the interface for querying Marko documentation, with interchangeable driver implementations.
+
+## Overview
+
+`marko/docs` is the contract package that defines how Marko documentation is searched. It ships no search implementation — install a driver instead: `marko/docs-fts` for lightweight lexical search (SQLite FTS5) or `marko/docs-vec` for hybrid semantic + lexical search (FTS5 + sqlite-vec). Both drivers implement the same `DocsSearchInterface`, so switching is a one-line dependency change.
+
+## Installation
+
+Install a driver (which pulls in this package automatically):
+
+```bash
+# Lightweight lexical search
+composer require marko/docs-fts
+
+# Hybrid semantic + lexical search
+composer require marko/docs-vec
+```
+
+Or install the contract alone if you are building a custom driver:
+
+```bash
+composer require marko/docs
+```
+
+## Usage
+
+```php
+use Marko\Docs\Contract\DocsSearchInterface;
+use Marko\Docs\ValueObject\DocsQuery;
+
+class DocsController
+{
+    public function __construct(
+        private DocsSearchInterface $docs,
+    ) {}
+
+    public function search(string $term): array
+    {
+        return $this->docs->search(new DocsQuery($term, limit: 10));
+    }
+}
+```
+
+## Customization
+
+Implement `DocsSearchInterface` and register your implementation as a Preference:
+
+```php
+#[Preference(DocsSearchInterface::class)]
+class MyDocsSearch implements DocsSearchInterface
+{
+    public function search(DocsQuery $query): array { /* ... */ }
+    public function getPage(string $id): DocsPage { /* ... */ }
+    public function listNav(): array { /* ... */ }
+    public function driverName(): string { return 'custom'; }
+}
+```
+
+## Documentation
+
+Full driver comparison and API reference: [marko/docs](https://marko.build/docs/packages/docs/)

--- a/packages/docs/composer.json
+++ b/packages/docs/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "marko/docs",
+    "description": "Documentation search contract for Marko Framework",
+    "license": "MIT",
+    "type": "marko-module",
+    "require": {
+        "php": "^8.5",
+        "marko/core": "self.version"
+    },
+    "require-dev": {
+        "pestphp/pest": "^4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Marko\\Docs\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Marko\\Docs\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
+    "extra": {
+        "marko": {
+            "module": true
+        }
+    }
+}

--- a/packages/docs/module.php
+++ b/packages/docs/module.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'bindings' => [],
+    'singletons' => [],
+];

--- a/packages/docs/src/Contract/DocsSearchInterface.php
+++ b/packages/docs/src/Contract/DocsSearchInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Docs\Contract;
+
+use Marko\Docs\Exceptions\DocsException;
+use Marko\Docs\ValueObject\DocsNavEntry;
+use Marko\Docs\ValueObject\DocsPage;
+use Marko\Docs\ValueObject\DocsQuery;
+use Marko\Docs\ValueObject\DocsResult;
+
+interface DocsSearchInterface
+{
+    /**
+     * @return list<DocsResult>
+     *
+     * @throws DocsException
+     */
+    public function search(
+        DocsQuery $query,
+    ): array;
+
+    /**
+     * @throws DocsException
+     */
+    public function getPage(
+        string $id,
+    ): DocsPage;
+
+    /**
+     * @return list<DocsNavEntry>
+     *
+     * @throws DocsException
+     */
+    public function listNav(): array;
+
+    public function driverName(): string;
+}

--- a/packages/docs/src/Exceptions/DocsException.php
+++ b/packages/docs/src/Exceptions/DocsException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Docs\Exceptions;
+
+use Marko\Core\Exceptions\MarkoException;
+
+class DocsException extends MarkoException
+{
+    public static function pageNotFound(
+        string $id,
+    ): self {
+        return new self(
+            message: "Documentation page '$id' not found",
+            context: 'While retrieving docs page',
+            suggestion: 'Check the page ID is correct and a docs driver is installed',
+        );
+    }
+
+    public static function searchFailed(
+        string $reason,
+    ): self {
+        return new self(
+            message: "Documentation search failed: $reason",
+            context: 'While performing docs search',
+            suggestion: 'Ensure a docs driver is configured and the index has been built',
+        );
+    }
+}

--- a/packages/docs/src/ValueObject/DocsNavEntry.php
+++ b/packages/docs/src/ValueObject/DocsNavEntry.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Docs\ValueObject;
+
+readonly class DocsNavEntry
+{
+    public function __construct(
+        public string $id,
+        public string $title,
+        public string $path,
+        public int $depth = 0,
+    ) {}
+}

--- a/packages/docs/src/ValueObject/DocsPage.php
+++ b/packages/docs/src/ValueObject/DocsPage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Docs\ValueObject;
+
+readonly class DocsPage
+{
+    public function __construct(
+        public string $id,
+        public string $title,
+        public string $content,
+        public string $path,
+    ) {}
+}

--- a/packages/docs/src/ValueObject/DocsQuery.php
+++ b/packages/docs/src/ValueObject/DocsQuery.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Docs\ValueObject;
+
+readonly class DocsQuery
+{
+    public function __construct(
+        public string $query,
+        public int $limit = 10,
+    ) {}
+}

--- a/packages/docs/src/ValueObject/DocsResult.php
+++ b/packages/docs/src/ValueObject/DocsResult.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Docs\ValueObject;
+
+readonly class DocsResult
+{
+    public function __construct(
+        public string $pageId,
+        public string $title,
+        public string $excerpt,
+        public float $score,
+    ) {}
+}

--- a/packages/docs/tests/Pest.php
+++ b/packages/docs/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->in(__DIR__);

--- a/packages/docs/tests/Unit/PackageStructureTest.php
+++ b/packages/docs/tests/Unit/PackageStructureTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\Docs\Contract\DocsSearchInterface;
+use Marko\Docs\Exceptions\DocsException;
+use Marko\Docs\ValueObject\DocsNavEntry;
+use Marko\Docs\ValueObject\DocsPage;
+use Marko\Docs\ValueObject\DocsQuery;
+use Marko\Docs\ValueObject\DocsResult;
+
+it('has composer.json with name marko/docs and PSR-4 namespace Marko\\Docs\\', function (): void {
+    $composer = json_decode(
+        (string) file_get_contents(__DIR__ . '/../../composer.json'),
+        true,
+    );
+
+    expect($composer)->toBeArray()
+        ->and($composer['name'])->toBe('marko/docs')
+        ->and($composer['autoload']['psr-4'])->toHaveKey('Marko\\Docs\\')
+        ->and($composer['autoload']['psr-4']['Marko\\Docs\\'])->toBe('src/');
+});
+
+it('defines DocsSearchInterface with search query limit, getPage id, listNav methods', function (): void {
+    $reflection = new ReflectionClass(DocsSearchInterface::class);
+
+    expect($reflection->isInterface())->toBeTrue()
+        ->and($reflection->hasMethod('search'))->toBeTrue()
+        ->and($reflection->hasMethod('getPage'))->toBeTrue()
+        ->and($reflection->hasMethod('listNav'))->toBeTrue()
+        ->and($reflection->hasMethod('driverName'))->toBeTrue();
+
+    $search = $reflection->getMethod('search');
+    expect($search->getNumberOfParameters())->toBe(1)
+        ->and($search->getParameters()[0]->getType()?->getName())->toBe(DocsQuery::class);
+
+    $getPage = $reflection->getMethod('getPage');
+    expect($getPage->getParameters()[0]->getName())->toBe('id')
+        ->and($getPage->getParameters()[0]->getType()?->getName())->toBe('string');
+});
+
+it('defines readonly DocsQuery value object with query text and limit', function (): void {
+    $query = new DocsQuery(query: 'how to install', limit: 5);
+    $reflection = new ReflectionClass(DocsQuery::class);
+
+    expect($reflection->isReadOnly())->toBeTrue()
+        ->and($query->query)->toBe('how to install')
+        ->and($query->limit)->toBe(5)
+        ->and((new DocsQuery('x'))->limit)->toBe(10);
+});
+
+it('defines readonly DocsResult value object with pageId title excerpt score', function (): void {
+    $result = new DocsResult(
+        pageId: 'getting-started/installation',
+        title: 'Installation',
+        excerpt: 'How to install Marko...',
+        score: 0.92,
+    );
+    $reflection = new ReflectionClass(DocsResult::class);
+
+    expect($reflection->isReadOnly())->toBeTrue()
+        ->and($result->pageId)->toBe('getting-started/installation')
+        ->and($result->title)->toBe('Installation')
+        ->and($result->excerpt)->toBe('How to install Marko...')
+        ->and($result->score)->toBe(0.92);
+});
+
+it('defines readonly DocsPage value object with id title content path', function (): void {
+    $page = new DocsPage(
+        id: 'guides/routing',
+        title: 'Routing',
+        content: '# Routing\n\nMarko uses attribute-based routes.',
+        path: 'guides/routing.md',
+    );
+    $reflection = new ReflectionClass(DocsPage::class);
+
+    expect($reflection->isReadOnly())->toBeTrue()
+        ->and($page->id)->toBe('guides/routing')
+        ->and($page->title)->toBe('Routing')
+        ->and($page->path)->toBe('guides/routing.md');
+});
+
+it('defines DocsException with contextual error factories for page-not-found and search-failure', function (): void {
+    $notFound = DocsException::pageNotFound('missing/page');
+    $searchFailure = DocsException::searchFailed('database locked');
+
+    expect($notFound)->toBeInstanceOf(DocsException::class)
+        ->and($notFound->getMessage())->toContain('missing/page')
+        ->and($notFound->getContext())->not->toBeEmpty()
+        ->and($notFound->getSuggestion())->not->toBeEmpty()
+        ->and($searchFailure)->toBeInstanceOf(DocsException::class)
+        ->and($searchFailure->getMessage())->toContain('database locked');
+});
+
+it('has no runtime classes beyond value objects and interfaces', function (): void {
+    $srcDir = __DIR__ . '/../../src';
+    $allowedDirs = ['Contract', 'ValueObject', 'Exceptions'];
+
+    $items = array_filter(
+        scandir($srcDir) ?: [],
+        fn (string $entry): bool => $entry !== '.' && $entry !== '..',
+    );
+
+    foreach ($items as $item) {
+        expect($allowedDirs)->toContain($item);
+    }
+
+    expect(new DocsNavEntry(id: 'a', title: 'A', path: 'a'))->toBeInstanceOf(DocsNavEntry::class);
+});


### PR DESCRIPTION
Phase 4a of the #41 split. Adds `marko/docs` — the documentation-search **contract** package. Standard interface/driver split (like `marko/cache`): this ships only `DocsSearchInterface` + value objects; `marko/docs-fts` and `marko/docs-vec` implement it in a later phase.

## Contents
- `DocsSearchInterface` (`search(DocsQuery)`, `getPage`, `listNav`, `driverName`)
- Value objects: `DocsQuery`, `DocsResult`, `DocsPage`, `DocsNavEntry`
- `DocsException`

## End-user docs
- New `docs/src/content/docs/packages/docs.md` reference page (auto-sidebar)
- **Fixed README** usage/customization examples — they showed a stale `search(string $query, int $limit)` signature that doesn't exist; the real contract takes a `DocsQuery`. Now accurate.
- `architecture.md` "Documentation Search" inventory section
- Issue-template dropdown + root `composer.json` wiring

## Note on docs-markdown
`marko/docs-markdown` (the content package + Astro symlink migration) is a separate, meatier PR coming next — it migrates the live docs content into the package. Keeping the contract separate from that migration for cleaner review.

## Verification
- ✅ docs suite: 7 passed
- ✅ Full suite: **5780 passed**, 0 failed
- ✅ Docs build: 119 pages incl. `/packages/docs/`
- ✅ phpcs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)