### PR TITLE
fix: ship a correct .gitignore to generated projects

### DIFF
--- a/packages/skeleton/.gitattributes
+++ b/packages/skeleton/.gitattributes
@@ -1,5 +1,4 @@
 /tests              export-ignore
 /.github             export-ignore
 /.gitattributes     export-ignore
-/.gitignore         export-ignore
 /phpunit.xml.dist   export-ignore

--- a/packages/skeleton/.gitignore
+++ b/packages/skeleton/.gitignore
@@ -1,4 +1,9 @@
 /vendor/
+/node_modules/
 /.marko/
+/storage/*
+!/storage/.gitkeep
+/public/build
+/public/hot
+/public/storage
 .env
-composer.lock

--- a/packages/skeleton/tests/PackageStructureTest.php
+++ b/packages/skeleton/tests/PackageStructureTest.php
@@ -86,6 +86,52 @@ it('has a README.md file', function (): void {
     expect(file_exists($packagePath . '/README.md'))->toBeTrue();
 });
 
+it('ships a .gitignore to generated projects', function (): void {
+    $gitignorePath = __DIR__ . '/../.gitignore';
+
+    expect(file_exists($gitignorePath))->toBeTrue();
+
+    // The .gitignore must NOT be export-ignored, otherwise composer
+    // create-project strips it from the dist archive and generated
+    // projects ship without one (vendor/, .env, etc. left untracked).
+    $gitattributes = file_get_contents(__DIR__ . '/../.gitattributes');
+
+    expect($gitattributes)->not->toMatch('/^\s*\/?\.gitignore\s+export-ignore/m');
+});
+
+it('keeps composer.lock tracked in generated projects', function (): void {
+    // Application projects must commit composer.lock for reproducible,
+    // repeatable installs across the team. It must not be gitignored.
+    $gitignore = file_get_contents(__DIR__ . '/../.gitignore');
+
+    expect($gitignore)->not->toMatch('/^\s*composer\.lock\s*$/m');
+});
+
+it('ignores generated dependency and build directories', function (): void {
+    $gitignore = file_get_contents(__DIR__ . '/../.gitignore');
+
+    expect($gitignore)
+        ->toContain('/vendor/')        // composer install output
+        ->toContain('/node_modules/')  // npm/pnpm install output
+        ->toContain('/.marko/')        // framework runtime state
+        ->toContain('/public/build')   // vite production assets
+        ->toContain('/public/hot')     // vite dev-server HMR marker
+        ->toContain('/public/storage') // marko storage:link symlink
+        ->toContain('.env');           // secrets
+});
+
+it('ignores storage runtime contents but keeps the directory', function (): void {
+    // storage/ holds runtime output (cache, logs, debugbar) that must be
+    // ignored, while .gitkeep preserves the directory on a fresh clone.
+    $gitignore = file_get_contents(__DIR__ . '/../.gitignore');
+
+    expect($gitignore)
+        ->toMatch('/^\s*\/storage\/\*\s*$/m')
+        ->toMatch('/^\s*!\/storage\/\.gitkeep\s*$/m');
+
+    expect(file_exists(__DIR__ . '/../storage/.gitkeep'))->toBeTrue();
+});
+
 it('lists marko/view-twig in the skeleton composer suggest block', function (): void {
     $composer = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
 


### PR DESCRIPTION
## Problem

The skeleton's `.gitattributes` marked `/.gitignore` as `export-ignore`, so `composer create-project marko/skeleton` stripped it from the dist archive. **Every generated project shipped without a `.gitignore` at all** — leaving `vendor/` (~3,500 files), `node_modules/`, build artifacts and runtime state untracked and trivial to commit by accident. Confirmed on a fresh `marko/skeleton` project where `vendor/` landed in the initial commit.

## Changes

- **`.gitattributes`** — remove the `/.gitignore export-ignore` rule so the ignore file actually lands in new projects. The other export-ignore rules (`/tests`, `/.github`, `/phpunit.xml.dist`, `/.gitattributes`) are package-development files and correctly stay stripped.
- **`.gitignore`** — expand to cover everything the framework generates:
  - `/vendor/`, `/node_modules/` — dependency install output
  - `/.marko/` — framework runtime state (dev-server PIDs, code-index cache, devai marker)
  - `/storage/*` + `!/storage/.gitkeep` — runtime cache/logs/debugbar output, keeping the directory on a fresh clone
  - `/public/build`, `/public/hot`, `/public/storage` — Vite assets, HMR marker, and the `storage:link` symlink
  - **Drop `composer.lock`** — application projects must commit their lock file for reproducible, repeatable installs across the team.
- **`PackageStructureTest`** — new regression guards: `.gitignore` is shipped (not export-ignored), `composer.lock` stays tracked, dependency/build dirs are ignored, and `storage/` runtime contents are ignored while `.gitkeep` is preserved.

## Notes

- `.claude/` (written by `devai`) is intentionally left tracked — it's shared team agent config, and is the `devai` package's domain, not the skeleton's.
- Existing projects created from the old skeleton won't be retroactively fixed; this only affects newly generated projects.

## Test plan

- [x] `pest packages/skeleton/tests/PackageStructureTest.php` — 20 passed (37 assertions)
- [x] `phpcs` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)