### PR TITLE
fix: raise memory_limit in IntegrationVerificationTest pest subprocesses

### DIFF
--- a/tests/IntegrationVerificationTest.php
+++ b/tests/IntegrationVerificationTest.php
@@ -106,7 +106,7 @@ $results['composer_update_output'] = implode("\n", array_slice($updateOutput, -5
 
 // Step 3: Run test suite (exclude destructive group to avoid recursion)
 exec(
-    'cd ' . escapeshellarg($root) . ' && ' . $php . ' vendor/bin/pest --parallel --exclude-group=integration-destructive 2>&1',
+    'cd ' . escapeshellarg($root) . ' && ' . $php . ' -d memory_limit=2G vendor/bin/pest --parallel --exclude-group=integration-destructive 2>&1',
     $testOutput,
     $testExit,
 );
@@ -159,7 +159,7 @@ it('runs the full test suite and all tests pass', function () use ($root): void 
     exec(
         'cd ' . escapeshellarg(
             $root
-        ) . ' && ' . $php . ' vendor/bin/pest --parallel --exclude-group=integration-destructive 2>&1',
+        ) . ' && ' . $php . ' -d memory_limit=2G vendor/bin/pest --parallel --exclude-group=integration-destructive 2>&1',
         $output,
         $exitCode,
     );


### PR DESCRIPTION
## Summary
- `IntegrationVerificationTest` spawns pest as a subprocess via `exec()` to verify the suite still runs after a destructive `composer update` and to assert the captured output contains no fatal PHP errors.
- Those subprocesses inherited the default CLI `memory_limit=128M`, so paratest's parallel suite loader ran out of memory mid-run. The `not->toContain('PHP Fatal error')` assertion at `tests/IntegrationVerificationTest.php:171` then failed the release.
- Pass `-d memory_limit=2G` to both pest invocations (lines 109 and 162), completing the trio with #107 (composer scripts) and #108 (release.sh).

## Test plan
- [x] Locally: `php -d memory_limit=2G vendor/bin/pest --filter "runs the full test suite and all tests pass"` → passes in ~6s.
- [ ] `./bin/release.sh <version>` clears the test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)