### PR TITLE
fix: raise memory_limit in composer test scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -490,8 +490,8 @@
         "squizlabs/php_codesniffer": "^4.0"
     },
     "scripts": {
-        "test": "pest -c phpunit.xml --parallel --exclude-group=integration-destructive",
-        "test:all": "pest -c phpunit.xml --parallel",
+        "test": "php -d memory_limit=2G vendor/bin/pest -c phpunit.xml --parallel --exclude-group=integration-destructive",
+        "test:all": "php -d memory_limit=2G vendor/bin/pest -c phpunit.xml --parallel",
         "cs:check": "phpcs --standard=phpcs.xml",
         "cs:fix": [
             "php-cs-fixer fix --config=.php-cs-fixer.php",


### PR DESCRIPTION
## Summary
- `composer test` and `composer test:all` were dying with `Allowed memory size of 134217728 bytes exhausted` on default PHP installs (CLI `memory_limit=128M`) before any test could run — Pest's parallel discovery across 90+ Marko packages exceeds that limit during paratest's `SuiteLoader` phase.
- Wrap both scripts with `php -d memory_limit=2G vendor/bin/pest …` so they work out of the box without requiring users to bump their global `php.ini`.

## Test plan
- [x] `composer test` runs to completion: 6138 passed, 36 risky, 145 notices, 22 skipped (18913 assertions, ~5s parallel).
- [ ] Confirm CI still picks up the same invocation path (CI typically sets its own memory_limit, so this is a no-op there but a quality-of-life win locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)