### PR TITLE
fix: raise memory_limit in release.sh test invocation

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -60,7 +60,7 @@ echo "  ✓ Tag ${TAG} available"
 echo ""
 echo "Running test suite (including integration-destructive group to verify clean install)..."
 
-"$PHP_BIN" vendor/bin/pest --parallel || {
+"$PHP_BIN" -d memory_limit=2G vendor/bin/pest --parallel || {
     echo ""
     echo "Error: Tests failed. Fix failing tests before releasing."
     exit 1


### PR DESCRIPTION
## Summary
- `bin/release.sh` invokes pest directly (not through `composer test`) to include the `integration-destructive` group, so the memory_limit fix from #107 didn't apply here.
- Default PHP CLI `memory_limit=128M` is exhausted during paratest's parallel suite loader, killing the release before any test runs.
- Mirror the composer-script fix by passing `-d memory_limit=2G` to the pest invocation in the release script.

## Test plan
- [ ] `./bin/release.sh <version>` reaches the test phase without "Allowed memory size … exhausted".

🤖 Generated with [Claude Code](https://claude.com/claude-code)