### PR TITLE
docs: document devai marker-based override model in agent docs

### DIFF
--- a/packages/docs-markdown/docs/ai-assisted-development/agents/claude-code.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/agents/claude-code.md
@@ -31,6 +31,8 @@ CLAUDE.md                          # Includes @AGENTS.md and Claude-specific not
 
 The installer writes merged Marko guidelines to `AGENTS.md`. The `CLAUDE.md` file references it via `@AGENTS.md` and adds a short Marko tooling section that describes the three plugins and the skill authority directive (skills are canonical spec — do not infer from sibling code).
 
+Both files are written inside a `<!-- BEGIN/END marko:devai -->` marker block: each is created if absent, and on later runs only the marked region is refreshed — so anything you add outside the markers (your own project instructions in `CLAUDE.md`, extra guidelines in `AGENTS.md`) is preserved. Remove the markers to take full ownership and devai leaves the file alone. See [Editing generated files](../#editing-generated-files). This is separate from the `.marko/devai.json` install marker described below, which only tracks whether devai has run.
+
 ### .claude/settings.json
 
 `devai:install` writes (or merges into) `.claude/settings.json` with two keys:

--- a/packages/docs-markdown/docs/ai-assisted-development/agents/codex.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/agents/codex.md
@@ -24,7 +24,7 @@ MCP registration is performed via the Codex CLI (`codex mcp add`) rather than by
 
 ### AGENTS.md
 
-The root `AGENTS.md` receives Marko project guidelines:
+The root `AGENTS.md` receives Marko project guidelines inside a `<!-- BEGIN/END marko:devai -->` marker block: created if absent, and on later runs only the marked region is refreshed, so anything you add outside the markers is preserved. Remove the markers to take full ownership — devai then leaves the file alone (see [Editing generated files](../#editing-generated-files)). It contains:
 
 - Marko module conventions and project structure overview
 - Available MCP tools and their descriptions

--- a/packages/docs-markdown/docs/ai-assisted-development/agents/copilot.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/agents/copilot.md
@@ -18,14 +18,14 @@ Running `marko devai:install` with Copilot detected produces the following files
 ```
 .github/copilot-instructions.md    # Workspace-level guidelines for Copilot Chat
 .vscode/mcp.json                   # MCP server registration (marko mcp:serve)
-AGENTS.md                          # Shared guidelines file (written if not already present)
+AGENTS.md                          # Shared guidelines file (devai-managed marker block)
 ```
 
 Copilot does not implement LSP registration and no skills are distributed for Copilot.
 
 ### copilot-instructions.md
 
-The `.github/copilot-instructions.md` file is read by Copilot Chat for every workspace session. The installer writes merged Marko guidelines:
+The `.github/copilot-instructions.md` file is read by Copilot Chat for every workspace session. The installer writes merged Marko guidelines inside a `<!-- BEGIN/END marko:devai -->` marker block, so your own edits outside the markers survive re-runs (see [Editing generated files](../#editing-generated-files)):
 
 - Module structure and naming conventions
 - Available MCP tools
@@ -37,7 +37,7 @@ The `.vscode/mcp.json` file registers `marko mcp:serve` as an MCP server using t
 
 ### AGENTS.md
 
-If no `AGENTS.md` exists in the project root, `devai:install` creates one with the same guidelines content. If `AGENTS.md` already exists, it is left untouched.
+`devai:install` writes the shared `AGENTS.md` guidelines inside a `<!-- BEGIN/END marko:devai -->` marker block: created if absent, and on later runs only the marked region is refreshed, so content you add outside the markers is preserved. Remove the markers to take full ownership — devai then leaves the file alone. See [Editing generated files](../#editing-generated-files).
 
 ## Manual verification
 

--- a/packages/docs-markdown/docs/ai-assisted-development/agents/cursor.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/agents/cursor.md
@@ -17,14 +17,14 @@ Running `marko devai:install` with Cursor detected produces the following files:
 ```
 .cursor/rules/marko.mdc            # Project guidelines and conventions (alwaysApply: true)
 .cursor/mcp.json                   # MCP server registration (marko mcp:serve)
-AGENTS.md                          # Shared guidelines file (written if not already present)
+AGENTS.md                          # Shared guidelines file (devai-managed marker block)
 ```
 
 Cursor does not implement LSP registration and no skills are distributed for Cursor.
 
 ### .cursor/rules/marko.mdc
 
-The `.cursor/rules/marko.mdc` file is written with `alwaysApply: true` frontmatter so it is always included in Cursor's context. It contains merged Marko guidelines:
+The `.cursor/rules/marko.mdc` file is written with `alwaysApply: true` frontmatter so it is always included in Cursor's context. The YAML frontmatter stays the first line of the file; the devai-managed guidelines sit below it inside a `<!-- BEGIN/END marko:devai -->` marker block, so you can add your own rules outside the markers without losing them on re-run. It contains merged Marko guidelines:
 
 - Module structure and naming conventions
 - Available MCP tools and usage patterns
@@ -36,7 +36,7 @@ The `.cursor/mcp.json` file registers `marko mcp:serve` as an MCP server using t
 
 ### AGENTS.md
 
-If no `AGENTS.md` exists in the project root, `devai:install` creates one with the same guidelines content. If `AGENTS.md` already exists, it is left untouched.
+`devai:install` writes the shared `AGENTS.md` guidelines inside a `<!-- BEGIN/END marko:devai -->` marker block: created if absent, and on later runs only the marked region is refreshed, so content you add outside the markers is preserved. Remove the markers to take full ownership — devai then leaves the file alone. See [Editing generated files](../#editing-generated-files).
 
 ## Manual verification
 

--- a/packages/docs-markdown/docs/ai-assisted-development/agents/gemini-cli.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/agents/gemini-cli.md
@@ -18,14 +18,14 @@ Running `marko devai:install` with Gemini CLI detected produces the following:
 ```
 GEMINI.md                          # Project guidelines for Gemini CLI
 .gemini/skills/                    # Marko skill files distributed for Gemini CLI
-AGENTS.md                          # Shared guidelines file (written if not already present)
+AGENTS.md                          # Shared guidelines file (devai-managed marker block)
 ```
 
 MCP registration is performed via the Gemini CLI (`gemini mcp add`) rather than by writing a config file. Gemini CLI does not implement LSP registration.
 
 ### GEMINI.md
 
-The root `GEMINI.md` file receives Marko project guidelines:
+The root `GEMINI.md` file receives Marko project guidelines inside a `<!-- BEGIN/END marko:devai -->` marker block, so your own edits outside the markers survive re-runs (see [Editing generated files](../#editing-generated-files)):
 
 - Module structure and naming conventions
 - Available MCP tools and their usage patterns
@@ -41,7 +41,7 @@ Marko skill bundles are written to `.gemini/skills/` so Gemini CLI can reference
 
 ### AGENTS.md
 
-If no `AGENTS.md` exists in the project root, `devai:install` creates one with the same guidelines content. If `AGENTS.md` already exists, it is left untouched.
+`devai:install` writes the shared `AGENTS.md` guidelines inside a `<!-- BEGIN/END marko:devai -->` marker block: created if absent, and on later runs only the marked region is refreshed, so content you add outside the markers is preserved. Remove the markers to take full ownership — devai then leaves the file alone. See [Editing generated files](../#editing-generated-files).
 
 ## Manual verification
 

--- a/packages/docs-markdown/docs/ai-assisted-development/agents/junie.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/agents/junie.md
@@ -18,7 +18,7 @@ Running `marko devai:install` with Junie detected produces the following files:
 ```
 junie/guidelines.md                # Project guidelines read by Junie on each session
 junie/skills/                      # Marko skill files distributed for Junie
-AGENTS.md                          # Shared guidelines file (written if not already present)
+AGENTS.md                          # Shared guidelines file (devai-managed marker block)
 ```
 
 Junie does not implement MCP registration or LSP registration.
@@ -37,7 +37,7 @@ Marko skill bundles are written to `junie/skills/` so Junie can reference them d
 
 ### AGENTS.md
 
-If no `AGENTS.md` exists in the project root, `devai:install` creates one with the same guidelines content. If `AGENTS.md` already exists, it is left untouched.
+`devai:install` writes the shared `AGENTS.md` guidelines inside a `<!-- BEGIN/END marko:devai -->` marker block: created if absent, and on later runs only the marked region is refreshed, so content you add outside the markers is preserved. Remove the markers to take full ownership — devai then leaves the file alone. See [Editing generated files](../#editing-generated-files).
 
 ## Manual verification
 

--- a/packages/docs-markdown/docs/ai-assisted-development/index.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/index.md
@@ -24,12 +24,28 @@ marko devai:install
 
 `devai:install` inspects your environment, detects which agents are present, and writes the necessary configuration files for each one. See the [Installation guide](./installation/) for the full walkthrough.
 
+## Editing generated files
+
+Every guideline file devai generates — `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `junie/guidelines.md`, `.cursor/rules/marko.mdc` — is **yours to edit**. devai only owns the content inside a marker block:
+
+```
+<!-- BEGIN marko:devai -->
+…devai-managed guidelines…
+<!-- END marko:devai -->
+```
+
+- A file that doesn't exist yet is **created** with the markers in place.
+- Re-running `marko devai:install` or `marko devai:update` rewrites **only the content between the markers** — anything you add above or below them is preserved verbatim.
+- **Remove the markers** (or hand-author a file that never had them) and devai **backs off entirely**: it stops managing that file and logs a notice. That's the full-ownership escape hatch — no lock-in.
+
+This behaves identically for every agent. (`.cursor/rules/marko.mdc` keeps its YAML frontmatter as the first line, with the marker block below it.)
+
 ## What each package provides
 
 ### marko/devai
 
 - Single `devai:install` command that auto-detects Claude Code, Codex, Cursor, Copilot, Gemini CLI, and Junie
-- Writes agent-specific configuration files (`CLAUDE.md`, `.cursor/rules/marko.mdc`, `.github/copilot-instructions.md`, `GEMINI.md`, `junie/guidelines.md`, etc.)
+- Writes agent-specific configuration files as editable marker blocks (`CLAUDE.md`, `.cursor/rules/marko.mdc`, `.github/copilot-instructions.md`, `GEMINI.md`, `junie/guidelines.md`, etc.) — see [Editing generated files](#editing-generated-files)
 - Registers the MCP server with each agent that supports it (via config file or CLI command depending on the agent)
 - Distributes per-package guidelines and skills from `resources/ai/` directories across your installed packages
 


### PR DESCRIPTION
## Summary

Follow-up to #124. That PR introduced the marker-based, user-overridable guideline files but only documented the override model on the `marko/devai` package page — the user-facing **AI-Assisted Development** docs still described the old behavior.

## What changed

- **`index.md`** — new **"Editing generated files"** section: the `<!-- BEGIN/END marko:devai -->` marker block, partial regeneration (only the marked region is rewritten), and the remove-the-markers full-ownership escape hatch.
- **Each agent page** (`claude-code`, `codex`, `cursor`, `gemini-cli`, `copilot`, `junie`) — replaced the now-stale `written if not already present` / `if it already exists, it is left untouched` wording with the marker-aware behavior, each linking to the shared section.
- **`cursor.md`** — notes the `.mdc` keeps its YAML frontmatter as the first line, with the marker block below it.

## Testing

`packages/docs-markdown` suite green: 17 passed. No stale wording remains (`grep` clean).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)