### PR TITLE
docs: widen sidebar + fix Claude Code install method + clarify MCP verification

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -38,6 +38,11 @@
   --sl-color-accent: #3498db;
   --sl-color-accent-high: #7ec8e3;
 
+  /* Left sidebar width (Starlight default is 18.75rem). Starlight derives the
+     whole page layout from this single variable, so overriding it here is the
+     only change needed — content width (--sl-content-width) is independent. */
+  --sl-sidebar-width: 19.75rem;
+
   --sl-color-white: #fcfcfc;
   --sl-color-gray-1: #e8e8e8;
   --sl-color-gray-2: #bcbcbc;

--- a/packages/docs-markdown/docs/ai-assisted-development/agents/claude-code.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/agents/claude-code.md
@@ -7,8 +7,14 @@ description: Set up Marko's AI tooling with Anthropic Claude Code — CLAUDE.md 
 
 ## Prerequisites
 
-- Claude Code installed: `npm install -g @anthropic-ai/claude-code`
-- Authenticated: `claude auth login`
+- **Claude Code installed.** The recommended method is the native installer (no Node.js required, auto-updates in the background):
+
+  ```bash
+  curl -fsSL https://claude.ai/install.sh | bash
+  ```
+
+  This covers macOS, Linux, and WSL; see the [Claude Code setup docs](https://docs.claude.com/en/docs/claude-code/setup) for Windows and other options. The legacy `npm install -g @anthropic-ai/claude-code` still works, but the native installer is now the preferred path.
+- **Authenticated.** Run `claude` in your terminal and complete the browser sign-in on first launch (there is no separate `auth login` command — use `/login` inside a session to switch or manage credentials). Run `claude doctor` to confirm the installation type.
 - `marko/devai` installed (see [Installation](../installation/))
 
 ## What devai:install writes
@@ -29,12 +35,13 @@ The installer writes merged Marko guidelines to `AGENTS.md`. The `CLAUDE.md` fil
 
 `devai:install` writes (or merges into) `.claude/settings.json` with two keys:
 
-- `extraKnownMarketplaces.marko` — registers the Marko plugin marketplace so Claude Code can fetch plugin metadata
-- `enabledPlugins` — activates `marko-skills@marko`, `marko-lsp@marko`, and `marko-mcp@marko`
+- `extraKnownMarketplaces.marko` — registers the Marko plugin marketplace so Claude Code can fetch plugin metadata.
 
-When run inside the Marko monorepo the marketplace source points to the local `packages/claude-plugins/plugins` path; for external projects it points to the `marko-php/marko` GitHub repo.
+  This is a named entry under Claude Code's `extraKnownMarketplaces` map. Its `source` tells Claude Code where to read the marketplace manifest (`.claude-plugin/marketplace.json`) from: when run inside the Marko monorepo the source is the local `packages/claude-plugins/plugins` path, and for external projects it is the `marko-php/marko` GitHub repo. Registering the marketplace does not install anything on its own — it only makes the `@marko` plugins discoverable.
 
-On first trust of the project folder, Claude Code fetches and installs the three plugins automatically.
+- `enabledPlugins` — activates `marko-skills@marko`, `marko-lsp@marko`, and `marko-mcp@marko`.
+
+  Each entry is a `plugin@marketplace` key set to `true`. Listing a plugin here tells Claude Code to install it from the registered marketplace and keep it enabled. On first trust of the project folder, Claude Code reads these entries and fetches the three plugins automatically — wiring the MCP server, the LSP server, and the scaffolding skills in a single step. `devai:install` only ever adds or replaces the `*@marko` entries, so any other plugins you have enabled are preserved.
 
 ### Plugins
 

--- a/packages/docs-markdown/docs/ai-assisted-development/verification-checklist.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/verification-checklist.md
@@ -26,7 +26,8 @@ Choose one agent and verify its guidelines file:
 **Claude Code:**
 - [ ] `CLAUDE.md` exists in the project root and references `@AGENTS.md`
 - [ ] `AGENTS.md` exists in the project root and includes a `## Package Guidelines` section
-- [ ] `claude mcp list` includes the `marko-mcp` server
+- [ ] `.claude/settings.json` registers `extraKnownMarketplaces.marko` and enables the `marko-mcp@marko` plugin
+- [ ] In Claude Code, run `/mcp` — the `marko-mcp` server appears (it is provided by the `marko-mcp@marko` plugin, not by `claude mcp add`)
 
 **Codex:**
 - [ ] `AGENTS.md` exists in the project root


### PR DESCRIPTION
Small docs/CSS follow-ups after the `marko/devai` landing.

## Changes

**Sidebar width** — `docs/src/styles/custom.css` overrides Starlight's `--sl-sidebar-width` from the default `18.75rem` to `19.75rem`. Starlight derives the whole layout from this single variable (`--sl-content-width` is independent, and the print stylesheet keeps its own `0px` override), so no other change is needed.

**Claude Code install method** — `ai-assisted-development/agents/claude-code.md` was telling users to install via `npm install -g @anthropic-ai/claude-code` and authenticate with `claude auth login`. Both are stale:
- The current recommended method is the **native installer**: `curl -fsSL https://claude.ai/install.sh | bash` (npm still works but is no longer preferred; the native install auto-updates). Source: [Claude Code setup docs](https://docs.claude.com/en/docs/claude-code/setup).
- There is **no `claude auth login`** command — first run opens a browser sign-in; `/login` manages credentials in-session. `claude doctor` verifies the install.

**`.claude/settings.json` explanation** — expanded the two key bullets (`extraKnownMarketplaces.marko`, `enabledPlugins`) with what each key is, the local-vs-GitHub `source` shapes, and how Claude Code consumes them on folder-trust (and that devai only touches `*@marko` entries).

**Verification checklist** — Claude Code's MCP server comes from the `marko-mcp@marko` **plugin**, not `claude mcp add` (the agent actively removes legacy `claude mcp` registrations). Changed the check from `claude mcp list` to `.claude/settings.json` + `/mcp`.

## Verification

- `cd docs && npm run build` → 140 pages, clean.
- `composer test` (docs-markdown) → 12 passed.

> Context: this is also the point at which I functionally verified the servers end-to-end (booted `mcp:serve` and confirmed `list_modules` / `find_event_observers` return correct results; booted `lsp:serve` and confirmed a real config-key completion round-trip). The doc fixes above came out of that exercise.