### PR TITLE
docs: fold remaining audit findings into remediation plans

### DIFF
--- a/.claude/plans/tier2-high-correctness/013-docsvec-hybrid-search-fusion-crash-and-fts5-exception-leak.md
+++ b/.claude/plans/tier2-high-correctness/013-docsvec-hybrid-search-fusion-crash-and-fts5-exception-leak.md
@@ -1,0 +1,119 @@
+# Task 013: F10 — docs-vec hybrid search crashes on FTS hits + leaks raw PDOException
+
+**Status**: pending
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+`VecSearch::search()` (the only `DocsSearchInterface` driver that does hybrid
+FTS5 + vector RRF fusion) has two distinct correctness defects in the same
+method:
+
+1. **Fusion crashes on every FTS hit.** In the RRF fusion loop, the FTS branch
+   writes the score directly onto the bucket key — `$fused[$key] = (float
+   expr)` — and the next line does `$fused[$key]['chunk'] = $chunk`, attempting
+   to write an array offset onto a `float`. Any query that returns ≥1 FTS
+   candidate aborts. (PHP raises "Cannot use a scalar value as an array" and,
+   even where coerced, the `['chunk']` key is never set, so the downstream
+   `$entry['chunk']` access fails regardless.) The adjacent vec branch is the
+   correct shape and the FTS branch must mirror it: write `['score']` onto the
+   bucket and set `['chunk']`. Because virtually every real query produces at
+   least one FTS hit, hybrid search is effectively always broken — it was never
+   caught because the existing `search()` tests are all gated on
+   `isSqliteVecAvailable()` and skip in CI, so the FTS-only path through
+   `search()` is never exercised.
+
+2. **Malformed FTS5 MATCH leaks a raw `PDOException`.** User search text is
+   bound as a parameter (no SQL injection) but is parsed by SQLite's FTS5 MATCH
+   grammar at query time. A lone `"`, a trailing `NEAR/`, or an unknown
+   `column:` prefix raises an `fts5: syntax error` as a raw `PDOException`.
+   `SearchDocsTool::handle()` catches ONLY `DocsException`, so the raw exception
+   escapes the tool (and a web route would 500 and leak the SQLite error). The
+   FTS5 query execution must be wrapped and converted to the documented
+   `DocsException::searchFailed(...)`.
+
+## Context
+- **Gap-audit follow-up.** docs-vec was missed by the original Tier 2 sweep
+  (F1–F9 covered core, errors, discovery, queue, mail, and database drivers);
+  this is the docs search driver. New finding F10.
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/docs-vec/src/VecSearch.php`
+    - `search()` (~44-95): the RRF fusion loops.
+      - FTS branch (~63-67) is the BUG:
+        `$fused[$key] = ($fused[$key]['score'] ?? 0.0) + 1.0 / (self::RRF_K + $rank + 1);`
+        then `$fused[$key]['chunk'] = $chunk;` — array offset onto a float.
+      - Vec branch (~69-73) is the CORRECT shape to mirror:
+        `$fused[$key]['score'] = ($fused[$key]['score'] ?? 0.0) + ...;`
+        then `$fused[$key]['chunk'] ??= $chunk;`. Note the `??=` so an
+        FTS-set chunk is not clobbered; the FTS branch should set `['chunk']`
+        with `=` (it runs first) or `??=` (equivalent on first write).
+    - `ftsSearch()` (~100-119): builds the `WHERE docs_fts MATCH :q` statement,
+      binds `:q` (value-bound — not the issue), then `$stmt->execute()` (~116)
+      and `$stmt->fetchAll()` (~118) — this is where a malformed MATCH raises
+      `PDOException`. Wrap the execute/fetch path and convert to
+      `DocsException::searchFailed(...)`.
+  - `/Users/markshust/Sites/marko/packages/docs/src/Exceptions/DocsException.php`
+    — factory is `DocsException::searchFailed(string $reason): self`
+    (VERIFIED: single `$reason` parameter). Reuse it; do NOT add a new factory
+    unless a more specific one is warranted (prefer reusing `searchFailed`).
+  - `/Users/markshust/Sites/marko/packages/mcp/src/Tools/SearchDocsTool.php`
+    — `handle()` catches ONLY `DocsException` (VERIFIED ~55); proves the raw
+    `PDOException` currently escapes and a route would 500.
+  - `/Users/markshust/Sites/marko/packages/docs/src/ValueObject/DocsQuery.php`
+    — `readonly` with `public string $query, public int $limit = 10`.
+  - `/Users/markshust/Sites/marko/packages/docs/src/ValueObject/DocsResult.php`
+    — `readonly` with `pageId, title, excerpt, score`.
+- **Test infrastructure to follow (VERIFIED).**
+  `/Users/markshust/Sites/marko/packages/docs-vec/tests/Unit/VecSearchTest.php`
+  already has two file-level helpers:
+  - `buildTestIndex(VecRuntime $runtime): array` → returns `[$search, $tempDir]`,
+    building a real temp-dir SQLite index. It uses `HybridIndexBuilder` when a
+    model is available, else falls back to `buildFtsOnlyIndex(...)`.
+  - `buildFtsOnlyIndex(VecRuntime, MarkdownRepository, string $indexPath): void`
+    — builds a real FTS5 (`docs_fts`) + `docs_meta` schema with NO vec table and
+    NO embedding model. `VecRuntime::isModelAvailable()` gates whether vec
+    results are produced.
+  **Critical for these tests:** the existing `search()` tests are skipped via
+  `->skip(fn () => ! (new VecRuntime(...))->isSqliteVecAvailable(), ...)`, which
+  is exactly why the FTS-fusion crash was never caught. The NEW tests for this
+  task MUST exercise the FTS-only path and MUST NOT be gated on
+  `isSqliteVecAvailable()` — they should build an FTS-only index (or use a
+  small in-process `:memory:`/temp FTS5 fixture) so they run deterministically
+  in `composer test` even with no sqlite-vec extension and no model. This is the
+  whole point: prove the FTS path through `search()` works.
+- Patterns to follow:
+  - Fix the FTS branch to mirror the vec branch exactly: accumulate into
+    `$fused[$key]['score']` and set `$fused[$key]['chunk']`. Do NOT change the
+    RRF formula (`1.0 / (RRF_K + rank + 1)`) or the `uasort`/`array_slice` top-N
+    logic — only the bucket assignment shape.
+  - Wrap ONLY the FTS5 MATCH execution (`execute()`/`fetchAll()` in
+    `ftsSearch()`, or the call site) in `try { ... } catch (PDOException $e) {
+    throw DocsException::searchFailed(...); }`. The `@throws DocsException` tag
+    on `search()` already documents this; add/confirm `@throws DocsException` on
+    `ftsSearch()` if the catch lives there. Import `PDOException` with a `use`
+    statement (no inline FQCN).
+  - Loud error: the converted exception message must include the FTS5 parse
+    reason (e.g. `$e->getMessage()`) so the failure is diagnosable, per the
+    loud-errors principle.
+  - Do NOT broaden the catch to `Throwable` (that would swallow the index-open
+    `DocsException` re-throw and other legitimate failures) — catch
+    `PDOException` specifically.
+
+## Requirements (Test Descriptions)
+- [ ] `it returns ranked DocsResult objects for a query that produces one or more FTS hits without erroring`
+- [ ] `it combines FTS and vector RRF scores into a single bucket and sets the chunk for an FTS-only entry`
+- [ ] `it still searches successfully on the FTS-only path when no embedding model is available`
+- [ ] `it throws DocsException not PDOException when the search text is a malformed FTS5 MATCH expression`
+- [ ] `it includes the underlying FTS5 parse reason in the DocsException message`
+- [ ] `it returns an empty list for a valid query that matches no documents`
+- [ ] `it preserves the existing DocsException when the index file is missing (does not convert it twice)`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- The new FTS-path tests run (not skip) under `composer test` without sqlite-vec
+- A malformed FTS5 MATCH surfaces as `DocsException`, caught by `SearchDocsTool`
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier2-high-correctness/_plan.md
+++ b/.claude/plans/tier2-high-correctness/_plan.md
@@ -19,6 +19,15 @@ none
 ## Discovery Notes
 - **New plan.** No existing `tier2-high-correctness` task files; the directory was
   empty at authoring time.
+- **Task 013 is a gap-audit follow-up (F10).** The original Tier 2 sweep (F1–F9)
+  missed `marko/docs-vec`, the hybrid FTS5 + vector docs search driver. A later
+  audit found `VecSearch::search()` crashes on every query that returns an FTS hit
+  (an array offset is written onto a float in the RRF fusion loop) and leaks a raw
+  `PDOException` to callers on malformed FTS5 MATCH text (`SearchDocsTool` catches
+  only `DocsException`). It was never caught because the existing `search()` tests
+  all `->skip` when sqlite-vec is unavailable, so the FTS path is never exercised
+  in CI. Task 013 fixes both in the single file and adds FTS-only-path tests that
+  are NOT gated on sqlite-vec.
 - **F1 supersedes the deferred slice of `plugin-interceptor-proxy-fix`.** That plan
   is fully `completed` (tasks 001–008), and its interface-wrapper strategy works
   (the wrapper calls `new $className()` then `initInterception($target, ...)`, so
@@ -76,6 +85,8 @@ none
 - F8: read/write `transaction()` sticky-write, write-statement routing to primary,
   replica-selection safety after fallback removal.
 - F9: PostgreSQL-correct `insertBatch()` primary-key assignment via `RETURNING`.
+- F10: docs-vec hybrid search — fix the RRF fusion crash on FTS hits and convert
+  malformed-FTS5-MATCH `PDOException` to `DocsException`.
 
 ### Out of Scope
 - The interface-wrapper strategy, plugin registry, trait, and container wiring already
@@ -106,6 +117,9 @@ none
 - [ ] Writes inside `transaction()` and `INSERT ... RETURNING` route to the primary;
       replica selection never indexes a removed replica.
 - [ ] `insertBatch()` assigns each entity its true DB id on both mysql and pgsql.
+- [ ] docs-vec hybrid search returns ranked results for any query that produces an
+      FTS hit (no crash), and a malformed FTS5 MATCH surfaces as a `DocsException`
+      (caught by `SearchDocsTool`) rather than a raw `PDOException`.
 - [ ] All tests passing
 - [ ] Code follows project standards
 
@@ -124,13 +138,14 @@ none
 | 010 | F7a: concrete StreamSocket implements SocketInterface (mail-smtp) | - | pending |
 | 011 | F7b: factory connect→EHLO→STARTTLS(220)→AUTH(case-insensitive) sequence + SmtpConfig defaults removal + module binding (mail-smtp) | 010 | pending |
 | 012 | F7c: DATA dot-stuffing + multi-recipient correctness (mail-smtp) | 011 | pending |
+| 013 | F10: docs-vec RRF fusion crash fix + malformed-FTS5-MATCH PDOException→DocsException (docs-vec) | - | pending |
 
 Parallel batches (each task is a distinct file-cluster; 008 and 005 now serialize
 after 009 because 009's `ConnectionInterface::driverName()` addition edits the same
 `ReadWriteConnection.php` / queue-database + readwrite test-stub files those tasks touch,
 and the abstract-method addition must land first or the suites fail to load):
 ```
