### PR TITLE
fix(docs-vec): make the hybrid driver buildable and runnable on stock PHP

### DIFF
--- a/packages/docs-markdown/docs/ai-assisted-development/docs-drivers.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/docs-drivers.md
@@ -36,11 +36,15 @@ If you want semantic search instead of lexical, install `marko/docs-vec` *instea
 
 ```bash
 composer require --dev marko/docs-vec
-marko docs-vec:download-model
-marko docs-vec:build
+composer require --dev codewithkyrian/transformers   # query-time embeddings (^0.6 with symfony 8)
+marko docs-vec:download-extension                     # sqlite-vec native binary for this platform
+marko docs-vec:download-model                         # bge-small-en-v1.5 ONNX model
+marko docs-vec:build                                  # build the hybrid FTS5 + vector index
 ```
 
 Re-running `marko devai:install` then builds the vec index — the orchestrator detects which driver is in `vendor/` (preferring `docs-vec` when present) and builds that one.
+
+**Graceful fallback.** Semantic ranking needs three things: the `sqlite-vec` extension, the ONNX model, and `codewithkyrian/transformers`. If any is missing — or the PHP build can't load SQLite extensions — `docs-vec` automatically builds and serves an **FTS5-only** index instead of failing, and `marko docs-vec:build` reports which mode it used. So `composer require marko/docs-vec` alone already works lexically; the two `download-*` commands plus `transformers` upgrade it to full semantic search.
 
 ## Switching drivers
 
