### PR TITLE
fix(docs-fts): sanitize natural-language queries into safe FTS5 expressions

### DIFF
--- a/packages/docs-fts/src/FtsQueryBuilder.php
+++ b/packages/docs-fts/src/FtsQueryBuilder.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\DocsFts;
+
+class FtsQueryBuilder
+{
+    /**
+     * Common English stop words plus the FTS5 boolean operator keywords
+     * (`and`/`or`/`not`). Dropped to improve precision. `near` is intentionally
+     * absent — it is neutralized by quoting instead, so a real search term like
+     * "near" is preserved.
+     */
+    private const array STOP_WORDS = [
+        'a', 'an', 'and', 'are', 'as', 'at', 'be', 'but', 'by', 'can', 'did',
+        'do', 'does', 'for', 'from', 'how', 'i', 'in', 'is', 'it', 'me', 'my',
+        'no', 'not', 'of', 'on', 'or', 'that', 'the', 'this', 'to', 'was', 'were',
+        'what', 'when', 'where', 'which', 'why', 'with', 'you', 'your',
+    ];
+
+    /**
+     * Convert a natural-language query into a safe FTS5 MATCH expression.
+     *
+     * Raw user input cannot be handed to FTS5 directly: apostrophes and quotes are
+     * parsed as query syntax (raising "fts5: syntax error"), and FTS5's default
+     * implicit-AND across every token tanks recall on full questions ("how do
+     * observers react to events" requires *every* word in one document).
+     *
+     * This tokenizes to alphanumeric words (dropping punctuation entirely), removes
+     * stop words, quotes each remaining term (neutralizing FTS5 keyword operators),
+     * and OR-joins them so BM25 ranks by term overlap. Returns '' when no usable
+     * term remains, so the caller can short-circuit to an empty result set.
+     */
+    public static function toMatchExpression(string $raw): string
+    {
+        $tokens = self::tokenize($raw);
+
+        if ($tokens === []) {
+            return '';
+        }
+
+        $meaningful = array_values(array_filter(
+            $tokens,
+            static fn (string $token): bool => mb_strlen($token) > 1
+                && !in_array($token, self::STOP_WORDS, true),
+        ));
+
+        // If filtering removed everything (e.g. an all-stop-word question), fall
+        // back to the raw tokens so the search still looks for something.
+        $terms = $meaningful === [] ? $tokens : $meaningful;
+
+        return implode(' OR ', array_map(
+            static fn (string $term): string => '"' . $term . '"',
+            $terms,
+        ));
+    }
+
+    /** @return list<string> */
+    private static function tokenize(string $raw): array
+    {
+        preg_match_all('/[\p{L}\p{N}]+/u', mb_strtolower($raw), $matches);
+
+        return $matches[0];
+    }
+}