-Batch 1: 001  002  003  004  009  010
+Batch 1: 001  002  003  004  009  010  013
 Batch 2: 005 (←004,009)   006 (←004)   008 (←009)   011 (←010)
 Batch 3: 007 (←006)   012 (←011)
 ```

--- a/.claude/plans/tier3-medium-fixes/013-docs-markdown-path-traversal.md
+++ b/.claude/plans/tier3-medium-fixes/013-docs-markdown-path-traversal.md
@@ -1,0 +1,35 @@
+# Task 013: docs-markdown rejects path-traversal page IDs
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`MarkdownRepository::getRawMarkdown(string $id)` builds the file path by concatenating the configured docs path with the caller-supplied `$id` and a `.md` suffix, with NO containment check. A `../`-laden id (e.g. `../../../../etc/passwd%00` style, or simply `../../composer`) resolves outside the docs directory and reads any `.md` file on disk — a path-traversal / arbitrary-file-read defect. Harden it: resolve the candidate path with `realpath()` and verify it stays under `realpath($docsPath)` before reading; reject loudly with a `DocsMarkdownException`.
+
+## Context
+- Related files:
+  - `packages/docs-markdown/src/MarkdownRepository.php` (`getRawMarkdown` lines 43-53 — builds `$this->docsPath . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $id) . '.md'` at line 46, `file_exists` guard at 48-50, read at 52; `listAllPages` 24-41 is unaffected)
+  - `packages/docs-markdown/src/Exceptions/DocsMarkdownException.php` (single factory `pageNotFound(string $id, string $docsPath)` — add a new traversal factory here, mirroring its message/context/suggestion shape)
+- Patterns to follow:
+  - Loud errors: add a static factory `DocsMarkdownException::pathTraversal(string $id, string $docsPath)` (or similarly named) with `message`/`context`/`suggestion` naming the rejected id and the docs root. Do NOT silently fall back to `pageNotFound` for traversal — the failure mode must be distinct and explicit.
+  - Containment check: `realpath()` the resolved candidate, `realpath()` the docs root, and confirm the resolved candidate is the root itself or begins with `root . DIRECTORY_SEPARATOR`. `realpath()` returns `false` for a nonexistent path — preserve the existing not-found behavior for legitimate-but-missing ids (they must still throw `pageNotFound`, NOT the traversal exception). Decide order carefully: a `../`-containing id that resolves to a real file outside the root must hit the traversal path; a clean id pointing at a missing file must hit `pageNotFound`.
+  - `@throws DocsMarkdownException` already documented on the method — keep it (it now covers both factories).
+
+### Verification note (read at planning time)
+Confirmed against source: line 46 concatenation has no `realpath`/containment; `file_exists` (48) is the only guard. `DocsMarkdownException` currently has exactly one factory (`pageNotFound`). Namespace `Marko\DocsMarkdown`; package `marko/docs-markdown`.
+
+## Requirements (Test Descriptions)
+- [ ] `it reads markdown for a legitimate page id`
+- [ ] `it throws DocsMarkdownException for an id containing path-traversal segments`
+- [ ] `it does not read a .md file outside the docs directory via a traversal id`
+- [ ] `it still throws pageNotFound for a clean id that does not exist`
+- [ ] `it populates message, context, and suggestion on the traversal exception`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier3-medium-fixes/014-devai-proc-open-deadlock.md
+++ b/.claude/plans/tier3-medium-fixes/014-devai-proc-open-deadlock.md
@@ -1,0 +1,38 @@
+# Task 014: devai CommandRunner drains stdout and stderr concurrently (no pipe deadlock)
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`CommandRunner::run()` opens a child process with separate stdout/stderr pipes and drains them sequentially: it fully reads stdout (`stream_get_contents($pipes[1])`), closes it, THEN reads stderr. A child that fills its stderr OS pipe buffer (~64KB; common for npm/build tooling) blocks on its `write()` to stderr before its stdout closes — meanwhile the parent is blocked reading stdout — producing a classic pipe deadlock where neither side makes progress. Drain both pipes concurrently (non-blocking reads driven by `stream_select`, or redirect stderr to a temp file) so a large stderr volume never deadlocks. Preserve the current return contract.
+
+## Context
+- Related files:
+  - `packages/devai/src/Process/CommandRunner.php` (`run()` lines 13-32 — `proc_open` with descriptor spec `[1 => ['pipe','w'], 2 => ['pipe','w']]` at 19, sequential drain at 25-28, `proc_close` at 29, return shape `array{exitCode:int, stdout:string, stderr:string}`; `isOnPath()` 34-39 calls `run()` and must keep working)
+  - `packages/devai/src/Process/CommandRunnerInterface.php` (the contract — `run()` return shape must not change)
+- Patterns to follow:
+  - Keep the exact return shape `['exitCode' => int, 'stdout' => string, 'stderr' => string]` and the existing `!is_resource($proc)` early return (`['exitCode' => -1, ...]`).
+  - Concurrent drain: set both pipes non-blocking (`stream_set_blocking($pipe, false)`) and loop on `stream_select()` accumulating from whichever pipe is readable until both reach EOF; OR redirect stderr to a temp file via the descriptor spec (`2 => ['file', $tmp, 'w']`) and read it after `proc_close`. Either is acceptable — pick one and keep it simple.
+  - Exit code must still come from `proc_close()` and be returned unchanged.
+  - This package has only `DevAiInstallException`; no new exception is needed — `run()` reports failure through the return array, not a throw. Do not add a throw to the happy/large-output path.
+
+### Verification note (read at planning time)
+Confirmed against source: lines 25-28 drain stdout fully, `fclose`, then stderr — sequential. Real deadlock is timing/buffer-size dependent, so the regression test must deterministically force a >64KB stderr write while stdout is also produced.
+
+### Testing note
+A genuine deadlock is hard to assert directly. Drive it with a tiny inline `sh`/`php` child that writes well over 64KB to stderr (and some bytes to stdout), invoked through `run()`, asserting the call returns (does not hang) with both streams captured and the exit code preserved. Wrap the hang-detection with a bounded timeout so a regression fails loudly rather than blocking the suite. If the child-script approach proves environment-fragile, mark the large-stderr case `->group('integration')` and keep the captured-output + exit-code assertions as plain unit tests against a small command.
+
+## Requirements (Test Descriptions)
+- [ ] `it captures both stdout and stderr from a command`
+- [ ] `it preserves the child process exit code`
+- [ ] `it completes without hanging when the child writes more than 64KB to stderr`
+- [ ] `it returns the proc_open failure shape when the process cannot start`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier3-medium-fixes/015-amphp-functional-pubsub-listener.md
+++ b/.claude/plans/tier3-medium-fixes/015-amphp-functional-pubsub-listener.md
@@ -1,0 +1,49 @@
+# Task 015: amphp pubsub:listen becomes a functional listener with graceful shutdown
+
+**Status**: pending
+**Depends on**: [016]
+**Retry count**: 0
+
+## Description
+`pubsub:listen` is currently pseudo-functionality. `PubSubListenCommand::execute()` prints "Starting..." then calls `EventLoopRunner::run()`, which runs an EMPTY `Revolt\EventLoop` (`EventLoop::run()` with nothing registered) and returns immediately — no subscription, no dispatch, no signal handling. The `amphp.shutdown_timeout` config and `AmphpConfig::shutdownTimeout()` are dead code (never consulted), and there is no SIGINT handler despite the "Press Ctrl+C to stop" prompt.
+
+DEFAULT APPROACH — implement a real listener: subscribe via the pubsub `SubscriberInterface` driver to the configured channel(s), register the resulting `Subscription`'s message stream on the amphp `EventLoop`, dispatch each received `Message`, and install a real SIGINT/graceful-shutdown path that uses the `shutdown_timeout` config to bound how long in-flight work may finish before the loop is stopped.
+
+## Context
+- Related files:
+  - `packages/amphp/src/Command/PubSubListenCommand.php` (lines 13-33 — `#[Command(name: 'pubsub:listen')]`, `execute()` writes two lines, calls `$this->runner->run()`, writes "Listener stopped.")
+  - `packages/amphp/src/EventLoopRunner.php` (lines 9-43 — `run()`/`stop()`/`isRunning()` flag plumbing; `doRun()` = `EventLoop::run()`, `doStop()` = `EventLoop::getDriver()->stop()`)
+  - `packages/amphp/src/AmphpConfig.php` (`shutdownTimeout(): int` → `config->getInt('amphp.shutdown_timeout')`)
+  - `packages/amphp/config/amphp.php` (`'shutdown_timeout' => (int) ($_ENV['AMPHP_SHUTDOWN_TIMEOUT'] ?? 30)`)
+  - `packages/amphp/module.php` (binding/registration — wire the new dependencies here)
+  - pubsub contract: `packages/pubsub/src/SubscriberInterface.php` (`subscribe(string ...$channels): Subscription`), `packages/pubsub/src/Subscription.php` (`IteratorAggregate<int, Message>`, `getIterator(): Generator`, `cancel(): void`), `packages/pubsub/src/Message.php`
+  - `packages/amphp/src/Exceptions/AmphpException.php` (currently `extends MarkoException` with no factories — add factories for any new loud-error path, e.g. no channels configured)
+- Patterns to follow:
+  - Constructor inject `SubscriberInterface`, `AmphpConfig`, and the configured channel list (channels come from a `config/*.php` getter — no hardcoded channel names in code).
+  - Use `EventLoop::queue()`/`EventLoop::onSignal(SIGINT, ...)` (Revolt) to register the subscription consumer and the shutdown handler. On signal, call the subscription's `cancel()` and stop the loop within `shutdownTimeout()` seconds.
+  - Dispatch each `Message`: emit to the framework's event/dispatch seam or invoke a configured handler — surface the received message in a way the test can assert. Keep the dispatch target explicit (constructor-injected), not a service-locator lookup.
+  - Loud errors: if no channels are configured, throw an `AmphpException` factory (message/context/suggestion) rather than silently running an idle loop.
+
+### DEPENDS ON Task 016
+This task subscribes through the pubsub driver and relies on `subscribe('a','b', ...)` actually registering ALL channels. Task 016 fixes the redis/pgsql drivers that currently drop all-but-the-first channel and serialize pgsql delivery. Build/rebase 015 on top of 016 so the functional listener exercises a correct multi-channel `Subscription`.
+
+### Implementation note — ALTERNATIVE (product decision, confirm with maintainer)
+If a functional async listener is out of scope at implementation time, the no-pseudo-functionality principle says do NOT ship an empty loop: instead REMOVE the `pubsub:listen` command, `EventLoopRunner`, and the dead `amphp.shutdown_timeout` config + `AmphpConfig::shutdownTimeout()`. This is a product decision and MUST be confirmed with the maintainer before choosing the removal path over the implementation path. The plan flags this in Risks & Notes.
+
+### Verification note (read at planning time)
+Confirmed: `EventLoopRunner::doRun()` calls `EventLoop::run()` with nothing registered; `PubSubListenCommand` never touches `AmphpConfig` or any subscriber; no `onSignal` anywhere in the package. `shutdownTimeout()` and its config key have no callers.
+
+## Requirements (Test Descriptions)
+- [ ] `it subscribes to the configured pub/sub channels`
+- [ ] `it dispatches a received message to the configured handler`
+- [ ] `it throws AmphpException when no channels are configured`
+- [ ] `it stops the listener on shutdown signal`
+- [ ] `it bounds graceful shutdown by the configured shutdown_timeout`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier3-medium-fixes/016-pubsub-multi-channel-subscribe.md
+++ b/.claude/plans/tier3-medium-fixes/016-pubsub-multi-channel-subscribe.md
@@ -1,0 +1,49 @@
+# Task 016: pubsub drivers honor multi-channel subscriptions (redis + pgsql)
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+The pubsub `Subscription` contract is a single object that multiplexes ALL subscribed channels into one message stream — that contract is correct. Both shipped drivers break it:
+
+- **redis** (`RedisSubscriber`): `subscribe(string ...$channels)` uses only `$channels[0]` (line 24) and `psubscribe(string ...$patterns)` uses only `$patterns[0]` (line 35) — every channel/pattern after the first is silently dropped.
+- **pgsql** (`PgSqlSubscription`): `subscribe()` correctly opens a `PostgresListener` per channel, but `getIterator()` (lines 22-30) iterates the listeners SEQUENTIALLY (`foreach ($this->listeners as $listener) { foreach ($listener as $notification) {...} }`). The inner loop over listener 1 blocks forever, so notifications on later channels are never delivered.
+
+Fix both: redis subscribes to ALL channels (and ALL patterns) and multiplexes them into one `Subscription`; pgsql multiplexes its listeners concurrently/non-blocking so any channel's notification yields. The interface stays unchanged.
+
+## Context
+This is one task spanning two driver packages. They are independent files and may be implemented as two sub-clusters, but ship together because they fix the same contract violation and share the multi-channel test shape.
+
+- redis files:
+  - `packages/pubsub-redis/src/Driver/RedisSubscriber.php` (`subscribe` 19-28 — `$channels[0]` at 24; `psubscribe` 30-40 — `$patterns[0]` at 35; `createAmphpSubscriber()` returns `AmphpRedisSubscriberInterface`)
+  - `packages/pubsub-redis/src/Driver/RedisSubscription.php` (wraps a single `Amp\Redis\RedisSubscription`; channel-vs-pattern branch in `getIterator()`, `stripPrefix()`) — to carry multiple channels/patterns this likely needs to wrap multiple amphp subscriptions and multiplex them, or a sibling subscription type
+  - `packages/pubsub-redis/tests/Driver/RedisSubscriberTest.php`, `RedisSubscriptionTest.php` (existing test patterns to mirror)
+- pgsql files:
+  - `packages/pubsub-pgsql/src/Driver/PgSqlSubscription.php` (`getIterator()` 22-30 sequential nested foreach; `cancel()` 32-37; ctor takes `PostgresListener[] $listeners` + `string $prefix`)
+  - `packages/pubsub-pgsql/src/Driver/PgSqlSubscriber.php` (`subscribe()` 20-30 already builds a listener per channel — leave as is; `psubscribe()` already throws `PubSubException::patternSubscriptionNotSupported('pgsql')` — leave as is)
+  - `packages/pubsub-pgsql/tests/Driver/PgSqlSubscriptionTest.php`, `PgSqlSubscriberTest.php`
+- shared contract: `packages/pubsub/src/Subscription.php`, `packages/pubsub/src/SubscriberInterface.php`, `packages/pubsub/src/Message.php`
+- Patterns to follow:
+  - redis: loop ALL `$channels` (and ALL `$patterns`), subscribing each, and yield from whichever amphp subscription produces next. Keep prefix handling and the pattern-vs-channel `Message` shape (pattern messages carry `pattern:`).
+  - pgsql: multiplex listeners so the iterator yields the next notification from ANY listener (non-blocking poll / concurrent await) instead of fully draining listener 0 first. Preserve prefix stripping and `cancel()` unlistening all listeners.
+  - No interface changes; `subscribe()` / `psubscribe()` signatures stay `string ...$x`.
+
+### Verification note (read at planning time — drift corrected)
+- redis: confirmed `$channels[0]` (line 24) and `$patterns[0]` (line 35).
+- pgsql: confirmed sequential `getIterator()` nested foreach (22-30). DRIFT vs. the original finding: pgsql `psubscribe()` does NOT silently drop patterns — it already throws `PubSubException::patternSubscriptionNotSupported('pgsql')`. So the "psubscribe multiple patterns works" requirement applies to the REDIS driver only; the pgsql bug is purely the sequential multiplex in `getIterator()`. Requirements below reflect this.
+
+## Requirements (Test Descriptions)
+- [ ] `it subscribes a redis subscription to every requested channel`
+- [ ] `it delivers a redis message published to a non-first subscribed channel`
+- [ ] `it subscribes a redis pattern subscription to every requested pattern`
+- [ ] `it multiplexes pgsql listeners so a non-first channel notification is delivered`
+- [ ] `it does not block pgsql delivery on the first listener`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier3-medium-fixes/017-mysql-offset-without-limit.md
+++ b/.claude/plans/tier3-medium-fixes/017-mysql-offset-without-limit.md
@@ -1,0 +1,35 @@
+# Task 017: MySQL query builder emits valid SQL for offset without limit
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`MySqlQueryBuilder::buildLimitOffsetClause()` appends ` OFFSET n` whenever an offset is set, independent of whether a limit is set. MySQL has no standalone `OFFSET` clause — `... OFFSET 10` with no preceding `LIMIT` is a syntax error. (The pgsql builder accepts a bare `OFFSET`, so this is MySQL-specific.) Fix: when an offset is set without a limit, emit the MySQL idiom (`LIMIT 18446744073709551615 OFFSET n`) or otherwise valid SQL. `limit + offset` together must stay unchanged.
+
+## Context
+- Related files:
+  - `packages/database-mysql/src/Query/MySqlQueryBuilder.php` (`buildLimitOffsetClause()` lines 943-956 — `' LIMIT ' . $this->limitValue` when `limitValue !== null` at 947-949; `' OFFSET ' . $this->offsetValue` when `offsetValue !== null` at 951-953. Props `?int $limitValue` (80), `?int $offsetValue` (82); setters `limit()` (417), `offset()` (425); `count()` saves/restores both at 620-632)
+- Patterns to follow:
+  - Only change the `offset-set && limit-null` branch. When `limitValue === null && offsetValue !== null`, emit `LIMIT 18446744073709551615 OFFSET n` (MySQL's documented "all rows from offset" idiom). Leave the `limit + offset` and `limit-only` outputs byte-identical to today.
+  - Use the existing integer property values directly (already typed `?int`, no injection risk). No new config, no new exception.
+
+### Cross-tier rebase note (this file is touched by Tiers 1, 3, and 5)
+`MySqlQueryBuilder.php` is also edited by **Tier 1 (SQL-injection hardening)** and **Tier 5 (whereIn-empty handling)**. All three tiers touch SQL-string assembly in this one file. The clauses differ (Tier 1 = identifier/binding safety, Tier 3 = limit/offset, Tier 5 = `whereIn([])`), so the conflicts are mechanical. Implementer must rebase this task onto whichever of Tier 1 / Tier 5 has merged first and re-run the MySQL builder suite before committing. Keep this change surgically scoped to `buildLimitOffsetClause()` to minimize overlap.
+
+### Verification note (read at planning time)
+Confirmed against source: `buildLimitOffsetClause()` at 943-956 emits the two clauses independently; a bare offset produces ` OFFSET n` with no `LIMIT`. Line numbers match the original finding exactly.
+
+## Requirements (Test Descriptions)
+- [ ] `it produces valid MySQL SQL for an offset without a limit`
+- [ ] `it does not emit a bare OFFSET clause without a LIMIT`
+- [ ] `it leaves limit and offset together unchanged`
+- [ ] `it leaves a limit without an offset unchanged`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier3-medium-fixes/018-inertia-query-string-and-version-flash.md
+++ b/.claude/plans/tier3-medium-fixes/018-inertia-query-string-and-version-flash.md
@@ -1,0 +1,40 @@
+# Task 018: Inertia preserves the query string and the version check does not discard flash
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+Two correctness defects in the Inertia integration:
+
+1. **Query string dropped from `url`.** `Inertia::render()` sets `'url' => $request->path()` (line 92), which excludes the query string. Inertia page objects must carry the full URL (path + query) so the client-side router stays in sync; a request to `/users?page=2` is reported to Inertia as `/users`. The 409 location header in `InertiaMiddleware` has the same defect (`'X-Inertia-Location' => $request->path()`, line 62).
+
+2. **Asset-version check runs AFTER the controller, losing flash.** `InertiaMiddleware::handle()` calls `$next($request)` FIRST (line 24), runs the controller, and only THEN performs the asset-version comparison (lines 49-65). On a version mismatch it returns a fresh 409 and discards `$response` — but the controller already ran and consumed any flashed session data, so the forced full reload that follows the 409 has no flash. The version check must happen so that a 409 does not silently drop flash: either perform the check before invoking the controller, or reflash on the 409 path.
+
+## Context
+- Related files:
+  - `packages/inertia/src/Inertia.php` (`render()` 80-108 — page array at 89-94, `'url' => $request->path()` at 92; Inertia-request JSON branch 96-105; `location()` 113+ builds a 409 with `X-Inertia` Vary)
+  - `packages/inertia/src/Middleware/InertiaMiddleware.php` (`handle()` 20-72 — `$next($request)` at 24; redirect 303-upgrade at 33-45; version check at 49-65 with `X-Inertia-Location => $request->path()` at 62; gated to `method() === 'GET'` and both versions non-null at 52-57; `nullableScalarConfig()` 96-113)
+  - `packages/routing/src/Http/Request.php` (`path()` and the query accessor — use whatever yields path-plus-query consistently; do NOT double-encode)
+- Patterns to follow:
+  - Build the full URL (path + `?` + raw query string when present) once. Apply it to BOTH `Inertia::render()`'s `url` AND the middleware's `X-Inertia-Location`. A request with no query string must produce exactly the current `path()` output (no trailing `?`).
+  - Flash preservation: keep routing/inertia decoupled from a specific session API where possible. Preferred — run the version check before `$next()` so a stale-version GET short-circuits to the 409 before the controller runs and consumes flash; if the response must be produced first for header-merging reasons, reflash on the 409 branch. Either way, the test asserts the controller's flash-consuming side effect does not happen (or is preserved) on a 409.
+  - Keep the existing `Vary: X-Inertia` and redirect 302→303 upgrade behavior intact.
+
+### Verification note (read at planning time)
+Confirmed: `Inertia.php:92` uses `$request->path()` (no query). `InertiaMiddleware` runs `$next` at line 24 before the version check at 49-65; 409 uses `$request->path()` at 62. DRIFT detail to preserve: the version check is gated to `method() === 'GET'` AND both configured/request versions non-null — keep that gating; the fix is about ORDERING (pre-controller vs reflash) and including the query string, not about widening when the check fires.
+
+## Requirements (Test Descriptions)
+- [ ] `it includes the query string in the Inertia page url`
+- [ ] `it reports only the path when the request has no query string`
+- [ ] `it includes the query string in the 409 X-Inertia-Location header`
+- [ ] `it returns a 409 on an asset-version mismatch`
+- [ ] `it does not lose flash data on an asset-version mismatch`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier3-medium-fixes/019-errors-simple-recoverable-and-web-notices.md
+++ b/.claude/plans/tier3-medium-fixes/019-errors-simple-recoverable-and-web-notices.md
@@ -1,0 +1,49 @@
+# Task 019: errors-simple does not destroy the response on recoverable warnings and surfaces non-fatal errors in web SAPI
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+Two defects in the simple error handler:
+
+1. **Recoverable warnings tear down the in-progress response.** `handleError()` (lines 101-127) only special-cases `Severity::Deprecated` and `Severity::Notice`; every other level — including `E_WARNING` (which maps to a non-fatal severity) and any unmapped level — falls through to `handleException()` → `handle()`, which clears ALL output buffers (`clearOutputBuffers()`, 64-70), sets a 500 status, prints a full HTML 500 page, and then `return true` so execution CONTINUES. A single recoverable `E_WARNING` during a request therefore destroys the half-rendered response and, because execution continues, can stack additional 500 pages. Recoverable warnings must be reported/logged WITHOUT replacing the response.
+
+2. **Non-fatal errors are silently dropped in web SAPI.** `handleNonFatal()` (87-99) opens with `if (!$this->environment->isCli()) { return; }`, so notices/deprecations (and, after fix 1, warnings) are silently discarded under a web SAPI — a silent failure inside the "loud errors" driver. Non-fatal errors must be surfaced in web SAPI (e.g. reported via the logging/report seam), not dropped.
+
+## Context
+- Related files:
+  - `packages/errors-simple/src/SimpleErrorHandler.php`:
+    - `handle()` 45-62 — `clearOutputBuffers()` then 500 page (web) / text (cli); this is the FULL-PAGE path and must stay reserved for genuinely fatal/uncaught throwables
+    - `clearOutputBuffers()` 64-70 — destroys all output buffers
+    - `handleException()` 80-85 — builds `Severity::Error` report and calls `handle()`
+    - `handleNonFatal()` 87-99 — early `return` under non-CLI; writes colored line to STDERR otherwise
+    - `handleError()` 101-127 — `error_reporting` mask check (108-110); Deprecated/Notice → `handleNonFatal` + return (117-122); ELSE → `handleException()` + return true (124-126)  ← the destructive fall-through
+    - `handleShutdown()` 141-161 — fatal-types-only path; must remain the route for true fatals (E_ERROR/E_PARSE/E_CORE_ERROR/E_COMPILE_ERROR)
+  - `packages/errors/src/...` — `ErrorReport`, `Severity` (use `Severity::fromErrorLevel()` and the existing severity enum; warnings are non-fatal recoverable)
+- Patterns to follow:
+  - Route recoverable non-fatal levels (Deprecated, Notice, Warning, and other non-fatal mappings) to a non-destructive report path that does NOT call `clearOutputBuffers()` and does NOT emit a 500 page. Reserve `handle()`/`handleException()`'s full-page teardown for uncaught exceptions and shutdown-detected fatals.
+  - `handleNonFatal()` must surface non-fatal errors in BOTH SAPIs. In CLI keep the STDERR line; in web SAPI report through the report/logging seam rather than early-returning. Do not echo into the response body in web SAPI (that would corrupt the in-progress response) — surface it where it is observable without mutating the response.
+  - Loud errors: the goal is the OPPOSITE of silent — non-fatal errors must end up reported. Keep `return true`/`return false` semantics for `handleError()` consistent with PHP's handler contract (respect the `error_reporting()` mask short-circuit at 108-110).
+  - Decide the non-fatal severity set explicitly via `Severity` (don't hardcode raw `E_*` bitmasks in the branch beyond the existing fatal-shutdown set).
+
+### Coordination note
+Tier 2 Task 002 touches errors-**ADVANCED** and references `SimpleErrorHandler` as a model. THIS task fixes errors-**SIMPLE**'s own bugs. Coordinate so the two don't diverge on how non-fatal vs fatal is classified, but they edit different packages — no shared-file rebase, only a consistency check on the severity routing.
+
+### Verification note (read at planning time)
+Confirmed against source: `handleError()` 101-127 only special-cases Deprecated/Notice and otherwise calls `handleException()` (destructive 500 + continue). `handleNonFatal()` 87-99 early-returns under `!isCli()`. The "E_WARNING destroys response" and "web notices dropped" findings both hold. (Original cited `handleNonFatal ~87-99` and the destructive path `~101-127` — exact match.)
+
+## Requirements (Test Descriptions)
+- [ ] `it does not clear output buffers when handling a recoverable warning`
+- [ ] `it does not replace the response with a 500 page on a recoverable warning`
+- [ ] `it reports a non-fatal error in web SAPI instead of discarding it`
+- [ ] `it still renders a 500 page for an uncaught exception`
+- [ ] `it still handles a fatal error on shutdown`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier3-medium-fixes/020-pgsql-insert-returning-pk.md
+++ b/.claude/plans/tier3-medium-fixes/020-pgsql-insert-returning-pk.md
@@ -1,0 +1,37 @@
+# Task 020: pgsql insert() returns the actual primary key, not a hardcoded "id"
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`PgSqlQueryBuilder::insert()` always appends `RETURNING "id"` and reads `$result[0]['id']`, so it returns a wrong/zero value for any table whose primary key is not named `id`. The entity layer supports `#[Column(primaryKey: true)]` on any property (e.g. `uuid`, `user_id`), so a non-`id` PK silently yields `0` from `insert()`. Fix: emit `RETURNING <pk>` for the table's actual primary-key column and read that key back.
+
+## Context
+- Related files:
+  - `packages/database-pgsql/src/Query/PgSqlQueryBuilder.php` (`insert()` lines 451-480 — builds `INSERT ... RETURNING %s` with `$this->quoteIdentifier('id')` at 474 and returns `(int) ($result[0]['id'] ?? 0)` at 479; `update()` begins at 482)
+- Patterns to follow:
+  - Return the actual generated key for the table's PK column. The builder must learn the PK column name (the same signal the entity layer uses for `#[Column(primaryKey: true)]`), not assume `'id'`.
+  - Quote the PK identifier via the existing `quoteIdentifier()` and read it back from the result row by that column name.
+  - No silent `?? 0` masking a wrong column — if the RETURNING row lacks the expected PK key that is a loud error, not a `0`.
+
+### COORDINATE with Tier 2 Task 009 (do NOT add a competing mechanism)
+Tier 2 Task 009 (F9 `insertBatch`) adds a `RETURNING`-aware path AND a driver-name/dialect accessor (`driverName()`) to `ConnectionInterface`. If Task 009 already introduces a PK-aware RETURNING helper (a way for the builder to know the PK column), THIS task MUST CONSUME that helper rather than inventing a second PK-resolution path. The two must converge on one mechanism for "what is this table's primary key column."
+- **Rebase dependency:** rebase this task onto merged Tier 2 Task 009 before implementation. If implementing first, use the exact helper/signature Tier 2 Task 009 specifies so single-row `insert()` and batch `insertBatch()` share it.
+- This is a cross-plan ordering concern, not an in-plan task dependency — `Depends on: [none]`.
+
+### Verification note (read at planning time)
+Confirmed against source: `insert()` at 451-480 hardcodes `$this->quoteIdentifier('id')` (line 474) in the RETURNING clause and reads `$result[0]['id']` (479). (Original cited ~469-475 — actual RETURNING line is 470-475; close.)
+
+## Requirements (Test Descriptions)
+- [ ] `it returns the generated key for a table whose primary key is not named id`
+- [ ] `it emits a RETURNING clause naming the table primary-key column`
+- [ ] `it still returns the generated id for a table whose primary key is id`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier3-medium-fixes/_plan.md
+++ b/.claude/plans/tier3-medium-fixes/_plan.md
@@ -7,7 +7,7 @@
 ready
 
 ## Objective
-Fix twelve medium-severity security and correctness defects across CORS, media processing, API tokens, admin CSRF, routing, validation, scheduling, queued jobs, session storage, page-cache, and the S3 filesystem driver. Each fix is a focused, test-first change to existing packages — no new packages.
+Fix twenty medium-severity security and correctness defects. The original twelve span CORS, media processing, API tokens, admin CSRF, routing, validation, scheduling, queued jobs, session storage, page-cache, and the S3 filesystem driver. A gap-audit / dropped-from-consolidation follow-up adds eight more (tasks 013–020) across docs-markdown, devai process running, the amphp listener, both pubsub drivers, the MySQL and pgsql query builders, the Inertia integration, and the simple error handler. Each fix is a focused, test-first change to existing packages — no new packages.
 
 ## Related Issues
 none
@@ -42,6 +42,23 @@ Cross-tier sequencing note (Job.php is shared by Tier 1, Tier 2, and Tier 3):
 Cross-tier sequencing note (ConnectionInterface dialect accessor — shared by Tier 2 F9 and Tier 3 F10):
 - `ConnectionInterface` has NO dialect/driver-name accessor today. **Tier 2 Task 009 (F9 `insertBatch`) adds a driver-name/dialect accessor to `ConnectionInterface` and every implementer.** Tier 3 Task 010 (F10 session upsert) needs the SAME signal to pick the upsert dialect. These must be ONE accessor, not two competing ones. Tier 3 Task 010 consumes the Tier 2 Task 009 accessor (e.g. `driverName()`); if implementing first, use the exact signature Tier 2 Task 009 specifies so they converge rather than collide.
 
+### Follow-up findings (Tasks 013–020)
+
+Tasks 013–020 are a second wave: gap-audit findings plus items dropped from the original consolidation, now folded into this tier because they are the same shape (focused bug-fix follow-ups against existing packages, no new packages). They were each independently source-verified at planning time; drift from the agent-reported descriptions is noted inline below and in the relevant task files.
+
+Confirmed source facts (read at planning time):
+- **013** `MarkdownRepository::getRawMarkdown()` (`docs-markdown`, lines 43-53) concatenates the docs path with the caller-supplied id (line 46) and only guards with `file_exists` (48) — a `../`-laden id reads any `.md` on disk. `DocsMarkdownException` has a single factory (`pageNotFound`); add a traversal factory and a `realpath()` containment check.
+- **014** `CommandRunner::run()` (`devai`, lines 13-32) drains stdout fully (25), `fclose`s it, then drains stderr (27) — sequential, so a child filling its ~64KB stderr buffer deadlocks. Drain both concurrently or redirect stderr to a temp file; return shape `array{exitCode,stdout,stderr}` unchanged. Package has only `DevAiInstallException`; `run()` reports failure via the return array, not a throw.
+- **015** `pubsub:listen` is pseudo-functionality: `PubSubListenCommand::execute()` calls `EventLoopRunner::run()` → `EventLoop::run()` with NOTHING registered, returning immediately; `AmphpConfig::shutdownTimeout()` + the `amphp.shutdown_timeout` config key (`config/amphp.php`) are dead; no `onSignal`/SIGINT anywhere. DEFAULT approach: implement a functional listener (subscribe via `SubscriberInterface`, register the `Subscription` stream on the loop, dispatch `Message`s, graceful SIGINT shutdown bounded by `shutdownTimeout()`). **Depends on 016** (needs working multi-channel subscribe). ALTERNATIVE (product decision — see Risks): remove the command + dead config instead.
+- **016** Multi-channel subscribe is broken in BOTH drivers. `RedisSubscriber` uses only `$channels[0]` (line 24) / `$patterns[0]` (line 35), dropping the rest. `PgSqlSubscription::getIterator()` (lines 22-30) iterates listeners sequentially (nested foreach) so listener 0 blocks forever and later channels never deliver. The `Subscription` contract (one object multiplexing all channels) is correct; these are driver bugs. **DRIFT:** pgsql `psubscribe()` already throws `PubSubException::patternSubscriptionNotSupported('pgsql')` — it does NOT silently drop patterns; the multi-pattern requirement therefore applies to the REDIS driver only, and pgsql's only bug is the sequential multiplex.
+- **017** `MySqlQueryBuilder::buildLimitOffsetClause()` (`database-mysql`, lines 943-956) emits the LIMIT and OFFSET fragments independently, so an offset with no limit produces a bare ` OFFSET n` (invalid in MySQL — pgsql tolerates it). Fix: when offset is set without a limit, emit `LIMIT 18446744073709551615 OFFSET n`. Props `?int $limitValue`/`?int $offsetValue`. **Cross-tier:** this file is also edited by Tier 1 (SQLi hardening) and Tier 5 (whereIn empty).
+- **018** `Inertia::render()` (`inertia`, line 92) sets `'url' => $request->path()` — no query string; the middleware's 409 `X-Inertia-Location` (line 62) has the same defect. `InertiaMiddleware::handle()` runs `$next($request)` FIRST (line 24) and performs the asset-version check AFTER (49-65), so a 409 discards a response whose controller already consumed flash. **DRIFT detail:** the version check is gated to `method()==='GET'` and both versions non-null — keep that gating; the fix is ORDERING (pre-controller or reflash) + including the query string.
+- **019** `SimpleErrorHandler::handleError()` (`errors-simple`, lines 101-127) special-cases only Deprecated/Notice; everything else (incl. `E_WARNING`) falls through to `handleException()` → `handle()`, which clears all output buffers, prints a 500 page, then `return true` (execution continues) — one recoverable warning destroys the in-progress response. And `handleNonFatal()` (87-99) opens `if (!isCli()) return;`, silently dropping non-fatal errors under web SAPI. Fix: report recoverable warnings non-destructively (no buffer teardown / no 500 page) and surface non-fatal errors in web SAPI. **Coordination:** Tier 2 Task 002 edits errors-ADVANCED and references SimpleErrorHandler as a model (different package — consistency check, no shared-file rebase).
+- **020** `PgSqlQueryBuilder::insert()` (`database-pgsql`, lines 451-480) hardcodes `RETURNING "id"` (474) and reads `$result[0]['id']` (479), returning a wrong/zero value for any table whose PK is not `id` (the entity layer supports `#[Column(primaryKey: true)]` on any property). Fix: emit `RETURNING <actual-pk>` and read it back. **COORDINATE with Tier 2 Task 009** (`insertBatch` RETURNING + `driverName()`): if 009 adds a PK-aware RETURNING helper, consume it — do NOT add a competing PK-resolution path.
+
+Cross-tier file-sharing note (query builders touched across Tier 1/2/3/5 — sequential rebase):
+- `MySqlQueryBuilder.php` is edited by Tier 1 (SQLi), Tier 3 Task 017 (offset/limit), and Tier 5 (whereIn empty). `PgSqlQueryBuilder.php` is edited by Tier 2 Task 009 (insertBatch RETURNING + driverName) and Tier 3 Task 020 (insert RETURNING PK). These are mechanical conflicts in SQL-string assembly; the implementer rebases each Tier 3 query-builder task onto the already-merged tiers and re-runs that builder's suite before committing. Keep each change surgically scoped to the one method it touches.
+
 ## Scope
 
 ### In Scope
@@ -57,6 +74,14 @@ Cross-tier sequencing note (ConnectionInterface dialect accessor — shared by T
 - F10 Atomic session upsert and loud write-after-close.
 - F11 One canonical query normalization shared by page-cache store and purge.
 - F12 S3 root-prefix fix, continuation-token paging for list/delete, and loud per-key delete errors.
+- 013 docs-markdown path-traversal containment (`realpath()` under docs root, loud rejection).
+- 014 devai CommandRunner concurrent stdout/stderr drain (no pipe deadlock).
+- 015 amphp `pubsub:listen` becomes a functional listener (subscribe, dispatch, graceful SIGINT shutdown using `shutdown_timeout`); OR removal of the command + dead config if the maintainer chooses the alternative.
+- 016 pubsub multi-channel subscribe correctness in both redis (all channels/patterns) and pgsql (concurrent listener multiplex).
+- 017 MySQL valid SQL for offset-without-limit.
+- 018 Inertia full-URL (path+query) in the page object and 409 location, and version-check ordering that does not drop flash.
+- 019 errors-simple non-destructive handling of recoverable warnings and surfacing of non-fatal errors in web SAPI.
+- 020 pgsql `insert()` returns the table's actual primary key (consuming Tier 2 Task 009's mechanism, not a competing one).
 
 ### Out of Scope
 - New packages, new drivers, or new public abstractions beyond what each fix requires.
@@ -77,6 +102,14 @@ Cross-tier sequencing note (ConnectionInterface dialect accessor — shared by T
 - [ ] Concurrent-ish session writes for one id don't error or drop the row; writes after `save()` fail loudly.
 - [ ] A URL containing a space or `+` stores and purges under the same page-cache key.
 - [ ] S3 prefixed-root listing returns entries; >1000-object listing and deletion are handled; per-key delete errors surface loudly.
+- [ ] docs-markdown rejects path-traversal ids loudly while legitimate ids read and clean-but-missing ids still throw pageNotFound.
+- [ ] devai CommandRunner returns both streams and the exit code without hanging when the child writes >64KB to stderr.
+- [ ] amphp `pubsub:listen` subscribes to configured channels, dispatches received messages, and shuts down gracefully within `shutdown_timeout` (OR the command + dead config are removed per the maintainer's product decision).
+- [ ] pubsub `subscribe('a','b')` delivers a message published to a non-first channel in both drivers; redis `psubscribe` honors all patterns.
+- [ ] MySQL `offset()` without `limit()` produces valid SQL (no bare OFFSET); limit+offset is unchanged.
+- [ ] Inertia page `url` and the 409 `X-Inertia-Location` include the query string; an asset-version mismatch returns 409 without losing flash.
+- [ ] errors-simple does not replace the response with a 500 page on a recoverable warning, and non-fatal errors are reported (not dropped) in web SAPI.
+- [ ] pgsql `insert()` returns the correct generated key for a non-`id` primary key.
 - [ ] All tests passing
 - [ ] Code follows project standards
 
@@ -95,8 +128,16 @@ Cross-tier sequencing note (ConnectionInterface dialect accessor — shared by T
 | 010 | Session: atomic DB upsert + loud write-after-close | - | pending |
 | 011 | Page-cache: single canonical query normalization for store and purge | - | pending |
 | 012 | S3: root-prefix fix, continuation-token paging, loud per-key delete errors | - | pending |
+| 013 | docs-markdown: reject path-traversal page IDs (realpath containment) | - | pending |
+| 014 | devai: drain stdout/stderr concurrently to avoid pipe deadlock | - | pending |
+| 015 | amphp: functional pubsub:listen (subscribe/dispatch/graceful shutdown) — OR remove command+dead config (product decision) | 016 | pending |
+| 016 | pubsub: multi-channel subscribe in both redis and pgsql drivers | - | pending |
+| 017 | MySQL: valid SQL for offset without limit | - | pending |
+| 018 | Inertia: include query string in url + version check that preserves flash | - | pending |
+| 019 | errors-simple: non-destructive recoverable warnings + surface web non-fatal errors | - | pending |
+| 020 | pgsql: insert() returns the actual primary key (consume Tier 2 Task 009 mechanism) | - | pending |
 
-All twelve tasks are file-cluster-isolated and have no inter-task code dependencies, so they may run fully in parallel. Task 009 carries the only external sequencing constraint (rebase after Tier 1 + Tier 2 — see Discovery Notes), which is a cross-plan ordering concern, not a dependency on another task in this plan.
+Tasks 001–012 are file-cluster-isolated with no inter-task code dependencies and may run fully in parallel. Among the follow-up wave, **015 depends on 016** (the functional listener needs working multi-channel subscribe), so run 016 first; 013, 014, 017, 018, 019, 020 are mutually independent. Cross-plan ordering constraints (not in-plan dependencies): Task 009 rebases after Tier 1 + Tier 2; Task 017 rebases after Tier 1/Tier 5's `MySqlQueryBuilder` edits; Task 020 rebases after and consumes Tier 2 Task 009's PK-aware RETURNING / `driverName()` mechanism on `PgSqlQueryBuilder`.
 
 ## Architecture Notes
 - **Loud errors**: every new rejection path (F1 config combo, F2 disallowed format, F3 expired token where a throw is appropriate, F5 missing param, F8 malformed cron, F10 write-after-close, F12 delete errors) raises a `MarkoException` subclass with `message`/`context`/`suggestion`, or returns a deliberate 4xx Response where the contract is HTTP-shaped (F5 router, F4 CSRF via the existing `CsrfTokenMismatchException`).
@@ -113,3 +154,8 @@ All twelve tasks are file-cluster-isolated and have no inter-task code dependenc
 - **F2 finfo availability**: deriving MIME via `finfo` requires the fileinfo extension. Mitigation: it is bundled/enabled by default in PHP 8.5; guard with a loud error if `finfo_open` is unavailable.
 - **F6 decode coordination**: url-decoding matched params could double-decode if `Request::path()` later changes. Mitigation: decode in exactly one place (the matcher/route param extraction) and add a test asserting a `%20`-encoded segment decodes once.
 - **F5 validation-vs-router boundary**: returning a validation error from the router must not couple routing to the validation package. Mitigation: return a plain 4xx `Response` (or a routing-owned exception mapped to 4xx), not a `marko/validation` type.
+- **⚑ 015 amphp implement-vs-remove (PRODUCT DECISION — needs maintainer input)**: `pubsub:listen` is currently pseudo-functionality (empty event loop, dead `shutdown_timeout` config, no SIGINT handler). The DEFAULT plan is to implement a real listener (subscribe → register on the loop → dispatch → graceful SIGINT shutdown bounded by `shutdown_timeout`), which depends on Task 016. The ALTERNATIVE, per the no-pseudo-functionality principle, is to REMOVE the command, `EventLoopRunner`, and the dead `shutdown_timeout` config + `AmphpConfig::shutdownTimeout()`. **Confirm with the maintainer which path to take before Task 015 is implemented.** If removal is chosen, Task 015 no longer depends on Task 016 (and 016 stands alone as a driver-correctness fix).
+- **015 functional-listener feasibility**: a real async listener requires registering the `Subscription` stream on the Revolt `EventLoop` and a working `onSignal` shutdown. Mitigation: tests assert observable behavior (channels subscribed, message dispatched, shutdown bounded by timeout) via injected fakes/handlers, not a specific loop-registration mechanism; if a full integration listener proves environment-fragile, the fall-back is the removal path above.
+- **014 deadlock test fragility**: a genuine pipe deadlock is timing/buffer-size dependent. Mitigation: drive it with a tiny inline child writing >64KB to stderr under a bounded timeout; if environment-fragile, mark that one case `->group('integration')` and keep the captured-output + exit-code assertions as plain unit tests.
+- **017 / 020 cross-tier query-builder rebase**: `MySqlQueryBuilder.php` (Tiers 1, 3, 5) and `PgSqlQueryBuilder.php` (Tiers 2, 3) are edited by multiple tiers. Mitigation: sequential rebase (see the cross-tier file-sharing note in Discovery Notes); keep each change scoped to the single method it touches; Task 020 consumes Tier 2 Task 009's PK/`driverName()` mechanism rather than adding a competing one; re-run the affected builder's suite before committing.
+- **013 realpath ordering**: `realpath()` returns `false` for nonexistent paths, so the containment check must be ordered so a clean-but-missing id still yields `pageNotFound` (not the traversal exception) while a `../` id resolving to a real outside file yields the traversal exception. Mitigation: explicit test for each path (legit, traversal, clean-missing).

--- a/.claude/plans/tier5-low-hardening/013-codeindexer-cache-unserialize-hardening.md
+++ b/.claude/plans/tier5-low-hardening/013-codeindexer-cache-unserialize-hardening.md
@@ -1,0 +1,40 @@
+# Task 013: codeindexer unsafe cache deserialize + silent corruption
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`IndexCache::load()` does `$this->data = unserialize((string) file_get_contents($cachePath))` with no `allowed_classes` restriction, then unconditionally `return true`. On a corrupt or truncated cache file `unserialize()` returns `false`, but `load()` still reports success, so `ensureLoaded()` never rebuilds and every getter reads `false['modules'] ?? []` — silently reporting an EMPTY index with no rebuild and no loud error. Restrict `allowed_classes` to the indexer's own value-object set, and treat a non-array `unserialize()` result as a load failure (return `false`) so `ensureLoaded()` falls through to `build()`.
+
+## Description-note
+This violates two core principles: it's a silent failure (an empty index masquerades as a valid one), and the unrestricted `unserialize()` permits object injection if the cache file is tampered with. The fix makes corruption self-healing (rebuild) and locks deserialization to a safe class allowlist.
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/codeindexer/src/Cache/IndexCache.php` (`load()` ~102-117 — the `unserialize(...)`; `return true`; `ensureLoaded()` ~123-135; getters like `getModules()` ~178-182 which read `$this->data['modules'] ?? []`)
+  - Tests: `/Users/markshust/Sites/marko/packages/codeindexer/tests/` (locate the existing `IndexCacheTest.php` and extend it)
+- Verified findings (source-confirmed):
+  - `load()` currently: returns `false` if file missing or `isStale()`, otherwise `unserialize(...)` then `return true` with NO check on the result.
+  - `build()` writes `serialize($this->data)` where `$this->data` is an array keyed `'modules'`, `'observers'`, `'plugins'`, `'preferences'`, `'commands'`, `'routes'`, etc. The stored payload is a plain associative array of arrays — confirm whether the leaf values are scalars/arrays or value objects before choosing the `allowed_classes` set.
+- Patterns to follow:
+  - If the serialized payload contains only arrays/scalars, pass `['allowed_classes' => false]` (block ALL object instantiation). If it stores value objects (e.g. an `IndexedObserver`/`IndexedPlugin` DTO), pass `['allowed_classes' => [...explicit list...]]` restricted to exactly those classes. Inspect `build()`/the cached DTOs to decide — do NOT guess; the value-object set must be derived from what `build()` actually stores.
+  - After `unserialize(...)`, if the result is not an array, return `false` (do not assign to `$this->data`, do not return `true`). This makes `ensureLoaded()` rebuild. A corrupt cache is recoverable, not fatal — rebuild is the correct loud-but-safe response; no exception is required here because `build()` already succeeds from source. (Do NOT introduce a silent-empty path.)
+  - Keep the existing missing-file and `isStale()` early returns unchanged.
+
+## Requirements (Test Descriptions)
+- [ ] `it rebuilds the index when the cache file is corrupt instead of reporting an empty index`
+- [ ] `it returns false from load when the cache deserializes to a non-array`
+- [ ] `it restricts unserialize to the indexer value-object allowlist`
+- [ ] `it loads a valid cache file and reports its contents`
+- [ ] `it still returns false from load when the cache file is missing`
+
+## Acceptance Criteria
+- A corrupt/truncated cache never yields a silently-empty index; it triggers a rebuild (or a loud error), and getters return real data afterward.
+- `unserialize()` is called with an `allowed_classes` restriction (either `false` or an explicit class list derived from what `build()` stores) — object injection of arbitrary classes is blocked.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/014-docs-fts-match-pdoexception-wrap.md
+++ b/.claude/plans/tier5-low-hardening/014-docs-fts-match-pdoexception-wrap.md
@@ -1,0 +1,39 @@
+# Task 014: docs-fts malformed MATCH leaks PDOException
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`FtsSearch::search()` binds the user query value via `bindValue(':q', ...)` (so there is no SQL injection), but a malformed FTS5 `MATCH` expression — e.g. an unbalanced quote or a bare `NEAR(` — makes SQLite throw a raw `PDOException` out of `$stmt->execute()`. The method is documented `@throws DocsException`, so a `PDOException` escaping it breaks the contract. Wrap the `execute()` (and the `fetchAll()` consumption) in a `try/catch` that converts the `PDOException` to `DocsException::searchFailed(...)`.
+
+## Description-note
+Loud errors must stay within the package's own exception type so callers can catch `DocsException` and not leak the underlying PDO driver exception. The value is already bound, so this is purely about converting an unexpected-but-possible runtime exception into the documented domain exception.
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/docs-fts/src/FtsSearch.php` (`search()` ~29-57 — the `$stmt->execute()` at the MATCH query; method already declares `@throws DocsException`)
+  - `/Users/markshust/Sites/marko/packages/docs/src/Exceptions/DocsException.php` (`searchFailed(...)` factory EXISTS at ~21 — reuse it; do NOT add a new factory)
+  - Tests: `/Users/markshust/Sites/marko/packages/docs-fts/tests/` (locate the existing `FtsSearchTest.php` and extend it)
+- Verified findings (source-confirmed):
+  - `search()` prepares the MATCH query, `bindValue(':q', $query->query, PDO::PARAM_STR)`, `bindValue(':limit', ...)`, then `$stmt->execute()` with NO try/catch. `getPage()` already throws `DocsException::pageNotFound()`, confirming `DocsException` is the package's domain exception.
+  - `DocsException extends MarkoException`; the `searchFailed` static factory is already defined.
+- Patterns to follow:
+  - Wrap `$stmt->execute();` (and the subsequent `fetchAll()` loop, since SQLite can defer the FTS error to fetch time) in `try { ... } catch (PDOException $e) { throw DocsException::searchFailed(...); }`.
+  - Pass the original `PDOException` through as the `previous` exception if `searchFailed()` accepts it; otherwise include the offending query and the PDO message in the `message`/`context`. Confirm `searchFailed()`'s exact signature before wiring (read the factory).
+  - `use PDOException;` at the top (the file already `use PDO;`). Keep `@throws DocsException` on `search()` accurate.
+
+## Requirements (Test Descriptions)
+- [ ] `it throws DocsException when the MATCH expression is malformed`
+- [ ] `it does not leak a PDOException from a malformed search query`
+- [ ] `it returns results for a valid search query`
+
+## Acceptance Criteria
+- A malformed FTS5 MATCH query surfaces as `DocsException` (via `searchFailed`), never as a raw `PDOException`.
+- A valid query is unaffected and still returns `DocsResult` rows.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/015-mcp-query-stacked-statement-guard.md
+++ b/.claude/plans/tier5-low-hardening/015-mcp-query-stacked-statement-guard.md
@@ -1,0 +1,41 @@
+# Task 015: mcp read-only DB guard bypass via stacked statements
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`QueryDatabaseTool::isAllowedPrefix()` checks ONLY the first whitespace-delimited token of the SQL (`strtok($sql, " \t\n\r")` upper-cased against an allowlist of `SELECT, WITH, SHOW, EXPLAIN, DESCRIBE`). A stacked statement like `SELECT 1; DELETE FROM users` passes the guard because its first token is `SELECT`, yet the second statement mutates data. Reject multiple/stacked statements (a `;` that terminates a statement, outside string literals) in addition to the existing first-token allowlist, keeping the `allowWrite=true` opt-in path unchanged.
+
+## Description-note
+This is a local stdio-only tool, so the severity is Low, but the read-only guard is the whole point of the no-`allowWrite` path — a trivial `;`-separated bypass defeats it. The fix tightens the guard without changing the tool's public arguments.
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/mcp/src/Tools/Runtime/QueryDatabaseTool.php` (`isAllowedPrefix()` ~71-76; the `! $allowWrite` branch ~42-48 that calls it; `ALLOWED_PREFIXES` const)
+  - Tests: `/Users/markshust/Sites/marko/packages/mcp/tests/` (locate the existing `QueryDatabaseToolTest.php` and extend it)
+- Verified findings (source-confirmed):
+  - `isAllowedPrefix()`: `$first = strtoupper(strtok($sql, " \t\n\r") ?: ''); return in_array($first, self::ALLOWED_PREFIXES, strict: true);`. Only the first token is inspected — stacked statements bypass.
+  - The guard is consulted only when `! $allowWrite`; when `$allowWrite` is true the tool requires `confirm=true` and otherwise executes writes. That opt-in write path must be preserved.
+- Patterns to follow:
+  - Add a stacked-statement rejection: a statement separator `;` that is NOT inside a single- or double-quoted string literal means more than one statement. The simplest robust approach: scan the SQL char-by-char tracking quote state (`'`/`"`, honoring escaped/doubled quotes), and reject if a `;` is seen outside a string AND any non-whitespace, non-comment content follows it. A bare trailing `;` (e.g. `SELECT 1;`) with nothing after should be allowed.
+  - Combine with the existing first-token allowlist: BOTH must pass for the read-only path. Return the existing not-permitted error response shape when either check fails (reuse the current `'content' => [['type' => 'text', 'text' => ...]], 'isError' => true` structure; the message may mention stacked statements).
+  - Do NOT attempt a full SQL parser. A string-literal-aware `;` scan is sufficient and matches the loud-but-pragmatic intent. Keep `ALLOWED_PREFIXES` and the `allowWrite`/`confirm` behavior untouched.
+
+## Requirements (Test Descriptions)
+- [ ] `it rejects a stacked statement that starts with SELECT`
+- [ ] `it allows a single SELECT statement`
+- [ ] `it allows a single SELECT statement with a trailing semicolon`
+- [ ] `it does not treat a semicolon inside a string literal as a statement separator`
+- [ ] `it still permits write statements when allowWrite and confirm are both true`
+
+## Acceptance Criteria
+- `SELECT 1; DELETE FROM users` is rejected on the read-only path; a plain `SELECT ...` (with or without a trailing `;`) is allowed.
+- A `;` inside a quoted string literal does not trip the stacked-statement guard.
+- The `allowWrite=true` + `confirm=true` path still executes write statements.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/016-lsp-malformed-frame-resilience.md
+++ b/.claude/plans/tier5-low-hardening/016-lsp-malformed-frame-resilience.md
@@ -1,0 +1,44 @@
+# Task 016: lsp server dies on one malformed frame
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`LspProtocol::readMessage()` returns `null` for TWO different conditions: genuine EOF (`fgets()` returns `false`) and a malformed header block (no/zero `Content-Length`, where it returns `null` after the header loop). `serve()` treats any `null` from `readMessage()` as EOF and `break`s the loop, so a single malformed frame kills the entire language server. Distinguish a malformed frame from real EOF; on a malformed frame, write a JSON-RPC parse error (`-32700`) and continue serving; only true EOF ends the loop.
+
+## Description-note
+`handleMessage()` already emits `-32700` for un-decodable JSON bodies, so the parse-error response shape exists. The gap is that a header-level malformation (zero `Content-Length`) never reaches `handleMessage()` — it collapses to the same `null` as EOF in `serve()`. The fix is to make the EOF-vs-malformed distinction explicit at the protocol boundary.
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/lsp/src/Protocol/LspProtocol.php` (`serve()` ~33-42 — the `$message = $this->readMessage(); if (... === null) break;` loop; `readMessage()` ~45-80 — returns `null` on `fgets()===false` AND on `$contentLength === 0`; `handleMessage()` ~82+ already writes `-32700` for JSON errors)
+  - `/Users/markshust/Sites/marko/packages/lsp/src/Server/LspServer.php` (`serve()` ~37-39 delegates to `protocol->serve()`)
+  - Tests: `/Users/markshust/Sites/marko/packages/lsp/tests/` (locate the existing LSP protocol test and extend it)
+- Verified findings (source-confirmed):
+  - `readMessage()`: returns `null` when `fgets()===false` (EOF) inside the header loop, AND returns `null` when `$contentLength === 0` after the header loop completes. `serve()` cannot tell these apart — both `break` the loop.
+  - `handleMessage()` already does `json_decode(..., JSON_THROW_ON_ERROR)` in a try/catch and writes `['jsonrpc'=>'2.0','error'=>['code'=>-32700,'message'=>'Parse error'],'id'=>null]` on `JsonException`.
+- Patterns to follow:
+  - Make the EOF-vs-malformed signal explicit. Two viable shapes (pick the one that reads cleanest against the existing code, do not over-engineer):
+    1. Have `readMessage()` distinguish: return `null` ONLY on true EOF (`fgets()===false` before any header bytes / clean stream end); on a header block that ends with `$contentLength === 0`, signal "malformed" distinctly (e.g. a sentinel or a small `ReadResult` value object with an `isEof()`/`isMalformed()` distinction), so `serve()` can respond `-32700` and `continue`.
+    2. Alternatively keep `readMessage()` returning `?string` but track whether the loop reached EOF vs. terminated a header block; expose that via a tiny private helper or a second return channel.
+  - In `serve()`: on true EOF → `break` (loop ends, server shuts down). On a malformed frame → write the same JSON-RPC parse-error response used by `handleMessage()` (code `-32700`, `id => null`) and `continue` so subsequent valid frames are still processed.
+  - Reuse the existing `writeResponse(...)` for the `-32700` payload; keep the `-32700`/`id=>null` shape consistent with `handleMessage()`. No interface signature changes to `LspServer`.
+  - Tests should drive a fake input stream containing: a malformed frame (e.g. a header block with `Content-Length: 0` or no Content-Length), followed by a valid framed message, followed by EOF — and assert the valid message is still handled and the loop terminates only at EOF.
+
+## Requirements (Test Descriptions)
+- [ ] `it does not terminate the serve loop on a malformed frame`
+- [ ] `it writes a JSON-RPC parse error for a malformed frame`
+- [ ] `it processes a valid message that follows a malformed frame`
+- [ ] `it ends the serve loop on genuine end of input`
+
+## Acceptance Criteria
+- A malformed frame produces a `-32700` parse-error response and the server keeps serving.
+- A valid framed message after a malformed one is still processed.
+- True EOF still ends the serve loop (server shuts down cleanly).
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/017-translator-placeholder-ordering.md
+++ b/.claude/plans/tier5-low-hardening/017-translator-placeholder-ordering.md
@@ -1,0 +1,43 @@
+# Task 017: Translator placeholder replacement ordering
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`Translator::applyReplacements()` loops the `$replacements` array and does a sequential `str_replace(":$placeholder", $replacement, $value)` for each entry. Two bugs follow from the sequential, unordered substitution:
+1. A short placeholder name that is a prefix of a longer one corrupts the longer one. With `['attr' => 'x', 'attribute' => 'y']` and a string `:attribute`, the `:attr` pass rewrites it to `xibute` before the `:attribute` pass can match.
+2. A replacement value that itself contains `:something` can be re-processed by a later iteration's `str_replace`.
+
+Fix by replacing in a single non-recursive pass: order placeholders longest-name-first (so `:attribute` is tried before `:attr`) and substitute without re-scanning already-substituted text (e.g. one `strtr()` call built from `[":$name" => $value]`, which replaces non-overlapping and never re-processes output).
+
+## Description-note
+`strtr()` with an array is the idiomatic single-pass fix: it scans left-to-right, replaces the longest matching key at each position, and does NOT re-examine inserted text — solving both the prefix-collision and the re-replacement bug at once. Building the `[":$name" => $value]` map directly avoids the longest-first sort entirely (strtr already prefers the longest key). If `str_replace` is retained instead, an explicit longest-first sort of keys is required.
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/translation/src/Translator.php` (`applyReplacements()` ~165-180 — the `foreach ($replacements as $placeholder => $replacement) { $value = str_replace(":$placeholder", $replacement, $value); }` loop; called from `get()` ~45 and `choice()` ~73)
+  - Tests: `/Users/markshust/Sites/marko/packages/translation/tests/` (locate the existing `TranslatorTest.php` and extend it)
+- Verified findings (source-confirmed):
+  - `applyReplacements(string $value, array $replacements): string` does exactly the sequential `str_replace(":$placeholder", $replacement, $value)` in a `foreach` with no ordering. Both `get()` and `choice()` route their final value through it.
+  - `$replacement` values are interpolated as-is, so a value containing `:x` is exposed to later `str_replace` iterations.
+- Patterns to follow:
+  - Prefer building a `$map = [];` of `$map[":$name"] = (string) $value;` and returning `strtr($value, $map)`. `strtr` is single-pass and longest-key-preferring, which fixes both bugs cleanly with no manual sort.
+  - Cast replacement values to `string` if the existing signature allows non-string values (confirm the param type; match it — do not widen or narrow the public contract).
+  - Keep the method `private` and its signature unchanged. No config or interface changes.
+
+## Requirements (Test Descriptions)
+- [ ] `it resolves :attribute to its own value when :attr is also a placeholder`
+- [ ] `it does not re-replace a placeholder appearing inside a replacement value`
+- [ ] `it replaces a single placeholder with its value`
+- [ ] `it leaves a string with no placeholders unchanged`
+
+## Acceptance Criteria
+- With replacements `['attr' => 'x', 'attribute' => 'y']`, the string `:attribute` resolves to `y` (not corrupted by the `:attr` substitution).
+- A replacement value that contains `:x` is inserted literally and not re-substituted by another placeholder.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/018-sql-generator-type-map-parity.md
+++ b/.claude/plans/tier5-low-hardening/018-sql-generator-type-map-parity.md
@@ -1,0 +1,54 @@
+# Task 018: SQL generator type-map parity across mysql/pgsql
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+The two schema SQL generators have non-overlapping abstract-type maps, so the same entity column type produces valid DDL on one driver and invalid (or absent) DDL on the other:
+- `uuid` and `enum` map ONLY on pgsql (`UUID`, `VARCHAR`). On mysql they fall through (and a literal `UUID` is not a valid MySQL column type anyway).
+- `bool`, `tinyint`, and `blob` map ONLY on mysql. On pgsql `TINYINT`/`BLOB` are invalid DDL, and the `bool`/`blob` aliases are absent (pgsql has `boolean`/`binary` but not those aliases).
+- `decimal` is `DECIMAL(10,2)` on mysql but bare `DECIMAL` (unconstrained, defaults to arbitrary precision) on pgsql.
+
+Add cross-driver mappings so every shared abstract type generates valid DDL on BOTH generators, with consistent `decimal` precision.
+
+## Description-note
+True modularity means siblings must accept the same abstract type vocabulary and emit each driver's correct native type. The Marko abstract types are the contract; each generator translates. This is the "sibling modules" parity rule applied to the schema layer.
+
+## Context
+- Related files (PATH CORRECTION — they live under `src/Sql/`, NOT `src/Schema/`):
+  - `/Users/markshust/Sites/marko/packages/database-mysql/src/Sql/MySqlGenerator.php` (`TYPE_MAP` const ~29-49; `mapType()` ~302)
+  - `/Users/markshust/Sites/marko/packages/database-pgsql/src/Sql/PgSqlGenerator.php` (`TYPE_MAP` const ~31-49)
+  - Tests: `/Users/markshust/Sites/marko/packages/database-mysql/tests/Sql/MySqlGeneratorTest.php` and `/Users/markshust/Sites/marko/packages/database-pgsql/tests/Sql/PgSqlGeneratorTest.php`
+- Verified findings (source-confirmed — exact current maps):
+  - MySQL `TYPE_MAP` HAS: `integer`/`int`→`INT`, `bigint`, `smallint`, `tinyint`→`TINYINT`, `string`→`VARCHAR`, `text`, `boolean`/`bool`→`TINYINT(1)`, `datetime`→`DATETIME`, `date`, `time`, `timestamp`, `decimal`→`DECIMAL(10,2)`, `float`, `double`, `blob`/`binary`→`BLOB`, `json`→`JSON`. MISSING: `uuid`, `enum`.
+  - PgSQL `TYPE_MAP` HAS: `integer`→`INTEGER`, `bigint`, `smallint`, `string`→`VARCHAR`, `text`, `boolean`→`BOOLEAN`, `datetime`/`timestamp`→`TIMESTAMP`, `date`, `time`, `decimal`→`DECIMAL` (unconstrained), `float`→`REAL`, `double`→`DOUBLE PRECISION`, `json`→`JSONB`, `uuid`→`UUID`, `binary`→`BYTEA`, `enum`→`VARCHAR`. MISSING: `tinyint`, `bool` (alias), `blob` (alias), `int` (alias).
+- Patterns to follow:
+  - MySQL generator: add `uuid` (a valid MySQL representation — `CHAR(36)` is the conventional UUID storage; do NOT emit literal `UUID`) and `enum` (`VARCHAR`, matching pgsql's pragmatic enum→varchar). Keep existing keys.
+  - PgSQL generator: add `tinyint` (→ `SMALLINT`, the nearest valid pg integer; pg has no `TINYINT`), `bool` alias (→ `BOOLEAN`), `blob` alias (→ `BYTEA`), and `int` alias (→ `INTEGER`) so the mysql-style aliases also resolve on pg.
+  - Reconcile `decimal` precision: make both emit the SAME constrained precision (e.g. both `DECIMAL(10,2)`) so a `decimal` column has identical scale/precision on both drivers. Update the pgsql map (and any pgsql `DECIMAL` test expectation) accordingly.
+  - These are `private const array TYPE_MAP` entries — edit the constants. If `enum` needs length handling it is out of scope; map to plain `VARCHAR` exactly as pgsql already does.
+  - Run BOTH packages' generator test suites; the existing `MySqlGeneratorTest`/`PgSqlGeneratorTest` decimal expectations may need updating to the reconciled precision.
+
+## Requirements (Test Descriptions)
+For `MySqlGeneratorTest`:
+- [ ] `it generates a valid MySQL type for a uuid column`
+- [ ] `it generates a valid MySQL type for an enum column`
+- [ ] `it generates DECIMAL with the shared precision for a decimal column`
+
+For `PgSqlGeneratorTest`:
+- [ ] `it generates a valid PostgreSQL type for a tinyint column`
+- [ ] `it generates a valid PostgreSQL type for a bool column`
+- [ ] `it generates a valid PostgreSQL type for a blob column`
+- [ ] `it generates DECIMAL with the shared precision for a decimal column`
+
+## Acceptance Criteria
+- Each shared abstract type (`uuid`, `enum`, `bool`, `tinyint`, `blob`, `decimal`) generates valid DDL on BOTH generators.
+- `decimal` emits identical precision/scale on both drivers.
+- No mysql output contains a literal `UUID` column type; no pgsql output contains `TINYINT` or `BLOB`.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/019-mysql-connection-bind-param-types.md
+++ b/.claude/plans/tier5-low-hardening/019-mysql-connection-bind-param-types.md
@@ -1,0 +1,43 @@
+# Task 019: MySQL connection binds bool/null/int as strings
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`MySqlConnection::query()`/`execute()` bind parameters by passing the bindings array straight to `PDOStatement::execute($this->prepareBindings($bindings))`. `prepareBindings()` only JSON-encodes array values; every other value is bound through `execute()`, which treats ALL parameters as `PDO::PARAM_STR`. So a PHP `false` is bound as `''`, `true` as `'1'`, `null` as `''`/`'0'` depending on context — which errors on INT/BOOL columns in MySQL strict mode. The pgsql sibling does NOT do this: its `bindValues()` selects an explicit `PDO::PARAM_BOOL`/`PARAM_NULL`/`PARAM_INT`/`PARAM_STR` per value. Bind explicit PDO param types in the mysql connection to match pgsql's behavior.
+
+## Description-note
+Sibling driver packages must behave identically for the same input. pgsql already binds with correct PDO types; mysql silently coerces booleans/nulls to strings. The fix brings mysql to parity by binding each value with its appropriate `PDO::PARAM_*` type.
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/database-mysql/src/Connection/MySqlConnection.php` (`query()` ~119-131 and `execute()` ~134-146 — both call `$statement->execute($this->prepareBindings($bindings))`; `prepareBindings()` ~158-174 ONLY JSON-encodes array values, no PDO type binding; `prepare()` ~178-187 returns a `MySqlStatement`)
+  - REFERENCE (the correct pattern): `/Users/markshust/Sites/marko/packages/database-pgsql/src/Connection/PgSqlConnection.php` (`bindValues()` ~187-213 — loops bindings, JSON-encodes arrays then binds `PDO::PARAM_STR`, else `match(true) { is_bool => PARAM_BOOL, is_null => PARAM_NULL, is_int => PARAM_INT, default => PARAM_STR }` and `$statement->bindValue($param, $value, $type)`; `query()` ~140-148 / `execute()` ~156-164 call `$this->bindValues($statement, $bindings)` then `$statement->execute()`)
+  - Tests: `/Users/markshust/Sites/marko/packages/database-mysql/tests/` (locate the existing connection test; SQLite-in-memory is the typical harness for these — confirm how the existing mysql connection tests bind/exercise PDO)
+- Verified findings (source-confirmed):
+  - MySQL `prepareBindings()` body is exactly: `foreach ($bindings as $key => $value) { if (!is_array($value)) continue; try { $bindings[$key] = json_encode(...); } catch (JsonException $e) { throw ConnectionException::invalidArrayBinding(...); } } return $bindings;`. It never sets a PDO param type — so `execute($array)` binds everything as a string.
+  - PgSQL `bindValues($statement, $bindings)` selects explicit param types via the `match(true)` shown above. THIS is the parity target.
+- Patterns to follow:
+  - Introduce a `bindValues(StatementInterface|PDOStatement $statement, array $bindings): void` (mirror pgsql's signature/visibility exactly — same name, same `private`) on the mysql connection that: JSON-encodes array values (folding in the existing `prepareBindings` array-handling so `ConnectionException::invalidArrayBinding` is still thrown), then `bindValue($param, $value, $type)` with the same `match(true)` type selection pgsql uses.
+  - Change `query()`/`execute()` to `$this->bindValues($statement, $bindings); $statement->execute();` — mirroring pgsql, NOT passing the array to `execute()`.
+  - Keep array-binding JSON-encoding behavior and the `ConnectionException::invalidArrayBinding` path intact (do not regress that fix).
+  - Match sibling conventions precisely (method name, visibility, ordering) per `.claude/sibling-modules.md`. Do NOT change the public `ConnectionInterface` signature.
+  - Note: PDO param keys may be positional (`?`) or named; mirror exactly how pgsql derives the `$param` (1-based index for positional). Read pgsql's `bindValues` loop fully before writing.
+
+## Requirements (Test Descriptions)
+- [ ] `it binds a false boolean as a boolean not an empty string`
+- [ ] `it binds a true boolean correctly`
+- [ ] `it binds a null value as SQL NULL`
+- [ ] `it binds an integer value as an integer`
+- [ ] `it still JSON-encodes array bindings and throws on un-encodable arrays`
+
+## Acceptance Criteria
+- Binding `false`/`true`/`null`/int values through the mysql connection produces the correct DB values, matching pgsql behavior (no boolean→`''` coercion).
+- Array values are still JSON-encoded, and an un-encodable array still throws `ConnectionException::invalidArrayBinding`.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/020-querybuilder-empty-wherein.md
+++ b/.claude/plans/tier5-low-hardening/020-querybuilder-empty-wherein.md
@@ -1,0 +1,43 @@
+# Task 020: whereIn([]) emits invalid `IN ()`
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+Both query builders compile a `whereIn(column, [])` (empty array) to `column IN ()`, which is a SQL syntax error on both MySQL and PostgreSQL. The same applies to `whereNotIn(column, [])`. An empty `whereIn` should compile to a guaranteed no-match (e.g. `1 = 0`) so the query is valid and returns zero rows; an empty `whereNotIn` should compile to a match-all (e.g. `1 = 1`) so it returns all rows.
+
+## Description-note
+An empty `IN` set has a well-defined logical answer (no row is in the empty set; every row is not-in the empty set). Emitting `IN ()` instead crashes the query. The fix substitutes the constant-condition equivalents so the generated SQL is always valid.
+
+## Context
+- Related files (BOTH siblings — the bug exists in each, fix both for parity):
+  - `/Users/markshust/Sites/marko/packages/database-mysql/src/Query/MySqlQueryBuilder.php` (`whereIn()` ~207; compile loop ~824-838 building `sprintf('%s IN (%s)', quoteIdentifier(col), implode(', ', array_fill(0, count(values), '?')))`; the `whereNotIn` twin)
+  - `/Users/markshust/Sites/marko/packages/database-pgsql/src/Query/PgSqlQueryBuilder.php` (`whereIn()` ~206; compile loop ~825-834 building the same `'%s IN (%s)'`; the `whereNotIn` twin)
+  - Tests: `/Users/markshust/Sites/marko/packages/database-mysql/tests/` and `/Users/markshust/Sites/marko/packages/database-pgsql/tests/` (locate the existing query-builder tests)
+- Verified findings (source-confirmed):
+  - MySQL builder compile loop: `$placeholders = array_fill(0, count($whereIn['values']), '?'); $condition = sprintf('%s IN (%s)', $this->quoteIdentifier($whereIn['column']), implode(', ', $placeholders));`. With an empty `values`, `array_fill(0, 0, '?')` yields `[]` → `IN ()`.
+  - PgSQL builder compile loop is the structurally identical `sprintf('%s IN (%s)', ...)` over `$whereIn['values']`.
+  - Confirm whether `whereNotIn` is a separate property/loop or a flag on the same `whereIns` entries (read each builder's `whereNotIn()` to see how negation is stored) before writing the fix so the empty-array branch is applied to BOTH in/not-in.
+- Patterns to follow:
+  - When the `values` array is empty: for `whereIn`, emit a constant false condition (`1 = 0`) and bind NO placeholders; for `whereNotIn`, emit a constant true condition (`1 = 1`) and bind no placeholders. Wire it into the same boolean/`AND` joining the existing loop uses so chained wheres still compose.
+  - Do not add placeholders for the empty case (so `$this->bindings` is untouched for that clause).
+  - Apply the SAME fix shape to both builders; keep them byte-for-byte parallel per `.claude/sibling-modules.md`.
+
+## Requirements (Test Descriptions)
+For each builder (MySQL and PgSQL):
+- [ ] `it compiles whereIn with an empty array to a no-match condition`
+- [ ] `it compiles whereNotIn with an empty array to a match-all condition`
+- [ ] `it binds no parameters for an empty whereIn`
+- [ ] `it still compiles whereIn with a non-empty array to an IN clause`
+
+## Acceptance Criteria
+- `whereIn(col, [])` produces valid SQL that returns zero rows on both drivers; `whereNotIn(col, [])` produces valid SQL that returns all rows.
+- No `IN ()` ever appears in generated SQL.
+- A non-empty `whereIn` still produces an `IN (?, ?, ...)` clause with the right bindings.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+- CROSS-TIER REBASE: `MySqlQueryBuilder.php` / `PgSqlQueryBuilder.php` are also touched by Tier 1 / Tier 2 / Tier 3 query-builder tasks. This task must be rebased sequentially onto whatever query-builder changes those tiers land first — do NOT assume the line numbers above are still exact at implementation time; re-locate the `IN (%s)` compile loop in each builder before editing, and re-run BOTH builders' full test suites after rebasing.

--- a/.claude/plans/tier5-low-hardening/021-gd-preserve-format-and-alpha.md
+++ b/.claude/plans/tier5-low-hardening/021-gd-preserve-format-and-alpha.md
@@ -1,0 +1,50 @@
+# Task 021: GD re-encodes to PNG and flattens alpha
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`GdImageProcessor::resize()` and `crop()` have three defects:
+1. They ALWAYS write the output as PNG (`uniqid(...) . '.png'` then `imagepng($canvas, ...)`), regardless of the source format — so resizing a JPEG silently returns a PNG.
+2. The `imagecreatetruecolor()` canvas is created without `imagealphablending(false)` + `imagesavealpha(true)`, and no transparent fill, so transparent PNG/WebP sources are composited onto an opaque black background — transparency is lost.
+3. The `imagepng()` (and any other encode) return value is unchecked, so an encode failure returns a path to a non-image silently.
+
+Preserve the source format on output, enable alpha preservation for PNG/WebP, and check encode return values (throwing `GdProcessingException` loudly on failure).
+
+## Description-note
+Loud errors plus "do what the caller expects": a resize must not change the format or destroy transparency, and a failed encode must not silently hand back a bogus path. The `convert()` method already encodes per-format via a `match` and `normalizeFormat()` — reuse that machinery so `resize()`/`crop()` honor the detected source format.
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/media-gd/src/Driver/GdImageProcessor.php` (`resize()` ~31-55, `crop()` ~62-78 — both hardcode `.png` + `imagepng(...)` with no return check and no alpha setup; `convert()` ~84-97 — has the per-format `match($extension) { 'jpeg' => imagejpeg, 'png' => imagepng, 'webp' => imagewebp, 'gif' => imagegif }`; `loadImage()` ~104-130 uses `imagecreatefromstring`; `normalizeFormat()` ~133+ maps/validates `jpeg|png|gif|webp`)
+  - Tests: `/Users/markshust/Sites/marko/packages/media-gd/tests/` (locate the existing GD processor test; tests should create real small images via GD in a temp dir)
+- Verified findings (source-confirmed):
+  - `resize()`: builds a `imagecreatetruecolor($width,$height)` canvas, `imagecopyresampled(...)`, then `$outputPath = sys_get_temp_dir().'/'.uniqid('marko-gd-',true).'.png'; imagepng($canvas, $outputPath); return $outputPath;` — format hardcoded to png, no alpha flags, return unchecked.
+  - `crop()`: identical pattern with `imagecopy(...)`.
+  - `convert()` already demonstrates the correct per-format encode `match` and reaches it via `normalizeFormat($format)`.
+  - `loadImage()` returns a `GdImage` from `imagecreatefromstring()` but does NOT currently report the detected format — detection will need `getimagesize()`/`exif_imagetype()` (or `image_type_to_extension`) on the source path inside `resize()`/`crop()`.
+- Patterns to follow:
+  - Detect the source format from the input path (e.g. `getimagesize($imagePath)[2]` → `IMAGETYPE_*`, mapped to an extension via `image_type_to_extension(..., false)` then normalized through the existing `normalizeFormat()` vocabulary). If detection fails, throw `GdProcessingException` (loud) — do not default-to-png silently.
+  - Build the output path with the detected extension, and encode via the SAME per-format `match` `convert()` uses (extract a small private `encode(GdImage $image, string $extension, string $outputPath): void` helper that both `convert()` and `resize()`/`crop()` call, so there is one encode path — DRY).
+  - For PNG and WebP canvases, before copying: `imagealphablending($canvas, false); imagesavealpha($canvas, true);` and fill with a transparent color (`imagecolorallocatealpha($canvas, 0,0,0,127)` via `imagefilledrectangle`) so transparency survives the resample/crop.
+  - Check the encode boolean: `if (imagepng(...) === false) throw GdProcessingException::processingFailed(...)` (use the existing `processingFailed`/`unsupportedFormat` factories; confirm signatures). Apply to ALL encode calls in the shared helper.
+  - Do NOT change the public method signatures (`resize`/`crop`/`thumbnail`/`convert` keep their parameters). `thumbnail()` already delegates to `resize()`, so it inherits the fix.
+
+## Requirements (Test Descriptions)
+- [ ] `it outputs a JPEG when resizing a JPEG source`
+- [ ] `it outputs a PNG when resizing a PNG source`
+- [ ] `it preserves transparency when resizing a transparent PNG`
+- [ ] `it preserves the source format when cropping`
+- [ ] `it throws GdProcessingException when encoding fails`
+
+## Acceptance Criteria
+- Resizing/cropping preserves the source image format (JPEG stays JPEG, PNG stays PNG).
+- A transparent PNG/WebP retains its transparency after resize/crop (no black flattening).
+- An encode failure surfaces a `GdProcessingException` (no silent bogus path).
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/022-admin-api-section-wildcard-and-show-filter.md
+++ b/.claude/plans/tier5-low-hardening/022-admin-api-section-wildcard-and-show-filter.md
@@ -1,0 +1,49 @@
+# Task 022: admin-api section visibility ignores wildcards and show() skips filter
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`SectionController` (in `marko/admin-api`) decides section/menu visibility with `userCanAccessSection()`, which checks `$user->hasPermission($permission)` directly. `AdminUser::hasPermission()` only does a super-admin bypass plus an exact permission-key check — it does NOT honor wildcard grants. But the `AdminAuthMiddleware` (in `marko/admin-auth`) that gates the actual routes DOES honor wildcards: after the exact `hasPermission()` check it iterates the user's permission keys and calls `PermissionRegistry::matches($permissionKey, $requiredPermission)`. So a user granted `catalog.*` can reach a catalog route (middleware lets them through) but is HIDDEN from the section menu (the controller's exact-match filter rejects them). Two fixes:
+1. Use wildcard-aware permission matching for section visibility (consult the same `PermissionRegistry::matches()` the middleware uses), so a `catalog.*` user sees catalog sections.
+2. `show($id)` applies NO permission filter at all — it returns any section by id regardless of the user's permissions. Apply the same visibility check `index()` uses to `show()` (return not-found / forbidden when the user can't access the section).
+
+## Description-note
+The menu and the route gate must agree on who can see what; today the menu is stricter than the gate, which is both a correctness bug (wildcard-granted users get an empty/short menu) and an inconsistency between `index()` (filtered) and `show()` (unfiltered). The fix routes both controller methods through the SAME wildcard-aware matching the middleware already implements.
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/admin-api/src/Controller/SectionController.php` (`index()` ~31-57 — filters via `userCanAccessSection()`; `show()` ~62-90 — NO permission filter, returns the section unconditionally; `userCanAccessSection()` ~91-110 — `foreach` menu items, `$permission === '' || $user->hasPermission($permission)`; constructor injects only `AdminSectionRegistryInterface` + `GuardInterface`)
+  - REFERENCE (the wildcard pattern to reuse): `/Users/markshust/Sites/marko/packages/admin-auth/src/Middleware/AdminAuthMiddleware.php` (~57-66 — `if ($user->hasPermission($requiredPermission)) {...}` then iterates the user's permission keys and `$this->permissionRegistry->matches($permissionKey, $requiredPermission)`; injects `PermissionRegistryInterface` ~24)
+  - `/Users/markshust/Sites/marko/packages/admin-auth/src/Contracts/PermissionRegistryInterface.php` (the `matches(string $pattern, string $key): bool` contract) and `/Users/markshust/Sites/marko/packages/admin-auth/src/PermissionRegistry.php` (the wildcard implementation)
+  - `/Users/markshust/Sites/marko/packages/admin-auth/src/Entity/AdminUser.php` (`hasPermission()` ~115-121 — super-admin bypass via `array_any($roles, isSuperAdmin)` then exact check; confirm the exact-match path and how the user's permission keys are exposed for wildcard iteration)
+  - Tests: `/Users/markshust/Sites/marko/packages/admin-api/tests/` (locate the existing `SectionControllerTest.php`)
+- Verified findings (source-confirmed — note PACKAGE drift):
+  - `AdminAuthMiddleware` and `PermissionRegistry`/`PermissionRegistryInterface` live in `packages/admin-auth/`, NOT `packages/admin-api/`. The original finding's path (`packages/admin-api/src/.../AdminAuthMiddleware`) is wrong; the cross-package reference above is correct.
+  - `SectionController::index()` filters sections with `userCanAccessSection()`; `show()` does not filter at all. `userCanAccessSection()` uses bare `$user->hasPermission(...)`.
+  - `SectionController` currently injects `AdminSectionRegistryInterface` + `GuardInterface` only — it does NOT have access to `PermissionRegistryInterface` yet. Adding wildcard matching requires injecting `PermissionRegistryInterface` into the controller.
+  - `AdminAuthMiddleware` proves the canonical "exact OR wildcard" matching shape to mirror.
+- Patterns to follow:
+  - Inject `PermissionRegistryInterface $permissionRegistry` into `SectionController` (constructor promotion; it is `readonly class` — keep it readonly). Update the existing controller-construction test helpers/bindings accordingly.
+  - In `userCanAccessSection()`, a menu item is visible when: its permission is `''`, OR `$user->hasPermission($permission)` (exact/super-admin), OR the user has a permission key that wildcard-`matches()` the required permission — mirroring `AdminAuthMiddleware`'s order. Read how the middleware enumerates the user's permission keys and reuse the same source.
+  - Apply the same per-section visibility check at the top of `show($id)`: after resolving the section, if the user is an `AdminUserInterface` and `!userCanAccessSection($user, $section)`, return the not-found response (`ApiResponse::notFound(...)`, matching the existing not-found shape) so an inaccessible section is not disclosed. Preserve the existing `AdminException`→not-found behavior for unknown ids.
+  - Do not change the route attributes or `ApiResponse` contract.
+
+## Requirements (Test Descriptions)
+- [ ] `it shows catalog sections to a user granted the catalog wildcard permission`
+- [ ] `it hides sections the user has no matching permission for`
+- [ ] `it shows a section to a user with the exact permission`
+- [ ] `it enforces the permission filter in show for an inaccessible section`
+- [ ] `it returns the section from show for an accessible section`
+
+## Acceptance Criteria
+- A user with `catalog.*` sees catalog sections in both `index()` and `show()`.
+- `show($id)` returns not-found for a section the user cannot access (parity with `index()`'s filter).
+- Exact-permission and super-admin users are unaffected.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/023-queue-retry-reset-attempts.md
+++ b/.claude/plans/tier5-low-hardening/023-queue-retry-reset-attempts.md
@@ -1,0 +1,43 @@
+# Task 023: RetryCommand doesn't reset attempts
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+`RetryCommand` re-queues a failed job by unserializing the stored payload and pushing it back as-is: `$job = unserialize($failedJob->payload); $this->queue->push($job, $failedJob->queue);`. The unserialized job carries its failure-time `attempts` count, which is already at (or above) `maxAttempts`. So the "retried" job goes straight back to failure on the next worker pass without ever performing a real retry — the worker's `if ($job->attempts < $job->maxAttempts)` check fails immediately. Reset the job's `attempts` to 0 when retrying, in both the single-job (`retryJob`) and bulk (`retryAll`) paths.
+
+## Description-note
+A retry must actually give the job fresh attempts; otherwise the command is a no-op that re-fails immediately. `Job::$attempts` is `public private(set) int = 0` with only an `incrementAttempts()` mutator and no reset, so the reset capability must be added to the Job (and the `JobInterface` contract if retry is to work polymorphically).
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/queue/src/Command/RetryCommand.php` (`retryJob()` ~75-99 — `unserialize` then `queue->push($job, ...)` then `failedJobRepository->delete(...)`; `retryAll()` ~49-72 — same pattern in a `foreach`)
+  - `/Users/markshust/Sites/marko/packages/queue/src/Job.php` (`public private(set) int $attempts = 0;` ~11; `incrementAttempts(): void { $this->attempts++; }` ~21-24; `serialize()`/`unserialize()` ~26-31 — NO reset method)
+  - `/Users/markshust/Sites/marko/packages/queue/src/JobInterface.php` (`public int $attempts { get; }` ~11, `public int $maxAttempts { get; }` ~13 — read-only get hooks on the interface)
+  - `/Users/markshust/Sites/marko/packages/queue/src/Worker.php` (~63 — `if ($job->attempts < $job->maxAttempts) { $delay = pow(2, $job->attempts) * 10; ... }` — this is the gate a non-reset retry fails immediately)
+  - Tests: `/Users/markshust/Sites/marko/packages/queue/tests/` (locate the existing `RetryCommandTest.php`)
+- Verified findings (source-confirmed):
+  - `RetryCommand` pushes the unserialized failed job with no attempt reset, in both single and bulk paths.
+  - `Job::$attempts` is `private(set)` with only `incrementAttempts()`; there is no reset method and `JobInterface` exposes `attempts` as a get-only hook.
+  - `Worker` gates real retries on `$job->attempts < $job->maxAttempts`, confirming a non-reset retry re-fails at once.
+- Patterns to follow:
+  - Add a `resetAttempts(): void` method to `Job` that sets `$this->attempts = 0` (allowed inside the class despite `private(set)`), and declare it on `JobInterface` so `RetryCommand` can call it on the `JobInterface` it holds. Follow code standards: typed return, `@throws` if applicable (none here).
+  - In `retryJob()` and `retryAll()`, call `$job->resetAttempts()` after unserializing and BEFORE `queue->push(...)`.
+  - Keep `serialize`/`unserialize` and the failed-job-delete ordering unchanged.
+
+## Requirements (Test Descriptions)
+- [ ] `it resets a retried job's attempts to zero before re-queuing`
+- [ ] `it resets attempts when retrying all failed jobs`
+- [ ] `it re-pushes the retried job to its original queue`
+- [ ] `it deletes the failed-job record after retrying`
+
+## Acceptance Criteria
+- A retried job has `attempts === 0` when pushed back, so the worker performs real retries before it can fail again.
+- Both single-job and bulk retry paths reset attempts.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+- CROSS-TIER COORDINATION (Tier 2): Tier 2 queue tasks 004 / 005 / 006 change the attempt-counting model (how/when `attempts` is incremented and how failures are recorded). This task must CONSUME that attempt model, not fight it — if Tier 2 introduces a different reset/increment API or moves attempt tracking, adopt it here rather than adding a parallel mechanism. Rebase onto Tier 2's queue changes first, re-locate `Job::$attempts` / the increment+reset API, and re-run `packages/queue/tests/` after rebasing.

--- a/.claude/plans/tier5-low-hardening/024-debugbar-lazy-all-and-mask-completeness.md
+++ b/.claude/plans/tier5-low-hardening/024-debugbar-lazy-all-and-mask-completeness.md
@@ -1,0 +1,54 @@
+# Task 024: debugbar all() full-decode perf + config-mask completeness
+
+**Status**: pending
+**Depends on**: [none]
+**Retry count**: 0
+
+## Description
+Two code hardening items in `marko/debugbar`:
+1. **`DebugbarStorage::all()` fully decodes every dataset just to list summaries.** It globs `*.json`, then for each file calls `get($id)` which `json_decode`s the ENTIRE stored dataset, only to read four fields (`summary`, `stored_at`, `profiler_url`, and `mtime` from `filemtime`). On a busy dev session with many large datasets this fully decodes every dataset file on each list. Store/read a lightweight summary index (or lazy-decode) so `all()` does not fully decode every dataset.
+2. **The default `masked` list misses common secret-named keys.** `config/debugbar.php` masks `*.key`, `*.password`, `*.secret`, `*.token`, `*.api_key`, `*.private_key`. The `matches()` logic turns `*` into `.+`, so a pattern like `*.password` only matches a NESTED key (`db.password`) and never a TOP-LEVEL `password`/`secret`/`token`/`dsn` key, and `dsn` is not covered at all. Make the default mask robustly cover common secret-named config keys (`password`, `secret`, `key`, `token`, `dsn`) at any depth, including top-level.
+
+## Description-note
+The `all()` change is a dev-time performance hardening (no behavior change to the returned summaries). The mask change is a default-safety hardening so an enabled config collector does not leak secrets that happen to be top-level or named `dsn`. The docs warning about enabling the config collector is handled by the doc-updater pipeline — this task is code-only.
+
+## Context
+- Related files:
+  - `/Users/markshust/Sites/marko/packages/debugbar/src/Storage/DebugbarStorage.php` (`put()` ~20-41 — writes full `$dataset` JSON via `file_put_contents(..., LOCK_EX)` then `prune()`; `get()` ~46-66 — full `json_decode(..., JSON_THROW_ON_ERROR)`; `all()` ~71-110 — globs `*.json`, calls `$this->get($id)` per file, then reads only `$dataset['summary']`, `$dataset['stored_at']`, `$dataset['profiler_url']`, and `filemtime($file)`, sorts by `mtime` desc)
+  - `/Users/markshust/Sites/marko/packages/debugbar/src/Collectors/ConfigCollector.php` (`collect()` ~16-28 reads `debugbar.options.config.masked`; `mask()`/`matches()` ~35-70 — `matches()` builds `'/^'.str_replace('\\*', '.+', preg_quote($pattern,'/')).'$/'` so `*` → `.+` which requires at least one preceding char)
+  - `/Users/markshust/Sites/marko/packages/debugbar/config/debugbar.php` (the `masked` default list ~36-42: `*.key`, `*.password`, `*.secret`, `*.token`, `*.api_key`, `*.private_key`)
+  - Tests: `/Users/markshust/Sites/marko/packages/debugbar/tests/` (locate the existing `DebugbarStorageTest.php` and `ConfigCollectorTest.php`)
+- Verified findings (source-confirmed):
+  - `all()` calls `$this->get($id)` (full decode) for every globbed file to assemble a summary list; the only fields used are `summary`, `stored_at`, `profiler_url`, `mtime`.
+  - `put()` writes the whole dataset as one JSON file and there is no separate summary/index artifact today.
+  - `matches()` maps `*` to `.+` (one-or-more), so `*.password` matches `db.password` but NOT a bare top-level `password`; `dsn` is absent from the default list entirely.
+- Patterns to follow:
+  - For `all()`: avoid the full per-file decode. Two acceptable shapes (pick the lower-churn one):
+    1. **Summary index file:** in `put()`, additionally maintain a small index (e.g. `index.json` mapping id → `{stored_at, profiler_url, summary}`); `all()` reads that single index plus `filemtime`/glob for ordering. Keep `prune()` and the index in sync (prune removes index entries too).
+    2. **Lazy/partial decode:** if a summary index is too invasive, have `put()` ALSO write a tiny `{id}.summary.json` next to `{id}.json` containing only the summary fields, and have `all()` read those summary files instead of full datasets. `get($id)` still full-decodes for the profiler detail view (unchanged).
+    Whichever is chosen, `all()` must NOT call the full-decode `get()` per file. The returned summary list shape (keys `id`, `stored_at`, `profiler_url`, `summary`, `mtime`, sorted by `mtime` desc) MUST stay identical so the UI is unaffected.
+  - For the mask defaults: add patterns that also match top-level keys and `dsn`. Because `*` → `.+` requires a prefix, add BOTH a bare-key form and a nested form for each secret name — e.g. for each of `password`, `secret`, `key`, `token`, `dsn`: include the exact key (`password`) AND the nested wildcard (`*.password`). Add `dsn`/`*.dsn`. Keep the existing `*.api_key`/`*.private_key`. (Alternatively, if a leading-wildcard form like `*password` is supported by `matches()`, prefer the smallest change that makes a top-level `password` mask — but confirm against `matches()`'s `.+` semantics before relying on it.)
+  - All defaults live in `config/debugbar.php` (config-file defaults per code standards) — do NOT hardcode mask patterns in `ConfigCollector`. `matches()`/`mask()` logic itself is correct and should stay.
+
+## Requirements (Test Descriptions)
+For `DebugbarStorageTest`:
+- [ ] `it lists stored datasets without fully decoding every dataset file`
+- [ ] `it returns the same summary fields for each listed dataset`
+- [ ] `it orders listed datasets by most-recent first`
+
+For `ConfigCollectorTest`:
+- [ ] `it masks a top-level password config key`
+- [ ] `it masks a top-level secret config key`
+- [ ] `it masks a dsn config key`
+- [ ] `it still masks a nested password key`
+- [ ] `it leaves non-secret config keys visible`
+
+## Acceptance Criteria
+- `all()` produces the identical summary list without fully decoding every dataset file (uses an index or summary-only read).
+- The default mask redacts common secret-named keys (`password`, `secret`, `key`, `token`, `dsn`) at top level AND nested; non-secret keys remain visible.
+- All requirements have passing tests
+- Code follows code standards
+- No decrease in test coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/tier5-low-hardening/_plan.md
+++ b/.claude/plans/tier5-low-hardening/_plan.md
@@ -14,6 +14,16 @@ none
 
 ## Discovery Notes
 - **New work.** No existing plan in `.claude/plans/` covers these specific hardening items. Adjacent plans (`sse-package`, `session-package`, `encryption`, `core-package`, `routing-package`, `cache-package`, `testing-package`, `layout-component-discovery`) define the packages themselves; this plan only touches already-built code.
+- **Tasks 013–024 are gap-audit + dropped-from-consolidation follow-ups now folded into this tier.** They were surfaced by a later low-severity audit pass (and items deferred out of an earlier consolidation), and are added here without renumbering or touching tasks 001–012. Each was independently re-verified by reading its cited source before being written; path/line drift was corrected against the actual files.
+- **Source-read drift corrections for the added tasks (verification notes):**
+  - **018:** The SQL generators live at `packages/database-{mysql,pgsql}/src/Sql/*Generator.php`, NOT `src/Schema/`. Confirmed maps: MySQL `TYPE_MAP` is missing `uuid`/`enum`; PgSQL `TYPE_MAP` is missing `tinyint`/`bool`/`blob` aliases; `decimal` is `DECIMAL(10,2)` on mysql vs bare `DECIMAL` on pgsql.
+  - **019:** The MySQL connection does NOT have a `bindValues()` method; it calls `$statement->execute($this->prepareBindings($bindings))`, where `prepareBindings()` only JSON-encodes array values — everything else binds as `PARAM_STR`. The pgsql sibling's `bindValues()` (`PgSqlConnection.php` ~187-213) selects explicit `PARAM_BOOL`/`PARAM_NULL`/`PARAM_INT`/`PARAM_STR` and IS the parity target.
+  - **022:** PACKAGE drift — `AdminAuthMiddleware` and `PermissionRegistry`/`PermissionRegistryInterface` live in `packages/admin-auth/`, NOT `packages/admin-api/`. The middleware does honor wildcards via `PermissionRegistry::matches()`; `SectionController` (admin-api) uses bare `$user->hasPermission()` and currently injects only `AdminSectionRegistryInterface` + `GuardInterface` (so the fix must inject `PermissionRegistryInterface`).
+  - **023:** Confirmed — `Job::$attempts` is `public private(set) int = 0` with only `incrementAttempts()` and no reset; `JobInterface` exposes `attempts` as a get-only hook, so the fix adds a `resetAttempts()` to `Job` and `JobInterface`. `Worker` gates real retries on `$job->attempts < $job->maxAttempts`, confirming a non-reset retry re-fails immediately.
+  - **024:** Confirmed — `DebugbarStorage::all()` calls the full-decode `get($id)` per file; the default `masked` list (`config/debugbar.php`) uses `*`→`.+` matching, so `*.password` cannot mask a TOP-LEVEL `password`, and `dsn` is absent entirely.
+  - **016:** `LspProtocol::handleMessage()` ALREADY emits `-32700` for un-decodable JSON bodies; the gap is purely that a header-level malformed frame (`Content-Length: 0`) collapses to the same `null` as EOF in `serve()`, so the fix is the EOF-vs-malformed distinction at the protocol boundary.
+  - **014:** `DocsException::searchFailed()` factory already exists — reuse it, no new factory needed.
+- **All cited findings reproduced in source; none were skipped.** The only adjustments were path/line/method-name drift (above), not absent bugs.
 - **No Tier 3 collision on `Request::path()`.** `tier3-medium-fixes/` is empty (no `_plan.md`, no task files). There is no prior task that touches `Request::path()` or Content-Type handling, so Task 008 owns these changes outright.
 - **Existing conventions confirmed by source reads:**
   - All target packages already use `MarkoException`-style exceptions with `message`/`context`/`suggestion` named params and static factory methods (`InvalidSignatureException`, `SseException`, `LayoutException`→`AmbiguousSortOrderException`, `BindingException`, `LogWriteException`, `DecryptionException`/`EncryptionException`). New factories must follow this shape.
@@ -31,6 +41,9 @@ none
 - F4 OpenSSL AEAD enforcement, false iv-length handling, payload field-type validation.
 - F5 Log line-injection: CR/LF escaping option for the line formatter (default-safe).
 - F6 misc correctness: container cycle detection, manifest `php*`-vendor filter, request Content-Type/path decode, FakeSession null semantics, layout deterministic ambiguity detection, cache-file tmp cleanup / clear glob / mkdir race.
+- F7 tooling/devx hardening (added tasks 013–017): codeindexer cache deserialize safety + corruption rebuild; docs-fts MATCH error → `DocsException`; mcp read-only DB guard against stacked statements; lsp resilience to a malformed frame; Translator placeholder-ordering correctness.
+- F8 database sibling parity (added tasks 018–020): SQL generator type-map parity (mysql/pgsql), MySQL connection explicit PDO param binding, valid empty `whereIn`/`whereNotIn` on both builders.
+- F9 media/admin/queue/debugbar correctness (added tasks 021–024): GD format+alpha preservation and checked encodes; admin-api section visibility wildcard-awareness + `show()` filter parity; queue retry attempt reset; debugbar lazy `all()` + default-mask completeness.
 
 ### Out of Scope
 - Any change to public interface signatures (`WebhookReceiverInterface`, `SessionHandlerInterface`, `EncryptorInterface`, `LoggerInterface`, `ContainerInterface`, `SessionInterface`).
@@ -51,6 +64,18 @@ none
 - [ ] `FakeSession::has()` reports a stored `null` as present, matching production `Session::has()`.
 - [ ] Layout ambiguity detection finds an ambiguous pair deterministically even with 17+ components.
 - [ ] cache-file leaves no orphan `.tmp` files on rename failure, `clear()` removes tmp files too, and concurrent directory creation does not error.
+- [ ] codeindexer treats a corrupt cache as a rebuild trigger (never a silently-empty index) and restricts `unserialize` to a class allowlist.
+- [ ] docs-fts converts a malformed FTS5 MATCH into `DocsException` (never a raw `PDOException`).
+- [ ] mcp read-only DB tool rejects stacked statements (`SELECT 1; DELETE ...`) while still allowing plain selects and opt-in writes.
+- [ ] lsp server responds to a malformed frame with a `-32700` parse error and keeps serving; only true EOF ends the loop.
+- [ ] Translator resolves `:attribute` correctly when `:attr` also exists and never re-replaces a placeholder inside a replacement value.
+- [ ] Each shared abstract column type (`uuid`, `enum`, `bool`, `tinyint`, `blob`, `decimal`) generates valid DDL on BOTH mysql and pgsql generators, with consistent decimal precision.
+- [ ] MySQL connection binds `false`/`true`/`null`/int with correct PDO types (parity with pgsql), not coerced to strings.
+- [ ] `whereIn(col, [])` / `whereNotIn(col, [])` generate valid SQL (no-match / match-all) on both builders — never `IN ()`.
+- [ ] GD resize/crop preserve the source format and transparency, and surface a loud error on encode failure.
+- [ ] admin-api section visibility honors wildcard permissions, and `show()` enforces the same filter as `index()`.
+- [ ] queue RetryCommand resets a retried job's attempts so the worker performs real retries.
+- [ ] debugbar `all()` lists summaries without fully decoding every dataset, and the default mask redacts common secret-named keys (`password`/`secret`/`key`/`token`/`dsn`) at top level and nested.
 - [ ] All tests passing
 - [ ] Code follows project standards
 
@@ -69,8 +94,25 @@ none
 | 010 | FakeSession null-key `has()` parity | - | pending |
 | 011 | Layout deterministic ambiguous-sort-order detection | - | pending |
 | 012 | cache-file tmp cleanup, clear glob, mkdir race | - | pending |
+| 013 | codeindexer cache unserialize hardening (allowed_classes + non-array load failure) | - | pending |
+| 014 | docs-fts malformed MATCH wraps PDOException in DocsException | - | pending |
+| 015 | mcp read-only DB guard rejects stacked statements | - | pending |
+| 016 | lsp server resilience to a malformed frame (parse error, keep serving) | - | pending |
+| 017 | Translator placeholder replacement ordering (single-pass strtr) | - | pending |
+| 018 | SQL generator type-map parity across mysql/pgsql | - | pending |
+| 019 | MySQL connection binds explicit PDO param types (parity with pgsql) | - | pending |
+| 020 | query builder empty `whereIn`/`whereNotIn` → valid no-match/match-all | cross-tier rebase | pending |
+| 021 | GD preserve source format + alpha; check encode returns | - | pending |
+| 022 | admin-api section visibility wildcard-aware + show() filter parity | - | pending |
+| 023 | queue RetryCommand resets attempts before re-queue | Tier-2 coordination | pending |
+| 024 | debugbar lazy `all()` + default-mask completeness | - | pending |
 
-All twelve tasks are independent (no shared files). Tasks 003 and 005 both touch the `sse` package but different files (Task 003: `SseEvent.php` + `SseException.php`; Task 005: `SseStream.php` only). They may run in parallel, but note a LOGICAL coupling: `SseStream::iterateSubscription()` constructs `new SseEvent(data:, event:)`, and Task 003 adds CRLF validation to the `SseEvent` constructor. If Task 005 lands first, its message fixtures must use channel/payload values WITHOUT CRLF so they remain valid once Task 003's constructor guard exists. Whichever task finishes last MUST re-run the full `packages/sse/tests/` suite to catch interaction regressions.
+The original twelve tasks (001–012) are independent (no shared files). Tasks 003 and 005 both touch the `sse` package but different files (Task 003: `SseEvent.php` + `SseException.php`; Task 005: `SseStream.php` only). They may run in parallel, but note a LOGICAL coupling: `SseStream::iterateSubscription()` constructs `new SseEvent(data:, event:)`, and Task 003 adds CRLF validation to the `SseEvent` constructor. If Task 005 lands first, its message fixtures must use channel/payload values WITHOUT CRLF so they remain valid once Task 003's constructor guard exists. Whichever task finishes last MUST re-run the full `packages/sse/tests/` suite to catch interaction regressions.
+
+Tasks 013–024 (gap-audit + dropped-from-consolidation follow-ups) are likewise independent and parallel, with two cross-tier coordination notes:
+- **Task 020** shares `MySqlQueryBuilder.php` / `PgSqlQueryBuilder.php` with Tier 1 / Tier 2 / Tier 3 query-builder tasks. It must be rebased sequentially onto whatever those tiers land; re-locate the `IN (%s)` compile loop before editing and re-run both builders' suites. (See its Implementation Notes.)
+- **Task 023** shares the queue attempt model with Tier 2 queue tasks 004 / 005 / 006. It must consume Tier 2's attempt-counting changes (rebase onto them, adopt their reset/increment API) rather than introduce a parallel mechanism. (See its Implementation Notes.)
+- Tasks 018, 019, 020 all touch the `database-mysql`/`database-pgsql` sibling pair but DIFFERENT files (018: `src/Sql/*Generator.php`; 019: `src/Connection/*Connection.php`; 020: `src/Query/*QueryBuilder.php`), so they are mutually parallel.
 
 ## Architecture Notes
 - **Exceptions:** Reuse each package's existing base exception. New factory methods follow `message`/`context`/`suggestion` named-parameter convention. New exception classes:


### PR DESCRIPTION
## Summary

Follow-up to #114. Adds **21 tasks** to the existing tiered remediation plans, bringing total coverage to **84 TDD tasks** across six plans. Planning artifacts only — no source changes; intended for autonomous execution via `hcf:plan-orchestrate`.

These cover two categories the first pass missed:
1. **Gap-sweep findings** — packages the original 6-agent audit didn't cover (docs-vec, docs-markdown, docs-fts, codeindexer, lsp, mcp, devai, amphp).
2. **Dropped originals** — Medium/Low findings present in the original audit but lost when it was consolidated into the first 63 tasks.

Each finding was re-verified against source before authoring (correcting several line/path drifts — e.g. pgsql `psubscribe` already throws so the multi-channel fix is redis-only; `SectionController` permission logic lives in `admin-auth`; SQL generators are under `src/Sql/`).

| Tier | Added | Now | Highlights |
|---|---|---|---|
| tier2-high-correctness | +1 | 13 | docs-vec hybrid-search RRF crash + FTS5/PDOException leak |
| tier3-medium-fixes | +8 | 20 | docs-markdown traversal, devai deadlock, amphp no-op listener, pubsub multi-channel, MySQL offset-without-limit, Inertia query-string/flash, errors-simple response destruction, pgsql RETURNING non-id PK |
| tier5-low-hardening | +12 | 24 | codeindexer unserialize, docs-fts MATCH wrap, mcp stacked-statement guard, lsp frame resilience, translator ordering, SQL type-map parity, MySQL bind types, empty whereIn, GD format/alpha, admin-api section wildcards, queue retry attempts, debugbar lazy all() |

## Open product decision

`tier3-medium-fixes/015` (amphp `pubsub:listen`): the command currently runs an empty event loop and exits (silent no-op). The task is written to **implement a functional listener** by default, with the documented alternative to **remove** the command + dead config (per the no-pseudo-functionality principle). Worth a maintainer call before that task runs.

Execution order unchanged: Tier 1 → Tier 2 → {Tier 3, Tier 4, discovery-cache} → Tier 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