@@ -62,14 +66,14 @@ Then re-run `marko devai:install --force` (or the driver's `:build` command) to 
 
 | Feature | docs-fts | docs-vec |
 |---|---|---|
-| Search type | Lexical (exact terms) | Semantic (meaning-based) |
-| Setup | None — single `composer require` | Requires ONNX model download (~40 MB) |
-| Offline | Yes | Yes (after model download) |
-| Exact-query accuracy | Excellent | Good |
+| Search type | Lexical (exact terms) | Hybrid: FTS5 keyword + semantic vector (meaning-based) |
+| Setup | None — single `composer require` | `download-extension` + `download-model` (~130 MB) + `composer require codewithkyrian/transformers` |
+| Offline | Yes | Yes (after the one-time downloads) |
+| Exact-query accuracy | Excellent | Excellent (FTS5 half) |
 | Conceptual-query accuracy | Limited | Excellent |
-| Index build time | Fast (< 1s) | Slower (30–120s depending on corpus size) |
-| Index size | Small | Larger (embeddings per chunk) |
-| Required PHP extensions | `pdo_sqlite` (standard) | `pdo_sqlite` + `sqlite-vec` |
+| Index build time | Fast (< 1s) | Slower (~30–120s — one ONNX embedding per chunk) |
+| Index size | Small | Larger (a 384-d embedding per chunk) |
+| Required PHP extensions | `pdo_sqlite` (standard) | `pdo_sqlite` + the `sqlite-vec` loadable extension; PHP must permit extension loading (falls back to FTS5 otherwise) |
 
 ## Choosing fts
 
@@ -85,7 +89,9 @@ Most projects should stay on fts.
 Use **`docs-vec`** when:
 - Your agents ask vague or conceptual questions ("how does Marko handle dependencies?")
 - You want results ranked by meaning, not term overlap
-- You can install `sqlite-vec` and spare the one-time ~40 MB model download
+- You can spare the one-time downloads (`marko docs-vec:download-extension` fetches the platform `sqlite-vec` binary; `marko docs-vec:download-model` fetches the ~130 MB ONNX model) and your PHP build permits loading SQLite extensions
+
+`marko docs-vec:download-extension` ships pinned, checksum-verified `sqlite-vec` builds for macOS, Linux, and Windows (x86_64 / arm64). On an unsupported platform — or a PHP build with extension loading compiled out — `docs-vec` degrades to FTS5-only rather than failing.
 
 ## Package READMEs
 

--- a/packages/docs-markdown/docs/packages/docs-vec.md
+++ b/packages/docs-markdown/docs/packages/docs-vec.md
@@ -3,7 +3,7 @@ title: marko/docs-vec
 description: Hybrid FTS5 + sqlite-vec semantic documentation search driver with local ONNX embeddings.
 ---
 
-Hybrid semantic search driver for Marko documentation, implementing [`DocsSearchInterface`](/docs/packages/docs/). It combines SQLite FTS5 keyword search with `sqlite-vec` vector similarity (local ONNX embeddings via `codewithkyrian/transformers-php`), ranking results by a weighted blend of BM25 and cosine similarity — so a query finds relevant docs even when the wording differs. When the model isn't present it falls back to FTS5-only keyword search using its own built-in index.
+Hybrid semantic search driver for Marko documentation, implementing [`DocsSearchInterface`](/docs/packages/docs/). It combines SQLite FTS5 keyword search with `sqlite-vec` vector similarity (local ONNX embeddings via `codewithkyrian/transformers`), ranking results by a weighted blend of BM25 and cosine similarity — so a query finds relevant docs even when the wording differs. When the model isn't present it falls back to FTS5-only keyword search using its own built-in index.
 
 `docs-fts` and `docs-vec` are sibling drivers of the same `marko/docs` contract — install **one**. Choose `docs-vec` for semantic relevance; choose [`marko/docs-fts`](/docs/packages/docs-fts/) for a zero-model lightweight option.
 
@@ -11,10 +11,34 @@ Hybrid semantic search driver for Marko documentation, implementing [`DocsSearch
 
 ```bash
 composer require marko/docs-vec
-composer require codewithkyrian/transformers-php   # query-time embeddings
+composer require codewithkyrian/transformers   # query-time embeddings (^0.6 with symfony 8)
+marko docs-vec:download-extension              # sqlite-vec native binary for this platform
+marko docs-vec:download-model                  # bge-small-en-v1.5 ONNX model
+marko docs-vec:build                           # build the hybrid index
 ```
 
-Requires `ext-pdo_sqlite`. Vector search additionally needs the `sqlite-vec` extension.
+Requires `ext-pdo_sqlite`. Semantic ranking additionally needs the `sqlite-vec` loadable
+extension, the ONNX model, `codewithkyrian/transformers`, and a PHP build that permits
+loading SQLite extensions.
+
+**Graceful fallback.** `docs-vec` works with `composer require` alone: when the extension,
+model, or `transformers` is unavailable (or PHP can't load extensions), both `build` and
+`search` automatically degrade to **FTS5-only keyword search** instead of failing. The two
+`download-*` commands plus `transformers` upgrade it to full hybrid semantic search.
+
+## The sqlite-vec extension
+
+Vector search relies on the native [`sqlite-vec`](https://github.com/asg017/sqlite-vec)
+loadable extension, loaded through PHP's `Pdo\Sqlite::loadExtension()`:
+
+```bash
+marko docs-vec:download-extension
+```
+
+- Ships pinned, SHA-256-verified `sqlite-vec` builds for macOS, Linux, and Windows (x86_64 / arm64).
+- Written to `resources/sqlite-vec/` (gitignored). Mirror override: `--base-url=<your-mirror>`.
+- On an unsupported platform, or a PHP build with extension loading disabled, `docs-vec`
+  falls back to FTS5-only search.
 
 ## The ONNX model
 
@@ -32,8 +56,9 @@ marko docs-vec:download-model
 ## Usage
 
 ```bash
-marko docs-vec:download-model   # once
-marko docs-vec:build            # build the hybrid index
+marko docs-vec:download-extension   # once — sqlite-vec native binary
+marko docs-vec:download-model       # once — ONNX model
+marko docs-vec:build                # build the hybrid index
 ```
 
 `module.php` binds `DocsSearchInterface` to `VecSearch` automatically; inject the contract and call `search(new DocsQuery(...))`.

--- a/packages/docs-vec/README.md
+++ b/packages/docs-vec/README.md
@@ -4,7 +4,7 @@ Hybrid FTS5 + sqlite-vec semantic documentation search driver for Marko — comb
 
 ## Overview
 
-`marko/docs-vec` implements `DocsSearchInterface` using both SQLite FTS5 (keyword) and `sqlite-vec` (vector embeddings) with ONNX Runtime for local inference via `codewithkyrian/transformers-php`. Results are ranked by a weighted combination of BM25 keyword score and cosine similarity, giving accurate answers even when the query wording differs from the documentation. When the model is not downloaded (or on a platform without ONNX support), it falls back to FTS5-only keyword search using its own built-in index. Use `marko/docs-fts` instead if you only want lightweight keyword search.
+`marko/docs-vec` implements `DocsSearchInterface` using both SQLite FTS5 (keyword) and `sqlite-vec` (vector embeddings) with ONNX Runtime for local inference via `codewithkyrian/transformers`. Results are fused (reciprocal-rank fusion) across BM25 keyword ranking and cosine similarity, giving accurate answers even when the query wording differs from the documentation. When the `sqlite-vec` extension, the model, or `transformers` is unavailable — or the PHP build can't load SQLite extensions — it falls back to FTS5-only keyword search using its own built-in index. Use `marko/docs-fts` instead if you only want lightweight keyword search.
 
 ## Installation
 
@@ -12,15 +12,36 @@ Hybrid FTS5 + sqlite-vec semantic documentation search driver for Marko — comb
 composer require marko/docs-vec
 ```
 
-For query-time embeddings, also install the ONNX runtime:
+That alone gives you working FTS5-only search. For full hybrid semantic search, add the
+ONNX runtime and fetch the native extension and model:
 
 ```bash
-composer require codewithkyrian/transformers-php
+composer require codewithkyrian/transformers   # ^0.6 with symfony 8 (^0.5 with symfony 6/7)
+marko docs-vec:download-extension              # sqlite-vec native binary for this platform
+marko docs-vec:download-model                  # bge-small-en-v1.5 ONNX model
+marko docs-vec:build                           # build the hybrid index
 ```
+
+> **Graceful fallback.** Every piece above is optional: if the extension, model, or
+> `transformers` is missing (or PHP can't load SQLite extensions), `build` and `search`
+> degrade to FTS5-only instead of failing. `marko docs-vec:build` reports which mode it used.
+
+## The sqlite-vec extension
+
+Vector search loads the native [`sqlite-vec`](https://github.com/asg017/sqlite-vec) extension
+via PHP's `Pdo\Sqlite::loadExtension()` (not a `SELECT load_extension(...)` SQL call, which
+SQLite blocks by default). Fetch a pinned, checksum-verified build for your platform:
+
+```bash
+marko docs-vec:download-extension
+```
+
+Ships `sqlite-vec` builds for macOS, Linux, and Windows (x86_64 / arm64), written to
+`resources/sqlite-vec/` (gitignored). Mirror/firewall override: `--base-url=<your-mirror>`.
 
 ## ONNX model
 
-This package uses the **bge-small-en-v1.5** model (~130MB across `model.onnx`, `tokenizer.json`, `config.json`) for semantic embeddings. The model is **not** committed to the repository — it is downloaded on demand and verified by SHA-256.
+This package uses the **bge-small-en-v1.5** model (~130MB across `onnx/model.onnx` plus `config.json`, `tokenizer.json`, `tokenizer_config.json`, and `special_tokens_map.json`) for semantic embeddings. The files use the HuggingFace layout transformers-php expects. The model is **not** committed to the repository — it is downloaded on demand and verified by SHA-256.
 
 ### Downloading the model
 
@@ -46,9 +67,12 @@ The ONNX runtime supports Linux (x64, ARM64), macOS (x64, ARM64), and Windows (x
 
 ## Usage
 
-After installing and downloading the model, `module.php` binds `DocsSearchInterface` to `VecSearch` automatically. Build the hybrid index, then search:
+`module.php` binds `DocsSearchInterface` to `VecSearch` automatically. After fetching the
+extension and model, build the index, then inject the contract and search:
 
 ```bash
+marko docs-vec:download-extension
+marko docs-vec:download-model
 marko docs-vec:build
 ```
 

--- a/packages/docs-vec/composer.json
+++ b/packages/docs-vec/composer.json
@@ -15,7 +15,7 @@
         "pestphp/pest": "^4.0"
     },
     "suggest": {
-        "codewithkyrian/transformers-php": "Required for query-time embeddings (^0.5)"
+        "codewithkyrian/transformers": "Required for query-time embeddings (^0.5 || ^0.6; use ^0.6 with symfony/console 8)"
     },
     "autoload": {
         "psr-4": {

--- a/packages/docs-vec/module.php
+++ b/packages/docs-vec/module.php
@@ -5,15 +5,23 @@ declare(strict_types=1);
 use Marko\Core\Container\Container;
 use Marko\Docs\Contract\DocsSearchInterface;
 use Marko\DocsMarkdown\MarkdownRepository;
+use Marko\DocsVec\Commands\DownloadExtensionCommand;
+use Marko\DocsVec\Commands\DownloadModelCommand;
 use Marko\DocsVec\Query\QueryEmbedder;
 use Marko\DocsVec\Runtime\VecRuntime;
 use Marko\DocsVec\VecSearch;
 
 return [
-    'bindings' => [
-        DocsSearchInterface::class => VecSearch::class,
-    ],
+    // Bindings are intentionally empty: DocsSearchInterface is provided by the
+    // singleton factory below. Declaring it here too would register the same
+    // interface twice in the same module and trip BindingConflictException.
+    'bindings' => [],
     'singletons' => [
+        // VecRuntime and the download commands take a scalar $packageRoot the
+        // container cannot autowire, so they are constructed explicitly here.
+        VecRuntime::class => fn () => new VecRuntime(__DIR__),
+        DownloadModelCommand::class => fn () => new DownloadModelCommand(__DIR__),
+        DownloadExtensionCommand::class => fn () => new DownloadExtensionCommand(__DIR__),
         DocsSearchInterface::class => fn (Container $c) => new VecSearch(
             repository: $c->get(MarkdownRepository::class),
             runtime: new VecRuntime(__DIR__),

--- a/packages/docs-vec/resources/sqlite-vec/.gitignore
+++ b/packages/docs-vec/resources/sqlite-vec/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/docs-vec/src/Commands/BuildIndexCommand.php
+++ b/packages/docs-vec/src/Commands/BuildIndexCommand.php
@@ -22,8 +22,18 @@ class BuildIndexCommand implements CommandInterface
         Output $output,
     ): int {
         $outputPath = dirname(__DIR__, 2) . '/resources/docs.sqlite';
-        $this->builder->build($outputPath);
-        $output->writeLine('Hybrid index built at: ' . $outputPath);
+        $withVectors = $this->builder->build($outputPath);
+
+        if ($withVectors) {
+            $output->writeLine('Hybrid FTS5 + vector index built at: ' . $outputPath);
+        } else {
+            $output->writeLine('FTS5-only index built at: ' . $outputPath);
+            $output->writeLine(
+                'Note: sqlite-vec extension, ONNX model, or transformers-php unavailable — '
+                . 'semantic ranking is off. Run `marko docs-vec:download-extension` and '
+                . '`marko docs-vec:download-model` (plus `composer require codewithkyrian/transformers`) to enable it.',
+            );
+        }
 
         return 0;
     }

--- a/packages/docs-vec/src/Commands/DownloadExtensionCommand.php
+++ b/packages/docs-vec/src/Commands/DownloadExtensionCommand.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\DocsVec\Commands;
+
+use Marko\Core\Attributes\Command;
+use Marko\Core\Command\CommandInterface;
+use Marko\Core\Command\Input;
+use Marko\Core\Command\Output;
+use Marko\DocsVec\Exceptions\VecRuntimeException;
+use PharData;
+use Throwable;
+
+#[Command(
+    name: 'docs-vec:download-extension',
+    description: 'Download the sqlite-vec native extension for this platform'
+)]
+class DownloadExtensionCommand implements CommandInterface
+{
+    private const string EXTENSION_DIR = '/resources/sqlite-vec';
+
+    /**
+     * Pinned to an exact sqlite-vec release so the tarball checksums below never
+     * shift under us. Override the host with --base-url=<mirror> for air-gapped
+     * or proxied environments; checksums are still enforced.
+     */
+    private const string VERSION = '0.1.9';
+
+    private const string BASE_URL = 'https://github.com/asg017/sqlite-vec/releases/download';
+
+    /**
+     * "<PHP_OS_FAMILY>|<machine>" => [release-asset suffix, tarball sha256, extracted binary].
+     * Machine aliases are normalized in {@see self::resolvePlatform()}.
+     *
+     * @var array<string, array{suffix: string, sha256: string, binary: string}>
+     */
+    private const array PLATFORMS = [
+        'Darwin|arm64' => [
+            'suffix' => 'macos-aarch64',
+            'sha256' => '8282126333399ddfe98bbbcc7a1936e7252625aac49df056a98be602e46bfd29',
+            'binary' => 'vec0.dylib',
+        ],
+        'Darwin|x86_64' => [
+            'suffix' => 'macos-x86_64',
+            'sha256' => '53ad76e400786515e2edcaed2f01271dda846316390b761fadbd2dcf56aa4713',
+            'binary' => 'vec0.dylib',
+        ],
+        'Linux|x86_64' => [
+            'suffix' => 'linux-x86_64',
+            'sha256' => 'b959baa1d8dc88861b1edb337b8587178cdcb12d60b4998f9d10b6a82052d5d7',
+            'binary' => 'vec0.so',
+        ],
+        'Linux|aarch64' => [
+            'suffix' => 'linux-aarch64',
+            'sha256' => 'ea03d39541e478fab5974253c461e1cb5d77742f69e40cf96e3fad5bc309a37c',
+            'binary' => 'vec0.so',
+        ],
+        'Windows|x86_64' => [
+            'suffix' => 'windows-x86_64',
+            'sha256' => '51581189d52066b4dfc6631f6d7a3eab7dedc2260656ab09ca97ab3fb8165983',
+            'binary' => 'vec0.dll',
+        ],
+    ];
+
+    public function __construct(
+        private string $packageRoot,
+    ) {}
+
+    /**
+     * @throws VecRuntimeException
+     */
+    public function execute(
+        Input $input,
+        Output $output,
+    ): int {
+        $platform = $this->resolvePlatform();
+        $extensionDir = $this->packageRoot . self::EXTENSION_DIR;
+        $target = $extensionDir . '/' . $platform['binary'];
+
+        if (is_file($target)) {
+            $output->writeLine('sqlite-vec already present at ' . $target);
+
+            return 0;
+        }
+
+        if (!is_dir($extensionDir)) {
+            mkdir($extensionDir, 0755, true);
+        }
+
+        $baseUrl = rtrim($input->getOption('base-url') ?? self::BASE_URL, '/');
+        $asset = sprintf('sqlite-vec-%s-loadable-%s.tar.gz', self::VERSION, $platform['suffix']);
+        $url = sprintf('%s/v%s/%s', $baseUrl, self::VERSION, $asset);
+
+        $tarball = $extensionDir . '/' . $asset;
+        $output->writeLine('Downloading ' . $asset . ' ...');
+        $this->streamToFile($url, $tarball);
+        $this->verifyChecksum($tarball, $platform['sha256']);
+
+        $this->extractBinary($tarball, $platform['binary'], $extensionDir);
+        @unlink($tarball);
+
+        $output->writeLine('Saved ' . $platform['binary'] . ' (checksum verified) to ' . $extensionDir);
+
+        return 0;
+    }
+
+    /**
+     * @return array{suffix: string, sha256: string, binary: string}
+     *
+     * @throws VecRuntimeException
+     */
+    private function resolvePlatform(): array
+    {
+        $machine = strtolower(php_uname('m'));
+
+        $normalized = match (true) {
+            in_array($machine, ['arm64', 'aarch64'], true) => PHP_OS_FAMILY === 'Darwin' ? 'arm64' : 'aarch64',
+            in_array($machine, ['x86_64', 'amd64'], true) => 'x86_64',
+            default => $machine,
+        };
+
+        $key = PHP_OS_FAMILY . '|' . $normalized;
+
+        return self::PLATFORMS[$key] ?? throw VecRuntimeException::unsupportedPlatform($key);
+    }
+
+    /**
+     * @throws VecRuntimeException
+     */
+    private function extractBinary(
+        string $tarball,
+        string $binary,
+        string $destDir,
+    ): void {
+        try {
+            $archive = new PharData($tarball);
+            $archive->extractTo($destDir, $binary, true);
+        } catch (Throwable $e) {
+            throw VecRuntimeException::extractionFailed($tarball, $e->getMessage());
+        }
+
+        if (!is_file($destDir . '/' . $binary)) {
+            throw VecRuntimeException::extractionFailed(
+                $tarball,
+                "expected '$binary' was not found in the archive",
+            );
+        }
+    }
+
+    /**
+     * Stream a remote file to disk without buffering it entirely in memory.
+     *
+     * @throws VecRuntimeException
+     */
+    private function streamToFile(
+        string $url,
+        string $target,
+    ): void {
+        $in = @fopen($url, 'rb');
+
+        if ($in === false) {
+            throw VecRuntimeException::downloadFailed($url);
+        }
+
+        $out = @fopen($target, 'wb');
+
+        if ($out === false) {
+            fclose($in);
+            throw VecRuntimeException::downloadFailed($url);
+        }
+
+        $bytes = stream_copy_to_stream($in, $out);
+        fclose($in);
+        fclose($out);
+
+        if ($bytes === false || $bytes === 0) {
+            @unlink($target);
+            throw VecRuntimeException::downloadFailed($url);
+        }
+    }
+
+    /**
+     * @throws VecRuntimeException
+     */
+    private function verifyChecksum(
+        string $file,
+        string $expectedSha,
+    ): void {
+        $actual = hash_file('sha256', $file);
+
+        if ($actual !== $expectedSha) {
+            throw VecRuntimeException::checksumMismatch($file, $expectedSha, $actual);
+        }
+    }
+}

--- a/packages/docs-vec/src/Commands/DownloadModelCommand.php
+++ b/packages/docs-vec/src/Commands/DownloadModelCommand.php
@@ -29,17 +29,27 @@ class DownloadModelCommand implements CommandInterface
      * @var array<string, array{path: string, sha256: string}>
      */
     private const array MODEL_FILES = [
-        'model.onnx' => [
+        // Stored under the same relative path locally so transformers-php's HF
+        // layout resolves: <model>/onnx/model.onnx, <model>/config.json, etc.
+        'onnx/model.onnx' => [
             'path' => 'onnx/model.onnx',
             'sha256' => '828e1496d7fabb79cfa4dcd84fa38625c0d3d21da474a00f08db0f559940cf35',
+        ],
+        'config.json' => [
+            'path' => 'config.json',
+            'sha256' => 'fa73f90bf92c8cace1fbcb709626306f2bdbc9ea3e5b5f94b440df9b6aa56350',
         ],
         'tokenizer.json' => [
             'path' => 'tokenizer.json',
             'sha256' => 'd241a60d5e8f04cc1b2b3e9ef7a4921b27bf526d9f6050ab90f9267a1f9e5c66',
         ],
-        'config.json' => [
-            'path' => 'config.json',
-            'sha256' => 'fa73f90bf92c8cace1fbcb709626306f2bdbc9ea3e5b5f94b440df9b6aa56350',
+        'tokenizer_config.json' => [
+            'path' => 'tokenizer_config.json',
+            'sha256' => '9261e7d79b44c8195c1cada2b453e55b00aeb81e907a6664974b4d7776172ab3',
+        ],
+        'special_tokens_map.json' => [
+            'path' => 'special_tokens_map.json',
+            'sha256' => 'b6d346be366a7d1d48332dbc9fdf3bf8960b5d879522b7799ddba59e76237ee3',
         ],
     ];
 
@@ -69,15 +79,16 @@ class DownloadModelCommand implements CommandInterface
                 continue;
             }
 
+            $subDir = dirname($target);
+
+            if (!is_dir($subDir)) {
+                mkdir($subDir, 0755, true);
+            }
+
             $url = $baseUrl . '/' . $meta['path'];
             $output->writeLine('Downloading ' . $filename . ' ...');
 
-            $data = @file_get_contents($url);
-            if ($data === false || $data === '') {
-                throw VecRuntimeException::downloadFailed($url);
-            }
-
-            file_put_contents($target, $data);
+            $this->streamToFile($url, $target);
             $this->verifyChecksum($target, $meta['sha256']);
             $output->writeLine('Saved ' . $filename . ' (checksum verified)');
         }
@@ -88,13 +99,45 @@ class DownloadModelCommand implements CommandInterface
     }
 
     /**
+     * Stream a remote file to disk. Copies chunk-by-chunk so a multi-hundred-MB
+     * model never has to fit in `memory_limit` (the old file_get_contents() OOM'd).
+     *
+     * @throws VecRuntimeException
+     */
+    private function streamToFile(
+        string $url,
+        string $target,
+    ): void {
+        $in = @fopen($url, 'rb');
+
+        if ($in === false) {
+            throw VecRuntimeException::downloadFailed($url);
+        }
+
+        $out = @fopen($target, 'wb');
+
+        if ($out === false) {
+            fclose($in);
+            throw VecRuntimeException::downloadFailed($url);
+        }
+
+        $bytes = stream_copy_to_stream($in, $out);
+        fclose($in);
+        fclose($out);
+
+        if ($bytes === false || $bytes === 0) {
+            @unlink($target);
+            throw VecRuntimeException::downloadFailed($url);
+        }
+    }
+
+    /**
      * @throws VecRuntimeException
      */
     public function verifyChecksum(
         string $file,
         string $expectedSha,
-    ): void
-    {
+    ): void {
         $actual = hash_file('sha256', $file);
 
         if ($actual !== $expectedSha) {
@@ -105,8 +148,7 @@ class DownloadModelCommand implements CommandInterface
     private function shouldSkip(
         string $target,
         string $sha256,
-    ): bool
-    {
+    ): bool {
         return file_exists($target) && hash_file('sha256', $target) === $sha256;
     }
 }

--- a/packages/docs-vec/src/Exceptions/VecRuntimeException.php
+++ b/packages/docs-vec/src/Exceptions/VecRuntimeException.php
@@ -29,9 +29,9 @@ class VecRuntimeException extends MarkoException
     public static function transformersNotInstalled(): self
     {
         return new self(
-            message: 'codewithkyrian/transformers-php is not installed.',
+            message: 'codewithkyrian/transformers is not installed.',
             context: 'The transformers-php package is required for query-time embeddings.',
-            suggestion: 'Run `composer require codewithkyrian/transformers-php` to install it.',
+            suggestion: 'Run `composer require codewithkyrian/transformers` to install it.',
         );
     }
 
@@ -39,8 +39,7 @@ class VecRuntimeException extends MarkoException
         string $file,
         string $expected,
         string $actual,
-    ): self
-    {
+    ): self {
         return new self(
             message: 'SHA-256 checksum mismatch for file: ' . $file,
             context: sprintf('Expected: %s, Got: %s', $expected, $actual),
@@ -63,6 +62,26 @@ class VecRuntimeException extends MarkoException
             message: 'Failed to download model file from: ' . $url,
             context: 'The HTTP request for a model file returned no data.',
             suggestion: 'Check your network connection. If you are behind a firewall or mirror the files, pass --base-url=<your-mirror> to `marko docs-vec:download-model`.',
+        );
+    }
+
+    public static function unsupportedPlatform(string $platform): self
+    {
+        return new self(
+            message: 'No prebuilt sqlite-vec binary for platform: ' . $platform,
+            context: 'docs-vec ships pinned sqlite-vec builds for macOS, Linux, and Windows (x86_64 / arm64).',
+            suggestion: 'Build sqlite-vec from https://github.com/asg017/sqlite-vec and place vec0.{so,dylib,dll} in resources/sqlite-vec/, or run docs-vec FTS5-only (no extension needed).',
+        );
+    }
+
+    public static function extractionFailed(
+        string $archive,
+        string $reason,
+    ): self {
+        return new self(
+            message: 'Failed to extract the sqlite-vec binary from: ' . $archive,
+            context: $reason,
+            suggestion: 'Delete the archive and re-run `marko docs-vec:download-extension`. Ensure the Phar extension is enabled.',
         );
     }
 }

--- a/packages/docs-vec/src/Indexing/HybridIndexBuilder.php
+++ b/packages/docs-vec/src/Indexing/HybridIndexBuilder.php
@@ -7,6 +7,7 @@ namespace Marko\DocsVec\Indexing;
 use Marko\Docs\Exceptions\DocsException;
 use Marko\DocsMarkdown\MarkdownRepository;
 use Marko\DocsVec\Runtime\VecRuntime;
+use PDO;
 
 class HybridIndexBuilder
 {
@@ -15,8 +16,17 @@ class HybridIndexBuilder
         private VecRuntime $runtime,
     ) {}
 
-    /** @throws DocsException */
-    public function build(string $outputPath): void
+    /**
+     * Build the search index. Produces a hybrid FTS5 + vector index when the
+     * sqlite-vec extension, ONNX model, and transformers-php are all available;
+     * otherwise degrades to an FTS5-only index (no docs_vec table, no embeddings)
+     * so the driver still works on minimal setups.
+     *
+     * @return bool true if vector embeddings were included, false if FTS5-only
+     *
+     * @throws DocsException
+     */
+    public function build(string $outputPath): bool
     {
         $pages = $this->repository->listAllPages();
 
@@ -34,21 +44,32 @@ class HybridIndexBuilder
             mkdir($dir, 0755, true);
         }
 
-        $pdo = $this->runtime->openConnection($outputPath);
-        $dim = $this->runtime->getEmbeddingDim();
+        $vectorsEnabled = $this->runtime->isVectorSearchAvailable();
+
+        $pdo = $vectorsEnabled
+            ? $this->runtime->openConnection($outputPath)
+            : $this->runtime->openPlainConnection($outputPath);
 
         $pdo->exec(
-            "CREATE VIRTUAL TABLE docs_fts USING fts5(page_id UNINDEXED, chunk_id UNINDEXED, title, content, tokenize='porter unicode61')"
+            "CREATE VIRTUAL TABLE docs_fts USING fts5(page_id UNINDEXED, chunk_id UNINDEXED, title, content, tokenize='porter unicode61')",
         );
-        $pdo->exec("CREATE VIRTUAL TABLE docs_vec USING vec0(chunk_id INTEGER PRIMARY KEY, embedding FLOAT[$dim])");
         $pdo->exec('CREATE TABLE docs_meta (page_id TEXT PRIMARY KEY, url TEXT, section TEXT, title TEXT)');
 
+        $insertVec = null;
+
+        if ($vectorsEnabled) {
+            $dim = $this->runtime->getEmbeddingDim();
+            $pdo->exec(
+                "CREATE VIRTUAL TABLE docs_vec USING vec0(chunk_id INTEGER PRIMARY KEY, embedding FLOAT[$dim])"
+            );
+            $insertVec = $pdo->prepare('INSERT INTO docs_vec (chunk_id, embedding) VALUES (:chunk_id, :embedding)');
+        }
+
         $insertFts = $pdo->prepare(
-            'INSERT INTO docs_fts (page_id, chunk_id, title, content) VALUES (:page_id, :chunk_id, :title, :content)'
+            'INSERT INTO docs_fts (page_id, chunk_id, title, content) VALUES (:page_id, :chunk_id, :title, :content)',
         );
-        $insertVec = $pdo->prepare('INSERT INTO docs_vec (chunk_id, embedding) VALUES (:chunk_id, :embedding)');
         $insertMeta = $pdo->prepare(
-            'INSERT INTO docs_meta (page_id, url, section, title) VALUES (:page_id, :url, :section, :title)'
+            'INSERT INTO docs_meta (page_id, url, section, title) VALUES (:page_id, :url, :section, :title)',
         );
 
         $chunkId = 0;
@@ -61,21 +82,29 @@ class HybridIndexBuilder
             $section = $this->extractSection($pageId);
 
             $insertMeta->execute(
-                ['page_id' => $pageId, 'url' => '/' . $pageId, 'section' => $section, 'title' => $title]
+                ['page_id' => $pageId, 'url' => '/' . $pageId, 'section' => $section, 'title' => $title],
             );
 
             foreach ($this->chunkByHeading($body) as $chunk) {
                 $chunkId++;
                 $insertFts->execute(
-                    ['page_id' => $pageId, 'chunk_id' => $chunkId, 'title' => $title, 'content' => $chunk]
+                    ['page_id' => $pageId, 'chunk_id' => $chunkId, 'title' => $title, 'content' => $chunk],
                 );
 
-                $embedding = $this->runtime->embed($chunk);
-                $insertVec->execute(['chunk_id' => $chunkId, 'embedding' => json_encode($embedding)]);
+                if ($insertVec !== null) {
+                    $embedding = $this->runtime->embed($chunk);
+                    // vec0 requires an integer primary key; PDO binds array params
+                    // as strings, which it rejects — bind chunk_id as PARAM_INT.
+                    $insertVec->bindValue(':chunk_id', $chunkId, PDO::PARAM_INT);
+                    $insertVec->bindValue(':embedding', json_encode($embedding), PDO::PARAM_STR);
+                    $insertVec->execute();
+                }
             }
         }
 
         $pdo->commit();
+
+        return $vectorsEnabled;
     }
 
     /** @return list<string> chunks */
@@ -112,8 +141,7 @@ class HybridIndexBuilder
     private function extractTitle(
         string $markdown,
         string $fallback,
-    ): string
-    {
+    ): string {
         if (preg_match('/^---\s*\n.*?title:\s*["\']?([^"\'\n]+)["\']?.*?\n---/s', $markdown, $m)) {
             return trim($m[1]);
         }

--- a/packages/docs-vec/src/Query/FtsQueryBuilder.php
+++ b/packages/docs-vec/src/Query/FtsQueryBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\DocsVec\Query;
+
+/**
+ * Sanitizes natural-language queries into safe FTS5 MATCH expressions for the
+ * keyword half of the hybrid search.
+ *
+ * NOTE: marko/docs-fts ships an identical helper. The two FTS5-backed drivers
+ * keep their own copy on purpose — marko/docs is a contract-only package, so
+ * there is no shared home for runtime logic, and Marko modules are designed to
+ * be self-contained. Keep the two in sync if either changes.
+ */
+class FtsQueryBuilder
+{
+    /**
+     * Common English stop words plus the FTS5 boolean operator keywords
+     * (`and`/`or`/`not`). Dropped to improve precision. `near` is intentionally
+     * absent — it is neutralized by quoting instead, so a real search term like
+     * "near" is preserved.
+     */
+    private const array STOP_WORDS = [
+        'a', 'an', 'and', 'are', 'as', 'at', 'be', 'but', 'by', 'can', 'did',
+        'do', 'does', 'for', 'from', 'how', 'i', 'in', 'is', 'it', 'me', 'my',
+        'no', 'not', 'of', 'on', 'or', 'that', 'the', 'this', 'to', 'was', 'were',
+        'what', 'when', 'where', 'which', 'why', 'with', 'you', 'your',
+    ];
+
+    /**
+     * Convert a natural-language query into a safe FTS5 MATCH expression.
+     *
+     * Raw user input cannot be handed to FTS5 directly: apostrophes and quotes are
+     * parsed as query syntax (raising "fts5: syntax error"), and FTS5's default
+     * implicit-AND across every token tanks recall on full questions ("how do
+     * observers react to events" requires *every* word in one document).
+     *
+     * This tokenizes to alphanumeric words (dropping punctuation entirely), removes
+     * stop words, quotes each remaining term (neutralizing FTS5 keyword operators),
+     * and OR-joins them so BM25 ranks by term overlap. Returns '' when no usable
+     * term remains, so the caller can short-circuit to an empty result set.
+     */
+    public static function toMatchExpression(string $raw): string
+    {
+        $tokens = self::tokenize($raw);
+
+        if ($tokens === []) {
+            return '';
+        }
+
+        $meaningful = array_values(array_filter(
+            $tokens,
+            static fn (string $token): bool => mb_strlen($token) > 1
+                && !in_array($token, self::STOP_WORDS, true),
+        ));
+
+        // If filtering removed everything (e.g. an all-stop-word question), fall
+        // back to the raw tokens so the search still looks for something.
+        $terms = $meaningful === [] ? $tokens : $meaningful;
+
+        return implode(' OR ', array_map(
+            static fn (string $term): string => '"' . $term . '"',
+            $terms,
+        ));
+    }
+
+    /** @return list<string> */
+    private static function tokenize(string $raw): array
+    {
+        preg_match_all('/[\p{L}\p{N}]+/u', mb_strtolower($raw), $matches);
+
+        return $matches[0];
+    }
+}

--- a/packages/docs-vec/src/Runtime/VecRuntime.php
+++ b/packages/docs-vec/src/Runtime/VecRuntime.php
@@ -5,27 +5,44 @@ declare(strict_types=1);
 namespace Marko\DocsVec\Runtime;
 
 use Codewithkyrian\Transformers\Pipelines\Pipeline;
+
+use function Codewithkyrian\Transformers\Pipelines\pipeline;
+
+use Codewithkyrian\Transformers\Transformers;
 use Marko\DocsVec\Exceptions\VecRuntimeException;
 use PDO;
+use Pdo\Sqlite;
 
-readonly class VecRuntime
+use Throwable;
+
+class VecRuntime
 {
     private const string MODEL_DIR = '/resources/models/bge-small-en-v1.5';
 
     private const int EMBEDDING_DIM = 384;
+
+    /**
+     * Memoized feature-extraction pipeline. Building it loads the ONNX model
+     * (~tens of MB), so it must be created once and reused — rebuilding per call
+     * reloads the model on every chunk, exhausting memory while indexing.
+     */
+    private ?Pipeline $pipeline = null;
 
     public function __construct(
         private string $packageRoot,
     ) {}
 
     /**
+     * Open a connection with the sqlite-vec extension loaded (vector search).
+     *
+     * Uses the driver-specific `Pdo\Sqlite::loadExtension()` API — NOT a
+     * `SELECT load_extension(...)` SQL call, which SQLite blocks by default
+     * ("not authorized"). `Pdo\Sqlite` extends `PDO`, so the return type holds.
+     *
      * @throws VecRuntimeException
      */
     public function openConnection(string $databasePath = ':memory:'): PDO
     {
-        $pdo = new PDO('sqlite:' . $databasePath);
-        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
         $extensionPath = $this->findSqliteVecExtension();
 
         if ($extensionPath === null) {
@@ -37,8 +54,16 @@ readonly class VecRuntime
             );
         }
 
-        $pdo->sqliteCreateFunction('load_extension', fn () => null, 0);
-        $pdo->exec("SELECT load_extension('" . $extensionPath . "')");
+        $pdo = new Sqlite('sqlite:' . $databasePath);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        try {
+            $pdo->loadExtension($extensionPath);
+        } catch (Throwable $e) {
+            throw VecRuntimeException::sqliteVecNotLoaded(
+                "Failed to load '$extensionPath': {$e->getMessage()}",
+            );
+        }
 
         return $pdo;
     }
@@ -62,26 +87,31 @@ readonly class VecRuntime
      */
     public function embed(string $text): array
     {
-        $modelPath = $this->packageRoot . self::MODEL_DIR . '/model.onnx';
+        $modelDir = $this->packageRoot . self::MODEL_DIR;
 
-        if (!file_exists($modelPath)) {
-            throw VecRuntimeException::modelMissing($modelPath);
+        if (!file_exists($modelDir . '/onnx/model.onnx')) {
+            throw VecRuntimeException::modelMissing($modelDir . '/onnx/model.onnx');
         }
 
-        if (!class_exists('Codewithkyrian\Transformers\Pipelines\Pipeline')) {
+        if (!self::transformersInstalled()) {
             throw VecRuntimeException::transformersNotInstalled();
         }
 
-        /** @var object $pipeline */
-        $pipeline = Pipeline::create(
-            task: 'feature-extraction',
-            model: $this->packageRoot . self::MODEL_DIR,
-        );
+        if ($this->pipeline === null) {
+            // transformers-php resolves files as <cacheDir>/<model>/{config.json, onnx/model.onnx, ...}.
+            Transformers::setup()->setCacheDir(dirname($modelDir))->apply();
 
-        /** @var array<int, float> $output */
-        $output = $pipeline($text);
+            // quantized:false → use the full-precision onnx/model.onnx we ship.
+            $this->pipeline = pipeline('feature-extraction', basename($modelDir), quantized: false);
+        }
 
-        return $output;
+        // pooling:'mean' collapses per-token states into one sentence vector;
+        // normalize:true yields a unit vector ready for cosine distance. The
+        // pipeline returns a batched array of shape [1, dim].
+        /** @var array<int, array<int, float>> $rows */
+        $rows = ($this->pipeline)($text, pooling: 'mean', normalize: true);
+
+        return $rows[0];
     }
 
     public function getEmbeddingDim(): int
@@ -91,12 +121,67 @@ readonly class VecRuntime
 
     public function isModelAvailable(): bool
     {
-        return file_exists($this->packageRoot . self::MODEL_DIR . '/model.onnx');
+        return file_exists($this->packageRoot . self::MODEL_DIR . '/onnx/model.onnx');
     }
 
+    /**
+     * True only when a usable sqlite-vec binary is present AND this PHP build can
+     * actually load SQLite extensions. Both are required before opening a vector
+     * connection; callers fall back to FTS5-only search otherwise.
+     */
     public function isSqliteVecAvailable(): bool
     {
-        return $this->findSqliteVecExtension() !== null;
+        return $this->findSqliteVecExtension() !== null
+            && self::supportsExtensionLoading();
+    }
+
+    /**
+     * Everything needed for semantic (vector) search: the extension, this PHP
+     * build's ability to load it, the ONNX model, and transformers-php.
+     */
+    public function isVectorSearchAvailable(): bool
+    {
+        return $this->isSqliteVecAvailable()
+            && $this->isModelAvailable()
+            && self::transformersInstalled();
+    }
+
+    public static function transformersInstalled(): bool
+    {
+        return class_exists(Pipeline::class);
+    }
+
+    /**
+     * Whether this PHP build permits loading SQLite extensions via PDO. Some
+     * builds compile the capability out (`SQLITE_OMIT_LOAD_EXTENSION`) or disable
+     * it; probing once avoids crashing on those — we degrade to FTS5 instead.
+     */
+    public static function supportsExtensionLoading(): bool
+    {
+        static $supported = null;
+
+        if ($supported !== null) {
+            return $supported;
+        }
+
+        if (!class_exists(Sqlite::class) || !method_exists(Sqlite::class, 'loadExtension')) {
+            return $supported = false;
+        }
+
+        try {
+            // Probe with an invalid path: "unable to load" means loading is
+            // permitted (the path was just bad); "disabled"/"not authorized"
+            // means the capability is compiled out or blocked on this build.
+            (new Sqlite('sqlite::memory:'))->loadExtension('');
+        } catch (Throwable $e) {
+            $message = strtolower($e->getMessage());
+
+            if (str_contains($message, 'disabled') || str_contains($message, 'not authorized')) {
+                return $supported = false;
+            }
+        }
+
+        return $supported = true;
     }
 
     private function findSqliteVecExtension(): ?string

--- a/packages/docs-vec/src/VecSearch.php
+++ b/packages/docs-vec/src/VecSearch.php
@@ -11,6 +11,7 @@ use Marko\Docs\ValueObject\DocsPage;
 use Marko\Docs\ValueObject\DocsQuery;
 use Marko\Docs\ValueObject\DocsResult;
 use Marko\DocsMarkdown\MarkdownRepository;
+use Marko\DocsVec\Query\FtsQueryBuilder;
 use Marko\DocsVec\Query\QueryEmbedder;
 use Marko\DocsVec\Runtime\VecRuntime;
 use PDO;
@@ -50,12 +51,12 @@ class VecSearch implements DocsSearchInterface
 
         $vecResults = [];
 
-        if ($this->runtime->isModelAvailable()) {
+        if ($this->runtime->isVectorSearchAvailable()) {
             try {
                 $embedding = $this->embedder->embed($query->query);
                 $vecResults = $this->vectorSearch($pdo, $embedding, self::CANDIDATE_LIMIT);
             } catch (Throwable) {
-                // Fall back to FTS-only on embedding failure
+                // Fall back to FTS-only on embedding / vector-table failure
             }
         }
 
@@ -105,6 +106,15 @@ class VecSearch implements DocsSearchInterface
         string $query,
         int $limit,
     ): array {
+        // Raw NL input cannot go straight to FTS5 (apostrophes/quotes raise
+        // "fts5: syntax error"); the shared builder sanitizes it into a safe
+        // OR-of-quoted-terms MATCH expression.
+        $expression = FtsQueryBuilder::toMatchExpression($query);
+
+        if ($expression === '') {
+            return [];
+        }
+
         $stmt = $pdo->prepare("
             SELECT chunk_id, page_id, title,
                    snippet(docs_fts, 3, '<mark>', '</mark>', '...', 32) AS excerpt
@@ -113,7 +123,7 @@ class VecSearch implements DocsSearchInterface
             ORDER BY bm25(docs_fts)
             LIMIT :limit
         ");
-        $stmt->bindValue(':q', $query, PDO::PARAM_STR);
+        $stmt->bindValue(':q', $expression, PDO::PARAM_STR);
         $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
 
         try {
@@ -212,7 +222,12 @@ class VecSearch implements DocsSearchInterface
 
         try {
             if ($this->runtime->isSqliteVecAvailable()) {
-                $this->pdo = $this->runtime->openConnection($this->indexPath);
+                try {
+                    $this->pdo = $this->runtime->openConnection($this->indexPath);
+                } catch (Throwable) {
+                    // Extension present but unloadable at runtime — degrade to FTS5.
+                    $this->pdo = $this->runtime->openPlainConnection($this->indexPath);
+                }
             } else {
                 $this->pdo = $this->runtime->openPlainConnection($this->indexPath);
             }

--- a/packages/docs-vec/tests/Feature/DiBindingTest.php
+++ b/packages/docs-vec/tests/Feature/DiBindingTest.php
@@ -59,16 +59,16 @@ it(
     'throws BindingConflictException if both docs-fts and docs-vec are installed without explicit replace',
     function (): void {
         // The Marko container's bind() silently overwrites — no exception is thrown at bind time.
-    // Conflict detection would happen at the module-loading layer (not implemented yet).
-    // This test documents the current container behaviour: last writer wins.
-    $container = new Container();
-    
+        // Conflict detection would happen at the module-loading layer (not implemented yet).
+        // This test documents the current container behaviour: last writer wins.
+        $container = new Container();
+
         $container->bind(DocsSearchInterface::class, FtsSearch::class);
         $container->bind(DocsSearchInterface::class, VecSearch::class);
-    
+
         // No exception — last binding wins silently.
-    expect(true)->toBeTrue();
-    }
+        expect(true)->toBeTrue();
+    },
 )->skip(
-    'Container does not enforce conflict at bind time — last writer wins; conflict detection belongs in the module-loading layer'
+    'Container does not enforce conflict at bind time — last writer wins; conflict detection belongs in the module-loading layer',
 );

--- a/packages/docs-vec/tests/Unit/Commands/DownloadModelCommandTest.php
+++ b/packages/docs-vec/tests/Unit/Commands/DownloadModelCommandTest.php
@@ -14,14 +14,14 @@ it(
     function (): void {
         $reflection = new ReflectionClass(DownloadModelCommand::class);
         $attributes = $reflection->getAttributes(Command::class);
-    
+
         expect($attributes)->not->toBeEmpty();
-    
+
         $attr = $attributes[0]->newInstance();
-    
+
         expect($attr->name)->toBe('docs-vec:download-model')
             ->and($attr->description)->toContain('bge-small-en-v1.5');
-    }
+    },
 );
 
 it('skips download when model files already exist and checksums match', function (): void {
@@ -49,8 +49,7 @@ it('skips download when model files already exist and checksums match', function
         public function execute(
             Input $input,
             Output $output,
-        ): int
-        {
+        ): int {
             $target = func_get_arg(2) ?? $this->getModelDir() . '/model.onnx';
 
             // Just test shouldSkipPublic directly via verifyChecksum
@@ -80,8 +79,7 @@ it('skips download when model files already exist and checksums match', function
         public function execute(
             Input $input,
             Output $output,
-        ): int
-        {
+        ): int {
             $target = $this->dir . '/model.onnx';
 
             if (file_exists($target) && hash_file('sha256', $target) === $this->sha) {

--- a/packages/docs-vec/tests/Unit/Query/FtsQueryBuilderTest.php
+++ b/packages/docs-vec/tests/Unit/Query/FtsQueryBuilderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\DocsVec\Query\FtsQueryBuilder;
+
+it('lowercases and quotes each term joined with OR', function (): void {
+    expect(FtsQueryBuilder::toMatchExpression('Routing Attributes'))
+        ->toBe('"routing" OR "attributes"');
+});
+
+it('strips apostrophes and punctuation that break FTS5', function (): void {
+    expect(FtsQueryBuilder::toMatchExpression("how does Marko's module system work?"))
+        ->toBe('"marko" OR "module" OR "system" OR "work"');
+});
+
+it('neutralizes a raw FTS5 operator expression to a safe term', function (): void {
+    // "NEAR/" raw is a syntax error; sanitized it becomes a quoted term.
+    expect(FtsQueryBuilder::toMatchExpression('NEAR/'))
+        ->toBe('"near"');
+});
+
+it('drops common stop words to improve precision', function (): void {
+    $expr = FtsQueryBuilder::toMatchExpression('how do observers react to events');
+
+    expect($expr)->toContain('"observers"')
+        ->and($expr)->toContain('"react"')
+        ->and($expr)->toContain('"events"')
+        ->and($expr)->not->toContain('"how"')
+        ->and($expr)->not->toContain('"do"')
+        ->and($expr)->not->toContain('"to"');
+});
+
+it('returns an empty expression when no usable term remains', function (): void {
+    expect(FtsQueryBuilder::toMatchExpression('!!! ??? ...'))->toBe('');
+});

--- a/packages/docs-vec/tests/Unit/Runtime/VecRuntimeTest.php
+++ b/packages/docs-vec/tests/Unit/Runtime/VecRuntimeTest.php
@@ -81,13 +81,13 @@ it(
     'throws VecRuntimeException with helpful context when ONNX model is missing, suggesting marko docs-vec:download-model',
     function () use ($packageRoot): void {
         // Use a temp dir that has no model files to guarantee modelMissing is thrown
-    $tempRoot = sys_get_temp_dir() . '/marko-vec-test-' . uniqid();
+        $tempRoot = sys_get_temp_dir() . '/marko-vec-test-' . uniqid();
         mkdir($tempRoot . '/resources/models/bge-small-en-v1.5', 0755, true);
-    
+
         $runtime = new VecRuntime($tempRoot);
-    
+
         expect($runtime->isModelAvailable())->toBeFalse();
-    
+
         $runtime->embed('test');
-    }
+    },
 )->throws(VecRuntimeException::class, 'ONNX model not found');

--- a/packages/docs-vec/tests/Unit/SkeletonTest.php
+++ b/packages/docs-vec/tests/Unit/SkeletonTest.php
@@ -16,19 +16,25 @@ it('has composer.json with name marko/docs-vec and required dependencies', funct
     expect($composer['require']['marko/core'])->toBe('self.version');
     expect($composer['require']['marko/docs'])->toBe('self.version');
     expect($composer['require']['marko/docs-markdown'])->toBe('self.version');
-    expect($composer['suggest']['codewithkyrian/transformers-php'])->toContain('^0.5');
+    expect($composer['suggest']['codewithkyrian/transformers'])->toContain('^0.5');
 });
 
-it('has module.php binding DocsSearchInterface to VecSearch', function (): void {
+it('provides DocsSearchInterface via a singleton factory with empty bindings', function (): void {
     $path = dirname(__DIR__, 2) . '/module.php';
     expect(file_exists($path))->toBeTrue();
 
     $module = require $path;
 
     expect($module)->toBeArray();
-    expect($module['bindings'])->toBeArray();
-    expect(array_key_exists(DocsSearchInterface::class, $module['bindings']))->toBeTrue();
-    expect($module['bindings'][DocsSearchInterface::class])->toBe(VecSearch::class);
+
+    // bindings MUST stay empty: also declaring DocsSearchInterface here would
+    // register the same interface twice in one module → BindingConflictException.
+    expect($module['bindings'])->toBeArray()->toBeEmpty();
+
+    // The interface is provided by the singleton factory instead.
+    expect($module['singletons'])->toBeArray();
+    expect(array_key_exists(DocsSearchInterface::class, $module['singletons']))->toBeTrue();
+    expect($module['singletons'][DocsSearchInterface::class])->toBeInstanceOf(Closure::class);
 });
 
 it('has src tests/Unit tests/Feature directories with Pest bootstrap', function (): void {

--- a/packages/docs-vec/tests/Unit/VecSearchTest.php
+++ b/packages/docs-vec/tests/Unit/VecSearchTest.php
@@ -90,7 +90,7 @@ it('generates excerpt snippets from FTS5 highlighting', function (): void {
         ->and($results[0]->excerpt)->toContain('<mark>');
 })->skip(fn () => ! (new VecRuntime(dirname(__DIR__, 2)))->isSqliteVecAvailable(), 'sqlite-vec not available');
 
-it('returns empty list for a query with no matches', function (): void {
+it('returns no keyword matches for a gibberish query', function (): void {
     $runtime = new VecRuntime(dirname(__DIR__, 2));
 
     if (! $runtime->isSqliteVecAvailable()) {
@@ -101,7 +101,15 @@ it('returns empty list for a query with no matches', function (): void {
 
     $results = $search->search(new DocsQuery('xyzzyqqqqq12345'));
 
-    expect($results)->toBeEmpty();
+    // FTS5-only mode: a no-keyword-match query returns nothing. When the vector
+    // path is active, cosine nearest-neighbour search always returns the closest
+    // documents (there is no relevance threshold), so results may be non-empty —
+    // assert only that the search runs cleanly and returns a list.
+    if ($runtime->isVectorSearchAvailable()) {
+        expect($results)->toBeArray();
+    } else {
+        expect($results)->toBeEmpty();
+    }
 })->skip(fn () => ! (new VecRuntime(dirname(__DIR__, 2)))->isSqliteVecAvailable(), 'sqlite-vec not available');
 
 it(
@@ -179,26 +187,26 @@ it('returns an empty list for a valid query that matches no documents', function
 });
 
 it(
-    'throws DocsException not PDOException when the search text is a malformed FTS5 MATCH expression',
+    'sanitizes raw FTS5 operator syntax instead of throwing',
     function (): void {
         $runtime = new VecRuntime(dirname(__DIR__, 2));
         [$search] = buildFtsTestIndex($runtime);
 
-        // NEAR/ is a malformed FTS5 MATCH expression (syntax error)
-        expect(fn () => $search->search(new DocsQuery('NEAR/')))->toThrow(DocsException::class);
+        // "NEAR/" would be a malformed FTS5 MATCH expression if passed raw; the
+        // query builder neutralizes it, so search must NOT throw.
+        expect(fn () => $search->search(new DocsQuery('NEAR/')))->not->toThrow(DocsException::class);
+        expect($search->search(new DocsQuery('NEAR/')))->toBeArray();
     },
 );
 
-it('includes the underlying FTS5 parse reason in the DocsException message', function (): void {
+it('sanitizes apostrophes so natural-language questions still match', function (): void {
     $runtime = new VecRuntime(dirname(__DIR__, 2));
     [$search] = buildFtsTestIndex($runtime);
 
-    try {
-        $search->search(new DocsQuery('NEAR/'));
-        $this->fail('Expected DocsException to be thrown');
-    } catch (DocsException $e) {
-        expect($e->getMessage())->toContain('fts5');
-    }
+    // Raw "Marko's" used to raise "fts5: syntax error"; sanitized it matches docs.
+    $results = $search->search(new DocsQuery("how does Marko's installation work"));
+
+    expect($results)->toBeArray()->not->toBeEmpty();
 });
 
 // Helper: builds a real index in a temp dir using FTS-only (no model needed for basic search tests)


### PR DESCRIPTION
## Summary

The `docs-vec` audit (#128) flagged six defects plus a presumed structural wall — "PDO can't load SQLite extensions on stock PHP." **The wall was a wrong API call, not a platform limit:** `Pdo\Sqlite::loadExtension()` works on stock Homebrew PHP 8.5. Every defect turned out to be code/packaging, and the driver is now functional end-to-end.

## Fixes (closes #128)

1. **Double-binding boot crash** — `module.php` bound `DocsSearchInterface` in both `bindings` and `singletons` → `BindingConflictException`. Now `bindings => []` + singleton factory.
2. **Unautowireable `$packageRoot`** — `VecRuntime` + the download commands now registered as singletons with `__DIR__`.
3. **128 MB OOM** — `DownloadModelCommand` streams the ONNX model to disk (`stream_copy_to_stream`).
4. **Missing sqlite-vec binary** — new `docs-vec:download-extension` command: pinned **v0.1.9**, **SHA-256-verified before extraction, fail-closed**, per-platform (macOS/Linux/Windows × x86_64/arm64).
5. **Wrong/`suggest`-only transformers** — `codewithkyrian/transformers-php` → `codewithkyrian/transformers` (`^0.5 || ^0.6`); kept optional with **graceful FTS5-only fallback** when extension/model/transformers are absent.
6. **Structural (decisive)** — `VecRuntime` now loads sqlite-vec via `Pdo\Sqlite::loadExtension()` instead of the blocked `SELECT load_extension(...)`, with a probe that degrades to FTS5 on builds that compile the capability out.

Plus latent bugs the never-run embedding path hid: HF model layout (`onnx/` subdir + tokenizer files), `pipeline()` usage + mean-pooling, per-call model reload (the indexing OOM), vec0 integer-PK bind. The FTS half now sanitizes NL queries (parity with #127), co-located because `marko/docs` is contract-only.

## Verification

- Real hybrid build over the docs corpus → **all 8 expected docs in top-3 (V = 8/8)**, matching `docs-fts`.
- **89 passed / 6 skipped / 0 failed** across `docs`, `docs-fts`, `docs-vec`. phpcs + php-cs-fixer clean.
- Downloaded binary/model are gitignored; root `composer.json` untouched.

`docs-fts` remains the recommended **zero-infra default**; `docs-vec` is now a working **opt-in** semantic option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)