--- a/packages/docs-fts/src/FtsSearch.php
+++ b/packages/docs-fts/src/FtsSearch.php
@@ -30,6 +30,13 @@ class FtsSearch implements DocsSearchInterface
      */
     public function search(DocsQuery $query): array
     {
+        $expression = FtsQueryBuilder::toMatchExpression($query->query);
+
+        // No usable search terms (e.g. punctuation-only input) — nothing to match.
+        if ($expression === '') {
+            return [];
+        }
+
         $pdo = $this->pdo();
         $stmt = $pdo->prepare("
             SELECT page_id, title,
@@ -40,7 +47,7 @@ class FtsSearch implements DocsSearchInterface
             ORDER BY bm25(docs_fts)
             LIMIT :limit
         ");
-        $stmt->bindValue(':q', $query->query, PDO::PARAM_STR);
+        $stmt->bindValue(':q', $expression, PDO::PARAM_STR);
         $stmt->bindValue(':limit', $query->limit, PDO::PARAM_INT);
 
         try {

--- a/packages/docs-fts/tests/Unit/FtsQueryBuilderTest.php
+++ b/packages/docs-fts/tests/Unit/FtsQueryBuilderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\DocsFts\FtsQueryBuilder;
+
+it('lowercases and quotes each term joined with OR', function (): void {
+    expect(FtsQueryBuilder::toMatchExpression('Routing Attributes'))
+        ->toBe('"routing" OR "attributes"');
+});
+
+it('strips apostrophes and punctuation that break FTS5', function (): void {
+    // "Marko's" must not leave a stray apostrophe in the expression.
+    expect(FtsQueryBuilder::toMatchExpression("how does Marko's module system work?"))
+        ->toBe('"marko" OR "module" OR "system" OR "work"');
+});
+
+it('drops common stop words to improve precision', function (): void {
+    $expr = FtsQueryBuilder::toMatchExpression('how do observers react to events');
+
+    expect($expr)->toContain('"observers"')
+        ->and($expr)->toContain('"react"')
+        ->and($expr)->toContain('"events"')
+        ->and($expr)->not->toContain('"how"')
+        ->and($expr)->not->toContain('"do"')
+        ->and($expr)->not->toContain('"to"');
+});
+
+it('joins terms with OR rather than implicit AND', function (): void {
+    expect(FtsQueryBuilder::toMatchExpression('observers events'))
+        ->toBe('"observers" OR "events"');
+});
+
+it('quotes an FTS5 keyword term so it is not treated as an operator', function (): void {
+    // "near" is a valid search term but also an FTS5 operator — quoting neutralizes it.
+    expect(FtsQueryBuilder::toMatchExpression('near cache'))
+        ->toBe('"near" OR "cache"');
+});
+
+it('falls back to all tokens when every token is a stop word', function (): void {
+    expect(FtsQueryBuilder::toMatchExpression('how do you'))
+        ->toBe('"how" OR "do" OR "you"');
+});
+
+it('returns an empty expression for input with no word characters', function (): void {
+    expect(FtsQueryBuilder::toMatchExpression('!!! "" ((('))->toBe('');
+});

--- a/packages/docs-fts/tests/Unit/FtsSearchTest.php
+++ b/packages/docs-fts/tests/Unit/FtsSearchTest.php
@@ -103,22 +103,35 @@ it('returns nav tree via listNav', function (): void {
         ->and($nav[0])->toBeInstanceOf(DocsNavEntry::class);
 });
 
-it('throws DocsException when the MATCH expression is malformed', function (): void {
-    expect(fn () => $this->search->search(new DocsQuery('"unbalanced')))->toThrow(DocsException::class);
+it('sanitizes stray quotes in the query instead of throwing', function (): void {
+    $results = $this->search->search(new DocsQuery('"unbalanced'));
+
+    expect($results)->toBeArray();
 });
 
-it('does not leak a PDOException from a malformed search query', function (): void {
+it('does not leak a PDOException for a query containing punctuation', function (): void {
     $thrown = null;
 
     try {
-        $this->search->search(new DocsQuery('"unbalanced'));
+        $this->search->search(new DocsQuery('Marko\'s "weird" query!'));
     } catch (Throwable $e) {
         $thrown = $e;
     }
 
-    expect($thrown)->not->toBeNull()
-        ->and($thrown)->not->toBeInstanceOf(PDOException::class)
-        ->and($thrown)->toBeInstanceOf(DocsException::class);
+    expect($thrown)->toBeNull();
+});
+
+it('matches a natural-language question via OR semantics', function (): void {
+    // Implicit-AND would require every word in one doc; OR + stop-word removal finds it.
+    $results = $this->search->search(new DocsQuery('How do I install the framework?'));
+
+    expect($results)->not->toBeEmpty();
+});
+
+it('does not throw on a query containing an apostrophe', function (): void {
+    $results = $this->search->search(new DocsQuery("Marko's installation guide"));
+
+    expect($results)->not->toBeEmpty();
 });
 
 it('returns results for a valid search query', function (): void {


### PR DESCRIPTION
## Summary

`search_docs` (the MCP docs tool, backed by `docs-fts`) returned syntax errors or zero results for ordinary natural-language questions. `FtsSearch::search()` bound the raw query into `docs_fts MATCH :q`, and FTS5 interprets that operand as a **query expression**:

1. **Punctuation = syntax error** — an apostrophe (`Marko's`) or stray quote raised `fts5: syntax error`.
2. **Implicit AND** — a full question (`how do observers react to events`) required *every* token in one document → **zero results**.

## Fix

New `FtsQueryBuilder::toMatchExpression()` converts NL input into a safe expression: tokenize to alphanumeric words (dropping punctuation), remove stop words + FTS5 boolean keywords, quote each term, OR-join them so BM25 ranks by overlap. Empty input short-circuits to no results.

## Evidence (real `docs-markdown` corpus)

Queries that previously failed now surface the right doc in top-3:

| Query | Before | After |
|---|---|---|
| observers react to events | **zero** | `concepts/events` |
| Preferences replace a class | miss | `concepts/preferences` (rank 1) |
| routes defined with attributes | miss | `guides/routing` (rank 1) |

This recovers ~3 of the 5 misses from an in-project audit (effective ~6/8). The two remaining (modularity ranking, `config` vs `configuration` porter stemming) are genuine content gaps, tracked separately.

## Testing

`packages/docs-fts` green: 36 passed. New `FtsQueryBuilderTest` (7 cases) + updated `FtsSearchTest` (malformed input is now sanitized, not thrown; NL + apostrophe queries return results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)