### PR TITLE
fix(marko-skills): derive scaffold vendor from project dir, never marko

### DIFF
--- a/packages/claude-plugins/plugins/marko-skills/skills/create-module/SKILL.md
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-module/SKILL.md
@@ -20,7 +20,9 @@ A Marko module is a Composer package that the framework auto-discovers via the `
 - Vendor package: standalone repo, resolves to `vendor/{vendor}/{name}/`
 - App-local module: `app/{Module}/` inside the host project
 
-The composer name is `{vendor}/{name}` (e.g. `marko/payment`, `acme/payment`). The PHP namespace is the StudlyCase form: `Marko\Payment`, `Acme\Payment`.
+The composer name is `{vendor}/{name}` and the PHP namespace is its StudlyCase form (e.g. `acme/payment` → `Acme\Payment`).
+
+**Choosing `{vendor}` — derive it from the host project, never hardcode it.** Use the project's root **directory name** as the vendor: a project in `~/Sites/acme` → vendor `acme`, namespace `Acme`. **Never suggest `marko` as the vendor for an application module.** The `marko` vendor is reserved for packages contributed to the Marko framework monorepo itself — only relevant when you are actually working inside that monorepo (its root contains `packages/core/`). Do **not** read the vendor from the project's `composer.json` `name`: a project scaffolded from `marko/skeleton` still carries `marko/skeleton` there, so the directory name is the reliable signal. When you offer the user a default, lead with the project-derived vendor (`{project-dir}/{name}`), not `marko/{name}`.
 
 ## Step 2 — Write composer.json
 

--- a/packages/claude-plugins/plugins/marko-skills/skills/create-plugin/SKILL.md
+++ b/packages/claude-plugins/plugins/marko-skills/skills/create-plugin/SKILL.md
@@ -84,9 +84,11 @@ Copy `assets/PluginClass.php.tmpl` verbatim. Substitute:
 
 | Placeholder       | Value                                  |
 |-------------------|----------------------------------------|
-| `{{Vendor}}`      | Composer vendor namespace (e.g., `App`) |
+| `{{Vendor}}`      | Host-project vendor in StudlyCase (e.g. project in `~/Sites/acme` → `Acme`) |
 | `{{Name}}`        | Module name (e.g., `Blog`)             |
 | `{{TargetClass}}` | Unqualified class name (e.g., `PostRepository`) |
+
+**Choosing `{{Vendor}}` — derive it from the host project, never hardcode it.** Use the project's root **directory name**, StudlyCased (a project in `~/Sites/acme` → `Acme`). **Never suggest `Marko` as the vendor for an application plugin** — the `Marko` vendor is reserved for code contributed to the Marko framework monorepo itself (only when you are working inside that monorepo). Do **not** read the vendor from the project's `composer.json` `name`: a skeleton-derived project still carries `marko/skeleton` there, so the directory name is the reliable signal.
 
 Place the file at `src/Plugins/{{TargetClass}}Plugin.php` inside the module.
 


### PR DESCRIPTION
## Summary

When scaffolding a module/plugin inside an application project, the `marko-skills` skills suggested the **`marko/`** vendor (e.g. `marko/payment` → `Marko\Payment`). That's wrong for an implementation — the `marko` vendor is reserved for packages contributed to the framework monorepo itself. An app's modules must use the **project's own vendor**.

## Fix

Both skills (`create-module`, `create-plugin`) now instruct the agent to:

- Derive `{{vendor}}` from the host project's **root directory name** (a project in `~/Sites/acme` → vendor `acme`, namespace `Acme`).
- **Never** suggest `marko` as the vendor for an application module/plugin (only valid inside the marko monorepo, whose root contains `packages/core/`).
- **Not** read the vendor from the project's `composer.json` `name` — a project scaffolded from `marko/skeleton` still carries `marko/skeleton` there, so the directory name is the reliable signal.

## Testing

`packages/claude-plugins` suite green: 71 passed. Examples use the conventional `acme` placeholder (matching existing test fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)