### PR TITLE
ci: retry split-repo pushes on concurrent ref-lock

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -59,13 +59,29 @@ jobs:
           REPO="https://x-access-token:${MARKO_BUILD_PAT}@github.com/${SPLIT_ORG}/marko-${{ matrix.package }}.git"
           SHA=$(splitsh-lite --prefix="packages/${{ matrix.package }}")
 
+          # During a release, release.sh pushes main, the tag, and develop in
+          # quick succession, so the main-run and tag-run race to push the same
+          # split repo's refs/heads/main and one loses the atomic ref-lock
+          # ("cannot lock ref ... expected <old>"). --force does not help: the
+          # collision is the ref-lock, not a fast-forward. Retry instead — the
+          # split SHA is deterministic, so a retry finds the ref already at the
+          # target SHA and succeeds ("Everything up-to-date").
+          push() {
+            for attempt in 1 2 3; do
+              git push --force "$REPO" "${SHA}:$1" && return 0
+              echo "push to $1 failed (attempt $attempt/3)"
+              [ "$attempt" -lt 3 ] && sleep "$attempt"
+            done
+            return 1
+          }
+
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
-            git push --force "$REPO" "${SHA}:refs/heads/main"
-            git push --force "$REPO" "${SHA}:refs/tags/${TAG}"
+            push "refs/heads/main"
+            push "refs/tags/${TAG}"
           else
             BRANCH="${GITHUB_REF#refs/heads/}"
-            git push --force "$REPO" "${SHA}:refs/heads/${BRANCH}"
+            push "refs/heads/${BRANCH}"
           fi
 
       - name: Notify Packagist


### PR DESCRIPTION
## Problem

Tagging 0.8.1 dropped the `0.8.1` tag from `marko/admin-api`. The split workflow's `split (admin-api)` job failed in **Split and push**:

```
! [remote rejected] af1ed26 -> main (cannot lock ref 'refs/heads/main': is at af1ed26 but expected 66cd071)
```

**Root cause:** `release.sh` pushes `main`, the release tag, and `develop` within seconds. `split.yml`'s concurrency is keyed per `github.ref`, so those land in three different groups and run **simultaneously** — and the `main`-run and tag-run both push each split repo's `refs/heads/main`. One wins; the other loses the atomic ref-lock and the job dies *before* pushing the tag. `--force` (already present) can't help: the collision is the ref-lock compare-and-swap, not a fast-forward.

Only `admin-api` was bitten this release (timing-dependent); its `main` was correct but the tag was missing. Already remediated by re-running the failed leg.

## Fix

Wrap each push in a 3-attempt retry with 1s/2s backoff. The split SHA is deterministic, so a retry finds the ref already at the target SHA and reports "Everything up-to-date". Genuine failures (bad PAT, missing repo) still surface in ~3s rather than retrying pointlessly.

Only the `run:` script of the **Split and push** step changes — triggers, concurrency, matrix, `--force`, refspecs, and Packagist notify are untouched.

## Verification

Rides into the next release tag; we'll confirm on the next `main`+tag push that no split leg fails the ref-lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)