### PR TITLE
ci: bump actions/checkout to v6 in readme drift check

### DIFF
--- a/.github/workflows/readme-package-check.yml
+++ b/.github/workflows/readme-package-check.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run drift check
         run: bin/check-readme-packages.sh


### PR DESCRIPTION
## Summary

Quick follow-up to #111. The new `readme-package-check.yml` workflow used `actions/checkout@v4` (Node 20, deprecation warning), while every other workflow in this repo (`deploy-docs`, `split`, `sync-issue-templates`) already uses `@v6` (Node 24). Bringing the new workflow in line.

## Test plan

- [ ] CI run completes without the Node 20 deprecation warning