### PR TITLE
feat(devai): offer to install a docs search driver during devai:install

### DIFF
--- a/.claude/plans/devai-docs-driver-prompt/001-confirmation-prompter.md
+++ b/.claude/plans/devai-docs-driver-prompt/001-confirmation-prompter.md
@@ -1,0 +1,64 @@
+# Task 001: ConfirmationPrompterInterface + StdinPrompter + FakePrompter
+
+**Status**: pending
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+Introduce a small, injectable interactive-confirmation seam inside the devai
+package, because `Marko\Core\Command\Input`/`Output` have no interactive input.
+A real `StdinPrompter` reads a Y/n answer from STDIN and reports whether the
+session is interactive; a `FakePrompter` lets tests script answers without
+touching real STDIN.
+
+## Context
+- New files under `packages/devai/src/Process/` (peer of `CommandRunner`):
+  `ConfirmationPrompterInterface.php`, `StdinPrompter.php`.
+- Interface shape (typed):
+  - `isInteractive(): bool`
+  - `confirm(string $question, bool $default): bool`
+- **`StdinPrompter` must be unit-testable without reading real STDIN.** Hardcoding
+  `STDIN`/`stream_isatty(STDIN)`/`fgets(STDIN)` makes the parsing logic impossible
+  to test on the real class. Therefore `StdinPrompter` takes an **injectable input
+  stream resource** plus the no-interaction flag, both constructor-promoted/readonly:
+  `__construct(private $stream = STDIN, private bool $noInteraction = false)`
+  (note: a resource cannot be type-declared, so `$stream` is untyped — document
+  this with a `@param resource $stream` docblock). Tests pass a `php://memory`/
+  `php://temp` stream pre-filled with the scripted answer, so `confirm()`'s real
+  parsing runs under test. Only `isInteractive()`'s `stream_isatty()` call against a
+  real TTY stays untested — keep that the single untested line, decomposed so
+  `confirm()` does not depend on it.
+- `isInteractive()` = `!$this->noInteraction && stream_isatty($this->stream)`.
+- `confirm()` reads one line via `fgets($this->stream)`, then parses a trimmed,
+  lowercased line: `y`/`yes` → true, `n`/`no` → false, empty → `$default`; any other
+  input is treated as `$default` (no re-read).
+- Test double: `FakePrompter` — it is a **test-only double**, NOT a production class.
+  Define it inside the test file(s) as an anonymous class or a small named class in
+  the `Marko\DevAi\Tests\` namespace under `packages/devai/tests/` (the registered
+  `autoload-dev` psr-4 is `Marko\DevAi\Tests\ => tests/`). Do **not** add a binding
+  for it and do **not** place it under `src/`. It implements
+  `ConfirmationPrompterInterface` with a scripted boolean answer and a configurable
+  `isInteractive()` flag. (The codebase uses inline anonymous-class doubles —
+  see `makeRecordingRunner()` in `InstallationOrchestratorTest` — follow that pattern.)
+- Bind in `packages/devai/module.php`: `ConfirmationPrompterInterface::class => StdinPrompter::class`
+  (alongside the existing `CommandRunnerInterface` binding). `StdinPrompter` autowires
+  with its default `STDIN`/`false` args (container passes no constructor values), so the
+  container binding resolves with no extra wiring.
+- Standards: `declare(strict_types=1)`, constructor property promotion, type decls,
+  no `final`. Interface methods fully typed.
+
+## Requirements (Test Descriptions)
+- [ ] `it returns true when the user answers yes` (StdinPrompter, in-memory stream)
+- [ ] `it returns false when the user answers no` (StdinPrompter, in-memory stream)
+- [ ] `it returns the default when the answer is empty` (StdinPrompter, in-memory stream)
+- [ ] `it parses answers case-insensitively and ignores surrounding whitespace` (StdinPrompter)
+- [ ] `it reports not interactive when constructed in no-interaction mode` (StdinPrompter)
+- [ ] `the fake prompter returns its scripted answer and configured interactivity`
+
+## Acceptance Criteria
+- All requirements have passing tests (using `FakePrompter`, never real STDIN)
+- `ConfirmationPrompterInterface` bound to `StdinPrompter` in `module.php`
+- Code follows code standards; no decrease in coverage
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/devai-docs-driver-prompt/001-confirmation-prompter.md
+++ b/.claude/plans/devai-docs-driver-prompt/001-confirmation-prompter.md
@@ -1,6 +1,6 @@
 # Task 001: ConfirmationPrompterInterface + StdinPrompter + FakePrompter
 
-**Status**: pending
+**Status**: complete
 **Depends on**: none
 **Retry count**: 0
 
@@ -48,12 +48,12 @@ touching real STDIN.
   no `final`. Interface methods fully typed.
 
 ## Requirements (Test Descriptions)
-- [ ] `it returns true when the user answers yes` (StdinPrompter, in-memory stream)
-- [ ] `it returns false when the user answers no` (StdinPrompter, in-memory stream)
-- [ ] `it returns the default when the answer is empty` (StdinPrompter, in-memory stream)
-- [ ] `it parses answers case-insensitively and ignores surrounding whitespace` (StdinPrompter)
-- [ ] `it reports not interactive when constructed in no-interaction mode` (StdinPrompter)
-- [ ] `the fake prompter returns its scripted answer and configured interactivity`
+- [x] `it returns true when the user answers yes` (StdinPrompter, in-memory stream)
+- [x] `it returns false when the user answers no` (StdinPrompter, in-memory stream)
+- [x] `it returns the default when the answer is empty` (StdinPrompter, in-memory stream)
+- [x] `it parses answers case-insensitively and ignores surrounding whitespace` (StdinPrompter)
+- [x] `it reports not interactive when constructed in no-interaction mode` (StdinPrompter)
+- [x] `the fake prompter returns its scripted answer and configured interactivity`
 
 ## Acceptance Criteria
 - All requirements have passing tests (using `FakePrompter`, never real STDIN)
@@ -61,4 +61,8 @@ touching real STDIN.
 - Code follows code standards; no decrease in coverage
 
 ## Implementation Notes
-(Left blank - filled in by programmer during implementation)
+- Created `ConfirmationPrompterInterface` with `isInteractive(): bool` and `confirm(string $question, bool $default): bool`
+- Created `StdinPrompter` with injectable `$stream` resource (untyped, `@param resource` docblock) and `bool $noInteraction = false`. Uses `stream_isatty()` for `isInteractive()`, `fgets()` for `confirm()` with trim+lowercase parsing
+- `FakePrompter` implemented as inline anonymous class in `makeFakePrompter()` helper inside the test file, following the `makeRecordingRunner()` pattern
+- Bound `ConfirmationPrompterInterface::class => StdinPrompter::class` in `module.php` alongside `CommandRunnerInterface`
+- All 6 requirements have passing tests; 228 total package tests pass

--- a/.claude/plans/devai-docs-driver-prompt/002-docs-driver-resolver.md
+++ b/.claude/plans/devai-docs-driver-prompt/002-docs-driver-resolver.md
@@ -1,6 +1,6 @@
 # Task 002: DocsDriverResolver (registry-driven driver detection)
 
-**Status**: pending
+**Status**: complete
 **Depends on**: none
 **Retry count**: 0
 
@@ -47,12 +47,12 @@ orchestrator and the install command stay driver-agnostic.
 - Standards: `declare(strict_types=1)`, promotion, type decls, no `final`.
 
 ## Requirements (Test Descriptions)
-- [ ] `it returns the installed driver when its vendor directory exists`
-- [ ] `it returns null for installed driver when no known driver is present`
-- [ ] `it lists known drivers that are not installed`
-- [ ] `it picks the recommended uninstalled driver by the description convention`
-- [ ] `it derives the build command from the package name`
-- [ ] `it treats the known set as empty when the contract registry file is absent`
+- [x] `it returns the installed driver when its vendor directory exists`
+- [x] `it returns null for installed driver when no known driver is present`
+- [x] `it lists known drivers that are not installed`
+- [x] `it picks the recommended uninstalled driver by the description convention`
+- [x] `it derives the build command from the package name`
+- [x] `it treats the known set as empty when the contract registry file is absent`
 
 ## Acceptance Criteria
 - All requirements have passing tests (use a temp project root with fake `vendor/marko/*` dirs and a stub `known-drivers.php`)
@@ -60,4 +60,7 @@ orchestrator and the install command stay driver-agnostic.
 - Code follows code standards
 
 ## Implementation Notes
-(Left blank - filled in by programmer during implementation)
+- `DocsDriverResolver` has no constructor dependencies (stateless service); no `readonly class` needed since there are no properties.
+- Used `array_find()` (PHP 8.5) for the first-match lookups, keeping code concise and idiomatic.
+- `buildCommand` uses `strpos`+`substr` to strip any `<vendor>/` prefix, not just `marko/`, making it forward-compatible with other vendors.
+- `knownDrivers()` guards with `is_file()` before `require`; absent file → empty array, no throw/warning.

--- a/.claude/plans/devai-docs-driver-prompt/002-docs-driver-resolver.md
+++ b/.claude/plans/devai-docs-driver-prompt/002-docs-driver-resolver.md
@@ -1,0 +1,63 @@
+# Task 002: DocsDriverResolver (registry-driven driver detection)
+
+**Status**: pending
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+Add a service that answers "what docs-search driver state is this project in?"
+by reading the existing `marko/docs` known-drivers registry and checking the
+project's `vendor/` — without hardcoding `docs-fts`. This is what lets both the
+orchestrator and the install command stay driver-agnostic.
+
+## Context
+- New file: `packages/devai/src/Installation/DocsDriverResolver.php`.
+- Registry source: `marko/docs` ships `known-drivers.php` returning
+  `array<string, string>` (package => description). Read it from the installed
+  contract package at `{projectRoot}/vendor/marko/docs/known-drivers.php`. Confirmed
+  real shape (do not assume otherwise): a single entry today —
+  `['marko/docs-fts' => 'Full-text documentation search driver (recommended; SQLite FTS5, zero infrastructure)']`.
+  In a real installed project the contract lives at `vendor/marko/docs/`, so the
+  `{projectRoot}/vendor/marko/docs/known-drivers.php` path is correct; the monorepo
+  path (`packages/docs/known-drivers.php`) is only used by the package's own tests
+  and is irrelevant to the resolver. If the file is absent (e.g. devai installed
+  without the contract resolved yet, or a non-standard layout), `require` must NOT
+  be attempted — guard with `is_file()` and treat the known set as empty (degrade
+  gracefully, no throw, no warning). **Do NOT change the registry shape** — it is a
+  shared convention validated by
+  `packages/testing/src/KnownDrivers/KnownDriversValidator.php` and parity tests
+  across ~20 packages.
+- A driver `marko/<name>` is "installed" when `is_dir({projectRoot}/vendor/marko/<name>)`
+  (same check the orchestrator uses today for `docs-fts`).
+- Methods (typed):
+  - `installedDriver(string $projectRoot): ?string` — first known package whose vendor dir exists, else null.
+  - `uninstalledDrivers(string $projectRoot): list<string>` — known packages whose vendor dir is absent.
+  - `recommendedUninstalled(string $projectRoot): ?string` — among uninstalled, the one whose
+    registry description contains the word `recommended` (case-insensitive substring match —
+    the real description reads `(recommended; SQLite FTS5…)`, so match on `recommended`, NOT the
+    literal `(recommended ` with a trailing space). Else the first uninstalled, else null.
+  - `buildCommand(string $package): string` — derive the index-build command from the package
+    name: strip the `marko/` (or any `<vendor>/`) prefix and append `:build`
+    (e.g. `marko/docs-fts` → `docs-fts:build`). NOTE: this convention holds for the
+    only known driver today (`marko/docs-fts` → `docs-fts:build`, which matches the
+    command the orchestrator already runs). If a future driver's build command name
+    diverges from its short package name, this derivation breaks — but that is out of
+    scope here and acceptable while there is one known driver. Keep the derivation
+    simple (no per-package overrides).
+- Standards: `declare(strict_types=1)`, promotion, type decls, no `final`.
+
+## Requirements (Test Descriptions)
+- [ ] `it returns the installed driver when its vendor directory exists`
+- [ ] `it returns null for installed driver when no known driver is present`
+- [ ] `it lists known drivers that are not installed`
+- [ ] `it picks the recommended uninstalled driver by the description convention`
+- [ ] `it derives the build command from the package name`
+- [ ] `it treats the known set as empty when the contract registry file is absent`
+
+## Acceptance Criteria
+- All requirements have passing tests (use a temp project root with fake `vendor/marko/*` dirs and a stub `known-drivers.php`)
+- Registry file shape is read-only; no change to `marko/docs` or the shared validator
+- Code follows code standards
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/devai-docs-driver-prompt/003-orchestrator-resolved-build.md
+++ b/.claude/plans/devai-docs-driver-prompt/003-orchestrator-resolved-build.md
@@ -1,0 +1,56 @@
+# Task 003: Orchestrator builds the resolved installed driver
+
+**Status**: pending
+**Depends on**: 002
+**Retry count**: 0
+
+## Description
+Replace the hardcoded `is_dir(vendor/marko/docs-fts)` branch in
+`InstallationOrchestrator::buildDocsIndex()` with `DocsDriverResolver`, so it
+builds whichever known docs driver is installed and stays correct for any future
+(including third-party) driver. Behavior when no driver is installed is unchanged
+(it still logs the helpful hint).
+
+## Context
+- Edit: `packages/devai/src/Installation/InstallationOrchestrator.php`
+  (`buildDocsIndex()`, ~lines 106-118 after PR #132).
+- Inject `DocsDriverResolver` into the orchestrator constructor (promoted, readonly).
+  `DocsDriverResolver` has no constructor args, so it autowires — no `module.php`
+  binding needed and the container keeps resolving the orchestrator.
+- Update `makeInstallOrchestrator()` in `InstallationOrchestratorTest.php` to pass a
+  `new DocsDriverResolver()` (real object — it only reads files under the temp
+  `$projectRoot`). This is the single construction site in tests; the container
+  autowires it in production.
+- `UpdateCommand` also calls `orchestrator->install()` (which calls `buildDocsIndex()`),
+  so it inherits this behavior unchanged — no edit to `UpdateCommand` is required, but
+  verify its tests still pass after the constructor signature changes.
+- New logic: `$driver = $resolver->installedDriver($projectRoot)`. If null → keep the
+  current `'[docs] no search driver installed — run `composer require marko/docs-fts`…'`
+  log line and return. Otherwise run `$resolver->buildCommand($driver)` via the
+  existing `CommandRunnerInterface` and log success/failure exactly as today.
+- Keep the existing "build failed" log-line behavior and message shape.
+- **CRITICAL test-fixture update (do not miss):** the resolver only treats a driver as
+  installed if it appears in `vendor/marko/docs/known-drivers.php`. The existing
+  orchestrator tests
+  (`runs docs-fts:build during install when marko/docs-fts is in vendor` and
+  `records a helpful log line when the docs index build fails`) currently create only
+  `vendor/marko/docs-fts/` — with no registry file the resolver returns null and the
+  build would be skipped, BREAKING those tests. Update those tests to ALSO write a stub
+  `vendor/marko/docs/known-drivers.php` returning
+  `['marko/docs-fts' => '...(recommended; ...)']` so the resolver resolves the driver.
+  The `skips… when no driver is installed` test needs no registry file (empty set →
+  null → hint), and that behavior is unchanged.
+
+## Requirements (Test Descriptions)
+- [ ] `it builds the index for the installed docs driver resolved from the registry`
+- [ ] `it logs the install hint when no docs driver is installed`
+- [ ] `it records a helpful log line when the docs index build fails`
+- [ ] `it does not hardcode the docs-fts package when resolving the driver to build`
+
+## Acceptance Criteria
+- All requirements have passing tests; existing orchestrator tests still green
+- `buildDocsIndex()` no longer references `docs-fts` literally (resolves via `DocsDriverResolver`)
+- Code follows code standards
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/devai-docs-driver-prompt/003-orchestrator-resolved-build.md
+++ b/.claude/plans/devai-docs-driver-prompt/003-orchestrator-resolved-build.md
@@ -1,6 +1,6 @@
 # Task 003: Orchestrator builds the resolved installed driver
 
-**Status**: pending
+**Status**: complete
 **Depends on**: 002
 **Retry count**: 0
 
@@ -42,10 +42,10 @@ builds whichever known docs driver is installed and stays correct for any future
   null → hint), and that behavior is unchanged.
 
 ## Requirements (Test Descriptions)
-- [ ] `it builds the index for the installed docs driver resolved from the registry`
-- [ ] `it logs the install hint when no docs driver is installed`
-- [ ] `it records a helpful log line when the docs index build fails`
-- [ ] `it does not hardcode the docs-fts package when resolving the driver to build`
+- [x] `it builds the index for the installed docs driver resolved from the registry`
+- [x] `it logs the install hint when no docs driver is installed`
+- [x] `it records a helpful log line when the docs index build fails`
+- [x] `it does not hardcode the docs-fts package when resolving the driver to build`
 
 ## Acceptance Criteria
 - All requirements have passing tests; existing orchestrator tests still green
@@ -53,4 +53,7 @@ builds whichever known docs driver is installed and stays correct for any future
 - Code follows code standards
 
 ## Implementation Notes
-(Left blank - filled in by programmer during implementation)
+- Injected `DocsDriverResolver` as a promoted property with a default of `new DocsDriverResolver()` (PHP 8.1+ new-in-initializer) so the container continues to autowire it and existing `UpdateCommandTest` stubs that extend the orchestrator need no changes.
+- `buildDocsIndex()` now calls `$this->docsDriverResolver->installedDriver($projectRoot)` and uses `buildCommand($package)` for the command; the `$driver` name is extracted from the package for log messages.
+- Updated 2 existing tests (`runs docs-fts:build during install` and `records a helpful log line when the docs index build fails`) to write a stub `vendor/marko/docs/known-drivers.php` registry so the resolver resolves `marko/docs-fts`.
+- Added 4 new tests exercising `marko/docs-vec` as the installed driver to prove no `docs-fts` hardcoding remains in detection logic.

--- a/.claude/plans/devai-docs-driver-prompt/004-wire-prompt-into-install-command.md
+++ b/.claude/plans/devai-docs-driver-prompt/004-wire-prompt-into-install-command.md
@@ -1,0 +1,81 @@
+# Task 004: Wire prompt + opt-in composer require into InstallCommand
+
+**Status**: pending
+**Depends on**: 001, 002, 003
+**Retry count**: 0
+
+## Description
+Make `marko devai:install` offer to install the recommended docs driver when none
+is present and the session is interactive. On "yes" it runs
+`composer require --dev <package>` (so the orchestrator then builds its index); on
+"no", `--no-interaction`, or a non-TTY session it does nothing extra and falls back
+to the existing printed hint. Never blocks CI.
+
+## Context
+- Edit: `packages/devai/src/Commands/InstallCommand.php` (still `readonly`).
+  Add constructor deps: `DocsDriverResolver`, `ConfirmationPrompterInterface`,
+  `CommandRunnerInterface`. These all autowire/bind (resolver has no args;
+  `ConfirmationPrompterInterface` is bound in task 001; `CommandRunnerInterface`
+  is already bound) so `ContainerWiringTest` keeps resolving `InstallCommand`.
+- **`--no-interaction` handling — do NOT try to reconfigure the injected prompter.**
+  The prompter is injected `readonly` and the container builds `StdinPrompter` with
+  its default flag; the command cannot rebuild it per-invocation. Instead, the command
+  reads `$noInteraction = $input->hasOption('no-interaction')` itself and gates the
+  prompt on BOTH that flag and `$prompter->isInteractive()`. Concretely, treat the
+  session as promptable only when `!$noInteraction && $prompter->isInteractive()`.
+  This means `--no-interaction` is a real, parseable long option (verified against
+  `Marko\Core\Command\Input::hasOption()` — multi-char names match `--no-interaction`),
+  so no unknown-option handling is needed; an absent flag simply returns false.
+- Note `ConfirmationPrompterInterface::confirm(string $question, bool $default): bool`
+  (matches task 001's signature — pass `default: true`).
+- Flow, BEFORE calling `$this->orchestrator->install(...)`:
+  1. If `$resolver->installedDriver($projectRoot)` !== null → do nothing (orchestrator builds it).
+  2. Else let `$pkg = $resolver->recommendedUninstalled($projectRoot)`. If `$pkg`
+     is null → do nothing (orchestrator logs the hint).
+  3. Else if `$noInteraction || !$prompter->isInteractive()` → do nothing (orchestrator logs the hint).
+  4. Else `confirm("No docs search driver installed. Install $pkg to enable search_docs?", default: true)`:
+     - yes + `CommandRunner::isOnPath('composer')` → `run('composer', ['require','--dev',$pkg])`;
+       on non-zero exit write a helpful line (do NOT throw — never block the install). On
+       success, fall through so the orchestrator detects and builds it.
+     - yes + composer not on PATH → write a helpful "composer not found — run `composer require --dev $pkg`" line.
+     - no → fall through to the orchestrator's hint.
+- Then call the orchestrator as today and print the summary.
+- Tests: `packages/devai/tests/Unit/Commands/InstallCommandTest.php` **already exists**
+  with two passing tests (`supports non-interactive mode via the --agents flag`,
+  `is registered via Command attribute…`) — **ADD** the new cases to it, do not
+  overwrite or remove the existing ones. Construct `InstallCommand` directly with a
+  `FakePrompter` (task 001), a recording `CommandRunnerInterface` (reuse the
+  `makeRecordingRunner()` pattern), a real `DocsDriverResolver`, and the existing
+  orchestrator/registry doubles. Drive it through a temp project root
+  (`devaiTempDir()`) with/without `vendor/marko/*` dirs and a stub
+  `vendor/marko/docs/known-drivers.php`. Note the command reads `getcwd()` for the
+  project root — either `chdir()` into the temp root in the test (restore cwd in
+  `afterEach`) or assert at the level the resolver/runner are invoked; prefer the
+  `chdir()` approach to exercise the real path. Assert on the recorded command calls
+  (e.g. `['composer', ['require','--dev','marko/docs-fts']]`).
+- Add a guard test that devai's own `composer.json` gains no driver dependency
+  (still requires only `marko/docs`): decode `packages/devai/composer.json`, assert
+  `require` contains `marko/docs` and contains NO key matching `marko/docs-*`
+  (i.e. no concrete docs driver). This protects the modularity invariant.
+
+## Requirements (Test Descriptions)
+- [ ] `it offers to install the recommended driver and runs composer require on yes`
+- [ ] `it does not install anything when the user answers no`
+- [ ] `it does not prompt or install when run with --no-interaction`
+- [ ] `it does not prompt or install when the session is not interactive (no TTY)`
+- [ ] `it does not prompt when a docs driver is already installed`
+- [ ] `it writes a helpful message when composer is not on PATH`
+- [ ] `it writes a helpful message and does not throw when composer require exits non-zero`
+- [ ] `it keeps devai dependent on the marko/docs contract only (no driver in require)`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- The two pre-existing tests in `InstallCommandTest.php` remain green
+- `ContainerWiringTest` still resolves `InstallCommand` (new deps autowire/bind)
+- Non-interactive / no-driver path is unchanged from today (printed hint, exit 0)
+- A non-zero `composer require` exit is surfaced as a log/output line, never thrown — `execute()` still returns 0
+- `devai/composer.json` require still contains `marko/docs` and no concrete driver
+- Code follows code standards
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/devai-docs-driver-prompt/004-wire-prompt-into-install-command.md
+++ b/.claude/plans/devai-docs-driver-prompt/004-wire-prompt-into-install-command.md
@@ -59,14 +59,14 @@ to the existing printed hint. Never blocks CI.
   (i.e. no concrete docs driver). This protects the modularity invariant.
 
 ## Requirements (Test Descriptions)
-- [ ] `it offers to install the recommended driver and runs composer require on yes`
-- [ ] `it does not install anything when the user answers no`
-- [ ] `it does not prompt or install when run with --no-interaction`
-- [ ] `it does not prompt or install when the session is not interactive (no TTY)`
-- [ ] `it does not prompt when a docs driver is already installed`
-- [ ] `it writes a helpful message when composer is not on PATH`
-- [ ] `it writes a helpful message and does not throw when composer require exits non-zero`
-- [ ] `it keeps devai dependent on the marko/docs contract only (no driver in require)`
+- [x] `it offers to install the recommended driver and runs composer require on yes`
+- [x] `it does not install anything when the user answers no`
+- [x] `it does not prompt or install when run with --no-interaction`
+- [x] `it does not prompt or install when the session is not interactive (no TTY)`
+- [x] `it does not prompt when a docs driver is already installed`
+- [x] `it writes a helpful message when composer is not on PATH`
+- [x] `it writes a helpful message and does not throw when composer require exits non-zero`
+- [x] `it keeps devai dependent on the marko/docs contract only (no driver in require)`
 
 ## Acceptance Criteria
 - All requirements have passing tests
@@ -78,4 +78,9 @@ to the existing printed hint. Never blocks CI.
 - Code follows code standards
 
 ## Implementation Notes
-(Left blank - filled in by programmer during implementation)
+- Added `DocsDriverResolver`, `ConfirmationPrompterInterface`, and `CommandRunnerInterface` as constructor deps to `InstallCommand` (kept `readonly class`).
+- Added `maybeInstallDocsDriver()` private method that runs BEFORE `$this->orchestrator->install(...)`.
+- Used `$input->hasOption('no-interaction')` to detect the flag (multi-char name matches `--no-interaction` per `Input::hasOption`).
+- Non-zero composer exit writes a helpful output line and returns (does NOT throw) — execute() still returns 0.
+- Tests use `chdir()` into the temp root in `beforeEach`/`afterEach` pattern and local helper functions defined at file top.
+- ContainerWiringTest passes because `DocsDriverResolver` has no constructor args (autowires), and both interface deps were already bound in `module.php` from prior tasks.

--- a/.claude/plans/devai-docs-driver-prompt/_plan.md
+++ b/.claude/plans/devai-docs-driver-prompt/_plan.md
@@ -4,7 +4,7 @@
 2026-06-24
 
 ## Status
-ready
+completed
 
 ## Objective
 When `marko devai:install` runs in an interactive terminal and no docs-search
@@ -66,10 +66,10 @@ none
 ## Task Overview
 | Task | Description | Depends On | Status |
 |------|-------------|------------|--------|
-| 001 | ConfirmationPrompterInterface + StdinPrompter + FakePrompter | - | pending |
-| 002 | DocsDriverResolver (registry-driven driver detection) | - | pending |
-| 003 | Orchestrator builds the resolved installed driver | 002 | pending |
-| 004 | Wire prompt + opt-in composer require into InstallCommand | 001, 002, 003 | pending |
+| 001 | ConfirmationPrompterInterface + StdinPrompter + FakePrompter | - | completed |
+| 002 | DocsDriverResolver (registry-driven driver detection) | - | completed |
+| 003 | Orchestrator builds the resolved installed driver | 002 | completed |
+| 004 | Wire prompt + opt-in composer require into InstallCommand | 001, 002, 003 | completed |
 
 ## Architecture Notes
 - Prompter binding goes in `packages/devai/module.php` (`ConfirmationPrompterInterface => StdinPrompter`), alongside the existing `CommandRunnerInterface` binding.

--- a/.claude/plans/devai-docs-driver-prompt/_plan.md
+++ b/.claude/plans/devai-docs-driver-prompt/_plan.md
@@ -1,0 +1,87 @@
+# Plan: devai docs-driver install prompt
+
+## Created
+2026-06-24
+
+## Status
+ready
+
+## Objective
+When `marko devai:install` runs in an interactive terminal and no docs-search
+driver is installed, offer to install the recommended driver (`marko/docs-fts`)
+with a Y/n prompt — instead of just printing a "run composer require…" hint —
+then build its index. Keep devai depending only on the `marko/docs` contract.
+
+## Related Issues
+none
+
+## Discovery Notes
+- Follows the docs-vec removal (PR #132): `marko/docs-fts` is the only first-party
+  docs driver, but `devai` must stay coupled to the `marko/docs` **contract** only
+  (third parties can implement `DocsSearchInterface`). So: no hardcoded driver
+  `require`; detect + offer at install time instead.
+- **Console framework has no interactive input.** `Marko\Core\Command\Input` is
+  `readonly`/parse-only; `Output` is write-only. Decision (user-approved): add a
+  small `ConfirmationPrompterInterface` **inside devai** (real `StdinPrompter` +
+  test `FakePrompter`), injected into `InstallCommand`. Do NOT expand core's
+  console framework for this.
+- **`known-drivers.php` is a framework-wide convention**, not a docs-local file:
+  shared `KnownDriversValidator` (marko/testing) enforces `array<string,string>`,
+  with `KnownDriversValidationTest` + skeleton-suggest parity tests across ~20
+  packages. **Do not change its shape.** The resolver reads it as-is; "recommended"
+  is already encoded by the existing `(recommended…)` description convention
+  (read-only) and is irrelevant while there is exactly one docs driver.
+- `CommandRunner` (`proc_open`, `escapeshell*`) already runs `marko …:build`; it
+  can run `composer require --dev …` too, and exposes `isOnPath()` to guard it.
+- Seam: `InstallCommand` prompts + runs `composer require` **before** delegating to
+  `InstallationOrchestrator::install()`. The orchestrator then detects the
+  freshly-installed driver and builds its index in a **separate subprocess**
+  (`marko docs-fts:build`), so the running process's autoloader is irrelevant.
+
+## Scope
+
+### In Scope
+- `ConfirmationPrompterInterface` + `StdinPrompter` (TTY/`--no-interaction` aware) + `FakePrompter`
+- `DocsDriverResolver` — registry-driven detect of installed vs. uninstalled known docs drivers
+- Generalize `InstallationOrchestrator::buildDocsIndex()` to build whichever known driver is installed (drop the hardcoded `docs-fts` `is_dir`)
+- Wire the prompt + opt-in `composer require --dev` into `InstallCommand`, with a non-interactive fallback to today's printed hint
+
+### Out of Scope
+- Any change to the `known-drivers.php` shape or the shared `KnownDriversValidator`
+- Interactive-input primitives in `marko/core` (kept local to devai)
+- Multi-driver selection menu (offer the single recommended driver; opt-out only)
+- Persisting a "user declined" flag in `.marko/devai.json` (re-prompt each run)
+- Hardcoding `marko/docs-fts` as a devai dependency
+- Version/changelog work (rides the next release); docs pages handled by the post-implementation `doc-updater`
+
+## Success Criteria
+- [ ] Interactive `devai:install` with no driver offers to install `marko/docs-fts`; on "yes" it runs `composer require --dev marko/docs-fts` and the index builds
+- [ ] On "no", or `--no-interaction`, or no TTY: no prompt, no install — falls back to the printed hint (never blocks CI)
+- [ ] An already-installed driver is detected and built with no prompt
+- [ ] `devai` still requires only `marko/docs` (no concrete-driver dependency added)
+- [ ] `known-drivers.php` shape and the shared validator/parity tests are unchanged
+- [ ] All tests passing
+- [ ] Code follows project standards
+
+## Task Overview
+| Task | Description | Depends On | Status |
+|------|-------------|------------|--------|
+| 001 | ConfirmationPrompterInterface + StdinPrompter + FakePrompter | - | pending |
+| 002 | DocsDriverResolver (registry-driven driver detection) | - | pending |
+| 003 | Orchestrator builds the resolved installed driver | 002 | pending |
+| 004 | Wire prompt + opt-in composer require into InstallCommand | 001, 002, 003 | pending |
+
+## Architecture Notes
+- Prompter binding goes in `packages/devai/module.php` (`ConfirmationPrompterInterface => StdinPrompter`), alongside the existing `CommandRunnerInterface` binding.
+- Build-command convention: a known driver package `marko/<name>` builds via `marko <name>:build` (e.g. `marko/docs-fts` → `docs-fts:build`). The resolver derives this by stripping the `<vendor>/` prefix and appending `:build`. Holds for the only known driver today; per-package overrides are out of scope.
+- `StdinPrompter` takes an **injectable input stream** (`$stream = STDIN`) plus a `bool $noInteraction = false` flag so `confirm()`'s parsing is unit-testable against a `php://memory` stream; only the `stream_isatty()` line stays untested. `isInteractive()` = `!$noInteraction && stream_isatty($stream)`. Tests also use `FakePrompter` (scripted answer + interactivity flag) at the command level so no real STDIN is read.
+- `--no-interaction` is gated **in `InstallCommand`** via `$input->hasOption('no-interaction')` (verified parseable by `Input::hasOption`), NOT by reconfiguring the injected `readonly` prompter. The prompt path requires `!$noInteraction && $prompter->isInteractive()`.
+- The resolver's "installed driver" check reads `vendor/marko/docs/known-drivers.php`; a driver in `vendor/` that is absent from the registry is NOT considered installed. Orchestrator tests must stub that registry file (see task 003) or the existing docs-fts build tests break.
+- `InstallCommand` gains `DocsDriverResolver`, `ConfirmationPrompterInterface`, and `CommandRunnerInterface` deps (still `readonly`); guards the install with `isOnPath('composer')` and logs a helpful line on a non-zero exit without throwing. `InstallCommandTest.php` already exists — extend it.
+- Post-implementation `doc-updater` updates `ai-assisted-development/mcp.md` + the devai package docs to describe the prompt and keep the "devai depends on the contract, not a driver" note.
+
+## Risks & Mitigations
+- **Nested/again composer invocation fails**: only shell out to `composer` from the interactive command path (never from a composer hook context); guard with `isOnPath('composer')` and surface a helpful message on non-zero exit instead of throwing.
+- **Reading real STDIN makes tests flaky/hang**: all logic goes through `ConfirmationPrompterInterface`; production reads STDIN only inside `StdinPrompter`, never in tested branches.
+- **Accidentally coupling devai to a driver**: the install is a runtime `composer require` chosen by the user, not a composer `require` entry — asserted by a success-criterion test that devai's composer.json gains no driver dependency.
+- **Drift from the shared registry convention**: resolver only *reads* `known-drivers.php`; a test asserts the shape/validator are untouched.

--- a/packages/devai/module.php
+++ b/packages/devai/module.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 use Marko\DevAi\Process\CommandRunner;
 use Marko\DevAi\Process\CommandRunnerInterface;
+use Marko\DevAi\Process\ConfirmationPrompterInterface;
+use Marko\DevAi\Process\StdinPrompter;
 
 return [
     'bindings' => [
         CommandRunnerInterface::class => CommandRunner::class,
+        ConfirmationPrompterInterface::class => StdinPrompter::class,
     ],
     'singletons' => [],
 ];

--- a/packages/devai/src/Commands/InstallCommand.php
+++ b/packages/devai/src/Commands/InstallCommand.php
@@ -8,9 +8,13 @@ use Marko\Core\Attributes\Command;
 use Marko\Core\Command\CommandInterface;
 use Marko\Core\Command\Input;
 use Marko\Core\Command\Output;
+use Marko\DevAi\Exceptions\DevAiInstallException;
 use Marko\DevAi\Installation\AgentRegistry;
+use Marko\DevAi\Installation\DocsDriverResolver;
 use Marko\DevAi\Installation\InstallationContext;
 use Marko\DevAi\Installation\InstallationOrchestrator;
+use Marko\DevAi\Process\CommandRunnerInterface;
+use Marko\DevAi\Process\ConfirmationPrompterInterface;
 
 #[Command(name: 'devai:install', description: 'Install Marko AI development tooling for selected agents')]
 readonly class InstallCommand implements CommandInterface
@@ -18,8 +22,14 @@ readonly class InstallCommand implements CommandInterface
     public function __construct(
         private InstallationOrchestrator $orchestrator,
         private AgentRegistry $registry,
+        private DocsDriverResolver $docsDriverResolver,
+        private ConfirmationPrompterInterface $confirmationPrompter,
+        private CommandRunnerInterface $commandRunner,
     ) {}
 
+    /**
+     * @throws DevAiInstallException
+     */
     public function execute(
         Input $input,
         Output $output,
@@ -48,6 +58,8 @@ readonly class InstallCommand implements CommandInterface
             $context = $this->buildContextFromDetection($detected, $force, $gitignoreArg, $output);
         }
 
+        $this->maybeInstallDocsDriver($input, $output, $projectRoot);
+
         $result = $this->orchestrator->install($context, $projectRoot);
 
         if ($result['status'] === 'skipped') {
@@ -62,6 +74,54 @@ readonly class InstallCommand implements CommandInterface
         }
 
         return 0;
+    }
+
+    /**
+     * Offer to install the recommended docs search driver when none is present
+     * and the session is interactive. Does nothing (falls through gracefully) in
+     * non-interactive mode, CI, or when a driver is already installed.
+     */
+    private function maybeInstallDocsDriver(
+        Input $input,
+        Output $output,
+        string $projectRoot,
+    ): void {
+        if ($this->docsDriverResolver->installedDriver($projectRoot) !== null) {
+            return;
+        }
+
+        $pkg = $this->docsDriverResolver->recommendedUninstalled($projectRoot);
+
+        if ($pkg === null) {
+            return;
+        }
+
+        $noInteraction = $input->hasOption('no-interaction');
+
+        if ($noInteraction || !$this->confirmationPrompter->isInteractive()) {
+            return;
+        }
+
+        $question = "No docs search driver installed. Install $pkg to enable search_docs?";
+        $confirmed = $this->confirmationPrompter->confirm($question, default: true);
+
+        if (!$confirmed) {
+            return;
+        }
+
+        if (!$this->commandRunner->isOnPath('composer')) {
+            $output->writeLine("composer not found — run `composer require --dev $pkg` to enable search_docs.");
+
+            return;
+        }
+
+        $result = $this->commandRunner->run('composer', ['require', '--dev', $pkg]);
+
+        if ($result['exitCode'] !== 0) {
+            $stderr = trim($result['stderr']);
+            $hint = $stderr === '' ? '' : " ($stderr)";
+            $output->writeLine("composer require --dev $pkg failed$hint — run it manually to enable search_docs.");
+        }
     }
 
     /**

--- a/packages/devai/src/Installation/DocsDriverResolver.php
+++ b/packages/devai/src/Installation/DocsDriverResolver.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\DevAi\Installation;
+
+class DocsDriverResolver
+{
+    /**
+     * Returns the first known driver package whose vendor directory exists,
+     * or null if none is installed.
+     */
+    public function installedDriver(string $projectRoot): ?string
+    {
+        return array_find(
+            array_keys($this->knownDrivers($projectRoot)),
+            fn (string $package) => is_dir($projectRoot . '/vendor/' . $package),
+        );
+    }
+
+    /**
+     * Returns a list of known driver packages whose vendor directories are absent.
+     *
+     * @return list<string>
+     */
+    public function uninstalledDrivers(string $projectRoot): array
+    {
+        return array_values(array_filter(
+            array_keys($this->knownDrivers($projectRoot)),
+            fn (string $package) => !is_dir($projectRoot . '/vendor/' . $package),
+        ));
+    }
+
+    /**
+     * Returns the recommended uninstalled driver (description contains "recommended",
+     * case-insensitive), else the first uninstalled, else null.
+     */
+    public function recommendedUninstalled(string $projectRoot): ?string
+    {
+        $registry = $this->knownDrivers($projectRoot);
+        $uninstalled = $this->uninstalledDrivers($projectRoot);
+
+        $recommended = array_find(
+            $uninstalled,
+            fn (string $package) => str_contains(
+                strtolower($registry[$package] ?? ''),
+                'recommended',
+            ),
+        );
+
+        return $recommended ?? ($uninstalled[0] ?? null);
+    }
+
+    /**
+     * Derives the build command from the package name by stripping the vendor
+     * prefix and appending ":build" (e.g. "marko/docs-fts" → "docs-fts:build").
+     */
+    public function buildCommand(string $package): string
+    {
+        $name = substr($package, (int) strpos($package, '/') + 1);
+
+        return $name . ':build';
+    }
+
+    /**
+     * Reads the known-drivers registry from vendor/marko/docs/known-drivers.php.
+     * Returns an empty array if the file is absent.
+     *
+     * @return array<string, string>
+     */
+    private function knownDrivers(string $projectRoot): array
+    {
+        $file = $projectRoot . '/vendor/marko/docs/known-drivers.php';
+
+        if (!is_file($file)) {
+            return [];
+        }
+
+        /** @var array<string, string> $drivers */
+        $drivers = require $file;
+
+        return $drivers;
+    }
+}

--- a/packages/devai/src/Installation/InstallationOrchestrator.php
+++ b/packages/devai/src/Installation/InstallationOrchestrator.php
@@ -25,6 +25,7 @@ class InstallationOrchestrator
         private GuidelinesAggregator $guidelinesAggregator,
         private SkillsDistributor $skillsDistributor,
         private CommandRunnerInterface $runner,
+        private DocsDriverResolver $docsDriverResolver = new DocsDriverResolver(),
     ) {}
 
     /**
@@ -96,24 +97,26 @@ class InstallationOrchestrator
      * by the time devai:install returns.
      *
      * devai requires only the marko/docs contract — the search driver is a
-     * separate package. marko/docs-fts binds DocsSearchInterface; when it is
-     * installed we build its index so search_docs works immediately. When no
-     * driver is installed we skip gracefully and tell the user how to add one —
-     * a bare install is valid, just without docs search.
+     * separate package. When a known driver is installed we build its index so
+     * search_docs works immediately. When no driver is installed we skip
+     * gracefully and tell the user how to add one — a bare install is valid,
+     * just without docs search.
      */
     private function buildDocsIndex(
         string $projectRoot,
         string $markoBin,
     ): void {
-        if (is_dir($projectRoot . '/vendor/marko/docs-fts')) {
-            $command = 'docs-fts:build';
-            $driver = 'docs-fts';
-        } else {
+        $package = $this->docsDriverResolver->installedDriver($projectRoot);
+
+        if ($package === null) {
             $this->log[] = '[docs] no search driver installed — run `composer require marko/docs-fts`'
                 . ' then `marko docs-fts:build` to enable search_docs';
 
             return;
         }
+
+        $command = $this->docsDriverResolver->buildCommand($package);
+        $driver = substr($package, (int) strpos($package, '/') + 1);
 
         $result = $this->runner->run($markoBin, [$command]);
 

--- a/packages/devai/src/Process/ConfirmationPrompterInterface.php
+++ b/packages/devai/src/Process/ConfirmationPrompterInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\DevAi\Process;
+
+interface ConfirmationPrompterInterface
+{
+    public function isInteractive(): bool;
+
+    public function confirm(string $question, bool $default): bool;
+}

--- a/packages/devai/src/Process/StdinPrompter.php
+++ b/packages/devai/src/Process/StdinPrompter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\DevAi\Process;
+
+class StdinPrompter implements ConfirmationPrompterInterface
+{
+    /**
+     * @param resource $stream
+     */
+    public function __construct(
+        private $stream = STDIN,
+        private readonly bool $noInteraction = false,
+    ) {}
+
+    public function isInteractive(): bool
+    {
+        return !$this->noInteraction && stream_isatty($this->stream);
+    }
+
+    public function confirm(string $question, bool $default): bool
+    {
+        $line = fgets($this->stream);
+        $answer = strtolower(trim($line !== false ? $line : ''));
+
+        if ($answer === 'y' || $answer === 'yes') {
+            return true;
+        }
+
+        if ($answer === 'n' || $answer === 'no') {
+            return false;
+        }
+
+        return $default;
+    }
+}

--- a/packages/devai/tests/Unit/Commands/InstallCommandTest.php
+++ b/packages/devai/tests/Unit/Commands/InstallCommandTest.php
@@ -5,7 +5,172 @@ declare(strict_types=1);
 use Marko\Core\Attributes\Command;
 use Marko\Core\Command\CommandInterface;
 use Marko\Core\Command\Input;
+use Marko\Core\Command\Output;
 use Marko\DevAi\Commands\InstallCommand;
+use Marko\DevAi\Guidelines\GuidelinesAggregator;
+use Marko\DevAi\Installation\AgentRegistry;
+use Marko\DevAi\Installation\DocsDriverResolver;
+use Marko\DevAi\Installation\InstallationOrchestrator;
+use Marko\DevAi\Process\CommandRunnerInterface;
+use Marko\DevAi\Process\ConfirmationPrompterInterface;
+use Marko\DevAi\Rendering\AgentsMdRenderer;
+use Marko\DevAi\Skills\SkillsDistributor;
+
+// ---------------------------------------------------------------------------
+// Local test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * A scripted ConfirmationPrompterInterface double.
+ */
+function makeInstallCmdFakePrompter(bool $answer, bool $interactive = true): ConfirmationPrompterInterface
+{
+    return new readonly class ($answer, $interactive) implements ConfirmationPrompterInterface
+    {
+        public function __construct(
+            private bool $answer,
+            private bool $interactive,
+        ) {}
+
+        public function isInteractive(): bool
+        {
+            return $this->interactive;
+        }
+
+        public function confirm(string $question, bool $default): bool
+        {
+            return $this->answer;
+        }
+    };
+}
+
+/**
+ * A CommandRunner double that records every call and returns a configurable
+ * exit code for `composer require` commands.
+ */
+function makeInstallCmdRunner(bool $composerOnPath = true, int $requireExitCode = 0): CommandRunnerInterface
+{
+    return new class ($composerOnPath, $requireExitCode) implements CommandRunnerInterface
+    {
+        /** @var list<array{string, list<string>}> */
+        public array $calls = [];
+
+        public function __construct(
+            private readonly bool $composerOnPath,
+            private readonly int $requireExitCode,
+        ) {}
+
+        public function run(string $command, array $args = []): array
+        {
+            $this->calls[] = [$command, $args];
+
+            if ($command === 'composer' && ($args[0] ?? '') === 'require') {
+                return ['exitCode' => $this->requireExitCode, 'stdout' => '', 'stderr' => 'install failed'];
+            }
+
+            return ['exitCode' => 0, 'stdout' => '', 'stderr' => ''];
+        }
+
+        public function isOnPath(string $binary): bool
+        {
+            return $binary === 'composer' && $this->composerOnPath;
+        }
+    };
+}
+
+/**
+ * Create a minimal InstallationOrchestrator stub for command-level tests.
+ * Returns status=installed without running agent installs or real file system writes,
+ * but it does create .marko/devai.json (orchestrator requires this).
+ */
+function makeInstallCmdOrchestrator(string $tempRoot): InstallationOrchestrator
+{
+    $runner = devaiRunner();
+
+    return new InstallationOrchestrator(
+        registry: new AgentRegistry($runner),
+        agentsRenderer: new AgentsMdRenderer(),
+        guidelinesAggregator: new GuidelinesAggregator(devaiWalker(), '/dev/null'),
+        skillsDistributor: new SkillsDistributor(devaiWalker(), '/dev/null'),
+        runner: $runner,
+        docsDriverResolver: new DocsDriverResolver(),
+    );
+}
+
+/**
+ * Build an InstallCommand with all dependencies wired for testing.
+ */
+function makeInstallCmd(
+    InstallationOrchestrator $orchestrator,
+    DocsDriverResolver $resolver,
+    ConfirmationPrompterInterface $prompter,
+    CommandRunnerInterface $runner,
+): InstallCommand {
+    return new InstallCommand(
+        orchestrator: $orchestrator,
+        registry: new AgentRegistry(devaiRunner()),
+        docsDriverResolver: $resolver,
+        confirmationPrompter: $prompter,
+        commandRunner: $runner,
+    );
+}
+
+/**
+ * Write a stub known-drivers.php under {tempRoot}/vendor/marko/docs/.
+ *
+ * @param array<string, string> $drivers
+ */
+function writeInstallCmdKnownDrivers(string $tempRoot, array $drivers): void
+{
+    $docsDir = $tempRoot . '/vendor/marko/docs';
+    mkdir($docsDir, 0755, true);
+    $export = var_export($drivers, true);
+    file_put_contents($docsDir . '/known-drivers.php', "<?php\nreturn $export;\n");
+}
+
+/** Create a fake vendor directory for the given package. */
+function makeInstallCmdVendorDir(string $tempRoot, string $package): void
+{
+    mkdir($tempRoot . '/vendor/' . $package, 0755, true);
+}
+
+/** Create an in-memory output stream and return the Output object. */
+function makeInstallCmdOutput(): array
+{
+    $stream = fopen('php://memory', 'r+');
+
+    return ['stream' => $stream, 'output' => new Output($stream)];
+}
+
+/** Read all output written to the memory stream. */
+function readInstallCmdOutput(mixed $stream): string
+{
+    rewind($stream);
+
+    return (string) stream_get_contents($stream);
+}
+
+// ---------------------------------------------------------------------------
+// State shared across new tests
+// ---------------------------------------------------------------------------
+
+$originalCwd = null;
+
+beforeEach(function () use (&$originalCwd): void {
+    $this->tempRoot = devaiTempDir();
+    $originalCwd = getcwd();
+});
+
+afterEach(function () use (&$originalCwd): void {
+    devaiRemoveDir($this->tempRoot);
+    if ($originalCwd !== false) {
+        chdir($originalCwd);
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Original tests (kept green)
+// ---------------------------------------------------------------------------
 
 it('supports non-interactive mode via the --agents flag', function (): void {
     $input = new Input(['marko', 'devai:install', '--agents=claude-code']);
@@ -21,4 +186,167 @@ it('is registered via Command attribute with name devai:install', function (): v
 
     expect($attributes)->toHaveCount(1)
         ->and($attributes[0]->newInstance()->name)->toBe('devai:install');
+});
+
+// ---------------------------------------------------------------------------
+// New tests: docs driver prompt flow
+// ---------------------------------------------------------------------------
+
+it('offers to install the recommended driver and runs composer require on yes', function (): void {
+    writeInstallCmdKnownDrivers($this->tempRoot, [
+        'marko/docs-fts' => 'Full-text search driver (recommended)',
+    ]);
+    chdir($this->tempRoot);
+
+    $runner = makeInstallCmdRunner(composerOnPath: true);
+    $cmd = makeInstallCmd(
+        orchestrator: makeInstallCmdOrchestrator($this->tempRoot),
+        resolver: new DocsDriverResolver(),
+        prompter: makeInstallCmdFakePrompter(answer: true),
+        runner: $runner,
+    );
+
+    ['stream' => $stream, 'output' => $output] = makeInstallCmdOutput();
+    $cmd->execute(new Input(['marko', 'devai:install']), $output);
+
+    expect($runner->calls)->toContain(['composer', ['require', '--dev', 'marko/docs-fts']]);
+});
+
+it('does not install anything when the user answers no', function (): void {
+    writeInstallCmdKnownDrivers($this->tempRoot, [
+        'marko/docs-fts' => 'Full-text search driver (recommended)',
+    ]);
+    chdir($this->tempRoot);
+
+    $runner = makeInstallCmdRunner(composerOnPath: true);
+    $cmd = makeInstallCmd(
+        orchestrator: makeInstallCmdOrchestrator($this->tempRoot),
+        resolver: new DocsDriverResolver(),
+        prompter: makeInstallCmdFakePrompter(answer: false),
+        runner: $runner,
+    );
+
+    $cmd->execute(new Input(['marko', 'devai:install']), new Output(fopen('php://memory', 'r+')));
+
+    $composerCalls = array_filter($runner->calls, fn ($c) => $c[0] === 'composer');
+    expect($composerCalls)->toBeEmpty();
+});
+
+it('does not prompt or install when run with --no-interaction', function (): void {
+    writeInstallCmdKnownDrivers($this->tempRoot, [
+        'marko/docs-fts' => 'Full-text search driver (recommended)',
+    ]);
+    chdir($this->tempRoot);
+
+    $runner = makeInstallCmdRunner(composerOnPath: true);
+    $cmd = makeInstallCmd(
+        orchestrator: makeInstallCmdOrchestrator($this->tempRoot),
+        resolver: new DocsDriverResolver(),
+        prompter: makeInstallCmdFakePrompter(answer: true),
+        runner: $runner,
+    );
+
+    $cmd->execute(new Input(['marko', 'devai:install', '--no-interaction']), new Output(fopen('php://memory', 'r+')));
+
+    $composerCalls = array_filter($runner->calls, fn ($c) => $c[0] === 'composer');
+    expect($composerCalls)->toBeEmpty();
+});
+
+it('does not prompt or install when the session is not interactive (no TTY)', function (): void {
+    writeInstallCmdKnownDrivers($this->tempRoot, [
+        'marko/docs-fts' => 'Full-text search driver (recommended)',
+    ]);
+    chdir($this->tempRoot);
+
+    $runner = makeInstallCmdRunner(composerOnPath: true);
+    $cmd = makeInstallCmd(
+        orchestrator: makeInstallCmdOrchestrator($this->tempRoot),
+        resolver: new DocsDriverResolver(),
+        prompter: makeInstallCmdFakePrompter(answer: true, interactive: false),
+        runner: $runner,
+    );
+
+    $cmd->execute(new Input(['marko', 'devai:install']), new Output(fopen('php://memory', 'r+')));
+
+    $composerCalls = array_filter($runner->calls, fn ($c) => $c[0] === 'composer');
+    expect($composerCalls)->toBeEmpty();
+});
+
+it('does not prompt when a docs driver is already installed', function (): void {
+    writeInstallCmdKnownDrivers($this->tempRoot, [
+        'marko/docs-fts' => 'Full-text search driver (recommended)',
+    ]);
+    makeInstallCmdVendorDir($this->tempRoot, 'marko/docs-fts');
+    chdir($this->tempRoot);
+
+    $runner = makeInstallCmdRunner(composerOnPath: true);
+    $cmd = makeInstallCmd(
+        orchestrator: makeInstallCmdOrchestrator($this->tempRoot),
+        resolver: new DocsDriverResolver(),
+        prompter: makeInstallCmdFakePrompter(answer: true),
+        runner: $runner,
+    );
+
+    $cmd->execute(new Input(['marko', 'devai:install']), new Output(fopen('php://memory', 'r+')));
+
+    $composerCalls = array_filter($runner->calls, fn ($c) => $c[0] === 'composer');
+    expect($composerCalls)->toBeEmpty();
+});
+
+it('writes a helpful message when composer is not on PATH', function (): void {
+    writeInstallCmdKnownDrivers($this->tempRoot, [
+        'marko/docs-fts' => 'Full-text search driver (recommended)',
+    ]);
+    chdir($this->tempRoot);
+
+    $runner = makeInstallCmdRunner(composerOnPath: false);
+    $cmd = makeInstallCmd(
+        orchestrator: makeInstallCmdOrchestrator($this->tempRoot),
+        resolver: new DocsDriverResolver(),
+        prompter: makeInstallCmdFakePrompter(answer: true),
+        runner: $runner,
+    );
+
+    ['stream' => $stream, 'output' => $output] = makeInstallCmdOutput();
+    $cmd->execute(new Input(['marko', 'devai:install']), $output);
+
+    $text = readInstallCmdOutput($stream);
+    expect($text)->toContain('composer not found')
+        ->and($text)->toContain('composer require --dev marko/docs-fts');
+});
+
+it('writes a helpful message and does not throw when composer require exits non-zero', function (): void {
+    writeInstallCmdKnownDrivers($this->tempRoot, [
+        'marko/docs-fts' => 'Full-text search driver (recommended)',
+    ]);
+    chdir($this->tempRoot);
+
+    $runner = makeInstallCmdRunner(composerOnPath: true, requireExitCode: 1);
+    $cmd = makeInstallCmd(
+        orchestrator: makeInstallCmdOrchestrator($this->tempRoot),
+        resolver: new DocsDriverResolver(),
+        prompter: makeInstallCmdFakePrompter(answer: true),
+        runner: $runner,
+    );
+
+    ['stream' => $stream, 'output' => $output] = makeInstallCmdOutput();
+    $exitCode = $cmd->execute(new Input(['marko', 'devai:install']), $output);
+
+    $text = readInstallCmdOutput($stream);
+    expect($exitCode)->toBe(0)
+        ->and($text)->toContain('marko/docs-fts');
+});
+
+it('keeps devai dependent on the marko/docs contract only (no driver in require)', function (): void {
+    $composerJson = json_decode(
+        (string) file_get_contents(dirname(__DIR__, 3) . '/composer.json'),
+        true,
+    );
+
+    $require = $composerJson['require'] ?? [];
+
+    $driverKeys = array_filter(array_keys($require), fn ($k) => str_starts_with($k, 'marko/docs-'));
+
+    expect($require)->toHaveKey('marko/docs')
+        ->and($driverKeys)->toBeEmpty();
 });

--- a/packages/devai/tests/Unit/Installation/DocsDriverResolverTest.php
+++ b/packages/devai/tests/Unit/Installation/DocsDriverResolverTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\DevAi\Installation\DocsDriverResolver;
+
+beforeEach(function (): void {
+    $this->tempRoot = devaiTempDir();
+});
+
+afterEach(function (): void {
+    devaiRemoveDir($this->tempRoot);
+});
+
+/**
+ * Write a stub known-drivers.php under {tempRoot}/vendor/marko/docs/.
+ *
+ * @param array<string, string> $drivers
+ */
+function writeKnownDrivers(string $tempRoot, array $drivers): void
+{
+    $docsDir = $tempRoot . '/vendor/marko/docs';
+    mkdir($docsDir, 0755, true);
+    $export = var_export($drivers, true);
+    file_put_contents($docsDir . '/known-drivers.php', "<?php\nreturn $export;\n");
+}
+
+/** Create a fake vendor directory for the given package (e.g. 'marko/docs-fts'). */
+function makeVendorDir(string $tempRoot, string $package): void
+{
+    mkdir($tempRoot . '/vendor/' . $package, 0755, true);
+}
+
+describe('DocsDriverResolver', function (): void {
+    it('returns the installed driver when its vendor directory exists', function (): void {
+        writeKnownDrivers($this->tempRoot, [
+            'marko/docs-fts' => 'Full-text documentation search driver (recommended; SQLite FTS5, zero infrastructure)',
+        ]);
+        makeVendorDir($this->tempRoot, 'marko/docs-fts');
+
+        $resolver = new DocsDriverResolver();
+
+        expect($resolver->installedDriver($this->tempRoot))->toBe('marko/docs-fts');
+    });
+
+    it('returns null for installed driver when no known driver is present', function (): void {
+        writeKnownDrivers($this->tempRoot, [
+            'marko/docs-fts' => 'Full-text documentation search driver (recommended; SQLite FTS5, zero infrastructure)',
+        ]);
+        // No vendor dir created for any known driver
+
+        $resolver = new DocsDriverResolver();
+
+        expect($resolver->installedDriver($this->tempRoot))->toBeNull();
+    });
+
+    it('lists known drivers that are not installed', function (): void {
+        writeKnownDrivers($this->tempRoot, [
+            'marko/docs-fts' => 'Full-text documentation search driver (recommended; SQLite FTS5, zero infrastructure)',
+            'marko/docs-vec' => 'Vector search driver',
+        ]);
+        makeVendorDir($this->tempRoot, 'marko/docs-vec');
+
+        $resolver = new DocsDriverResolver();
+
+        expect($resolver->uninstalledDrivers($this->tempRoot))->toBe(['marko/docs-fts']);
+    });
+
+    it('picks the recommended uninstalled driver by the description convention', function (): void {
+        writeKnownDrivers($this->tempRoot, [
+            'marko/docs-vec' => 'Vector search driver',
+            'marko/docs-fts' => 'Full-text documentation search driver (recommended; SQLite FTS5, zero infrastructure)',
+        ]);
+        // Neither installed — recommended one should be picked
+
+        $resolver = new DocsDriverResolver();
+
+        expect($resolver->recommendedUninstalled($this->tempRoot))->toBe('marko/docs-fts');
+    });
+
+    it('derives the build command from the package name', function (): void {
+        $resolver = new DocsDriverResolver();
+
+        expect($resolver->buildCommand('marko/docs-fts'))->toBe('docs-fts:build');
+    });
+
+    it('treats the known set as empty when the contract registry file is absent', function (): void {
+        // No vendor/marko/docs/known-drivers.php written
+
+        $resolver = new DocsDriverResolver();
+
+        expect($resolver->installedDriver($this->tempRoot))->toBeNull()
+            ->and($resolver->uninstalledDrivers($this->tempRoot))->toBeEmpty()
+            ->and($resolver->recommendedUninstalled($this->tempRoot))->toBeNull();
+    });
+});

--- a/packages/devai/tests/Unit/Installation/InstallationOrchestratorTest.php
+++ b/packages/devai/tests/Unit/Installation/InstallationOrchestratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Marko\DevAi\Contract\AgentInterface;
 use Marko\DevAi\Guidelines\GuidelinesAggregator;
 use Marko\DevAi\Installation\AgentRegistry;
+use Marko\DevAi\Installation\DocsDriverResolver;
 use Marko\DevAi\Installation\InstallationContext;
 use Marko\DevAi\Installation\InstallationOrchestrator;
 use Marko\DevAi\Process\CommandRunnerInterface;
@@ -25,7 +26,7 @@ function makeInstallSpyAgent(bool $installed = false): AgentInterface
 
         public int $installCount = 0;
 
-        public function __construct(private bool $installed) {}
+        public function __construct(private readonly bool $installed) {}
 
         public function name(): string
         {
@@ -61,7 +62,7 @@ function makeInstallRegistry(array $agents): AgentRegistry
         /** @param array<string, AgentInterface> $agentMap */
         public function __construct(
             CommandRunnerInterface $runner,
-            private array $agentMap,
+            private readonly array $agentMap,
         ) {
             parent::__construct($runner);
         }
@@ -110,6 +111,7 @@ function makeInstallOrchestrator(
         guidelinesAggregator: new GuidelinesAggregator($walker, $devaiRoot),
         skillsDistributor: new SkillsDistributor($walker, $devaiRoot),
         runner: $runner ?? makeRecordingRunner(),
+        docsDriverResolver: new DocsDriverResolver(),
     );
 }
 
@@ -284,6 +286,11 @@ it('builds the MCP registration using the absolute path to vendor/bin/marko', fu
 
 it('runs docs-fts:build during install when marko/docs-fts is in vendor', function (): void {
     mkdir($this->tempRoot . '/vendor/marko/docs-fts', 0755, true);
+    mkdir($this->tempRoot . '/vendor/marko/docs', 0755, true);
+    file_put_contents(
+        $this->tempRoot . '/vendor/marko/docs/known-drivers.php',
+        '<?php return [\'marko/docs-fts\' => \'FTS driver (recommended; fast full-text search)\'];',
+    );
 
     $runner = makeRecordingRunner();
     $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
@@ -307,14 +314,18 @@ it('skips the docs index build when no driver is installed', function (): void {
 
     $buildCommands = array_map(fn ($c) => $c[1][0] ?? null, $runner->calls);
 
-    expect($buildCommands)->not->toContain('docs-fts:build');
-
     // A bare install is valid — but it should tell the user how to enable search.
-    expect(implode("\n", $result['log'] ?? []))->toContain('no search driver installed');
+    expect($buildCommands)->not->toContain('docs-fts:build')
+        ->and(implode("\n", $result['log'] ?? []))->toContain('no search driver installed');
 });
 
 it('records a helpful log line when the docs index build fails', function (): void {
     mkdir($this->tempRoot . '/vendor/marko/docs-fts', 0755, true);
+    mkdir($this->tempRoot . '/vendor/marko/docs', 0755, true);
+    file_put_contents(
+        $this->tempRoot . '/vendor/marko/docs/known-drivers.php',
+        '<?php return [\'marko/docs-fts\' => \'FTS driver (recommended; fast full-text search)\'];',
+    );
 
     $runner = new class () implements CommandRunnerInterface
     {
@@ -350,7 +361,7 @@ it('surfaces a loud notice in the install log when a guideline file has its mark
     // Use a spy agent that writes to AGENTS.md via the real GuidelinesWriter path
     // We simulate the stripped-markers scenario by having a pre-existing file without markers
     // and an agent that calls GuidelinesWriter::write() on it.
-    $writingAgent = new class ($this->tempRoot) implements AgentInterface
+    $writingAgent = new readonly class ($this->tempRoot) implements AgentInterface
     {
         public function __construct(private string $root) {}
 
@@ -372,8 +383,7 @@ it('surfaces a loud notice in the install log when a guideline file has its mark
         public function install(
             InstallationContext $ctx,
             string $projectRoot,
-        ): void
-        {
+        ): void {
             GuidelinesWriter::write($projectRoot . '/AGENTS.md', 'new content');
         }
     };
@@ -395,4 +405,86 @@ it('detects installed agents and filters out missing ones', function (): void {
     $detected = array_keys(array_filter($registry->all($this->tempRoot), fn ($a) => $a->isInstalled()));
 
     expect($detected)->toBe(['installed-agent']);
+});
+
+it('builds the index for the installed docs driver resolved from the registry', function (): void {
+    mkdir($this->tempRoot . '/vendor/marko/docs-vec', 0755, true);
+    mkdir($this->tempRoot . '/vendor/marko/docs', 0755, true);
+    file_put_contents(
+        $this->tempRoot . '/vendor/marko/docs/known-drivers.php',
+        '<?php return [\'marko/docs-vec\' => \'Vector driver (recommended; semantic search)\'];',
+    );
+
+    $runner = makeRecordingRunner();
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $buildCall = array_find(
+        $runner->calls,
+        fn ($call) => in_array('docs-vec:build', $call[1], true),
+    );
+
+    expect($buildCall)->not->toBeNull()
+        ->and($buildCall[0])->toBe($this->tempRoot . '/vendor/bin/marko');
+});
+
+it('logs the install hint when no docs driver is installed', function (): void {
+    $runner = makeRecordingRunner();
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $result = $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    expect(implode("\n", $result['log'] ?? []))->toContain('no search driver installed');
+});
+
+it('records a helpful log line when the docs index build fails for the resolved driver', function (): void {
+    mkdir($this->tempRoot . '/vendor/marko/docs-vec', 0755, true);
+    mkdir($this->tempRoot . '/vendor/marko/docs', 0755, true);
+    file_put_contents(
+        $this->tempRoot . '/vendor/marko/docs/known-drivers.php',
+        '<?php return [\'marko/docs-vec\' => \'Vector driver (recommended; semantic search)\'];',
+    );
+
+    $runner = new class () implements CommandRunnerInterface
+    {
+        public function run(
+            string $command,
+            array $args = [],
+        ): array {
+            return ['exitCode' => 1, 'stdout' => '', 'stderr' => 'disk full'];
+        }
+
+        public function isOnPath(string $binary): bool
+        {
+            return false;
+        }
+    };
+
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $result = $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $log = implode("\n", $result['log'] ?? []);
+    expect($log)->toContain('docs-vec')
+        ->and($log)->toContain('build failed')
+        ->and($log)->toContain('disk full');
+});
+
+it('does not hardcode the docs-fts package when resolving the driver to build', function (): void {
+    mkdir($this->tempRoot . '/vendor/marko/docs-vec', 0755, true);
+    mkdir($this->tempRoot . '/vendor/marko/docs', 0755, true);
+    file_put_contents(
+        $this->tempRoot . '/vendor/marko/docs/known-drivers.php',
+        '<?php return [\'marko/docs-vec\' => \'Vector driver (recommended; semantic search)\'];',
+    );
+
+    $runner = makeRecordingRunner();
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $allArgs = array_merge(...array_column($runner->calls, 1));
+    expect($allArgs)->not->toContain('docs-fts:build')
+        ->and($allArgs)->toContain('docs-vec:build');
 });

--- a/packages/devai/tests/Unit/Process/ConfirmationPrompterTest.php
+++ b/packages/devai/tests/Unit/Process/ConfirmationPrompterTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use Marko\DevAi\Process\ConfirmationPrompterInterface;
+use Marko\DevAi\Process\StdinPrompter;
+
+function makeMemoryStream(string $content): mixed
+{
+    $stream = fopen('php://memory', 'r+');
+    fwrite($stream, $content);
+    rewind($stream);
+
+    return $stream;
+}
+
+function makeFakePrompter(bool $answer, bool $interactive = true): ConfirmationPrompterInterface
+{
+    return new readonly class ($answer, $interactive) implements ConfirmationPrompterInterface
+    {
+        public function __construct(
+            private bool $answer,
+            private bool $interactive,
+        ) {}
+
+        public function isInteractive(): bool
+        {
+            return $this->interactive;
+        }
+
+        public function confirm(string $question, bool $default): bool
+        {
+            return $this->answer;
+        }
+    };
+}
+
+describe('StdinPrompter', function (): void {
+    it('returns true when the user answers yes', function (): void {
+        $stream = makeMemoryStream("yes\n");
+        $prompter = new StdinPrompter($stream);
+
+        expect($prompter->confirm('Continue?', false))->toBeTrue();
+    });
+
+    it('returns false when the user answers no', function (): void {
+        $stream = makeMemoryStream("no\n");
+        $prompter = new StdinPrompter($stream);
+
+        expect($prompter->confirm('Continue?', true))->toBeFalse();
+    });
+
+    it('returns the default when the answer is empty', function (): void {
+        $streamTrue = makeMemoryStream("\n");
+        $prompterTrue = new StdinPrompter($streamTrue);
+
+        $streamFalse = makeMemoryStream("\n");
+        $prompterFalse = new StdinPrompter($streamFalse);
+
+        expect($prompterTrue->confirm('Continue?', true))->toBeTrue()
+            ->and($prompterFalse->confirm('Continue?', false))->toBeFalse();
+    });
+
+    it('parses answers case-insensitively and ignores surrounding whitespace', function (): void {
+        $streamY = makeMemoryStream("  Y  \n");
+        $prompterY = new StdinPrompter($streamY);
+
+        $streamYes = makeMemoryStream("  YES  \n");
+        $prompterYes = new StdinPrompter($streamYes);
+
+        $streamN = makeMemoryStream("  N  \n");
+        $prompterN = new StdinPrompter($streamN);
+
+        expect($prompterY->confirm('Continue?', false))->toBeTrue()
+            ->and($prompterYes->confirm('Continue?', false))->toBeTrue()
+            ->and($prompterN->confirm('Continue?', true))->toBeFalse();
+    });
+
+    it('reports not interactive when constructed in no-interaction mode', function (): void {
+        $stream = makeMemoryStream('');
+        $prompter = new StdinPrompter($stream, noInteraction: true);
+
+        expect($prompter->isInteractive())->toBeFalse();
+    });
+});
+
+describe('FakePrompter', function (): void {
+    it('the fake prompter returns its scripted answer and configured interactivity', function (): void {
+        $fakeTrue = makeFakePrompter(answer: true, interactive: true);
+        $fakeFalse = makeFakePrompter(answer: false, interactive: false);
+
+        expect($fakeTrue->confirm('Continue?', false))->toBeTrue()
+            ->and($fakeTrue->isInteractive())->toBeTrue()
+            ->and($fakeFalse->confirm('Continue?', true))->toBeFalse()
+            ->and($fakeFalse->isInteractive())->toBeFalse();
+    });
+});

--- a/packages/docs-markdown/docs/ai-assisted-development/mcp.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/mcp.md
@@ -46,14 +46,22 @@ If `marko/database` is not installed, this tool does not appear in the MCP tool 
 
 Registered when a `DocsSearchInterface` binding is present in the container. That binding comes from a docs search driver — `marko/docs-fts` (SQLite FTS5 full-text search), or any other package that binds `DocsSearchInterface`.
 
-Install and build it so `search_docs` is wired up:
+When you run `marko devai:install` in an interactive terminal and no docs driver is installed, it prompts:
+
+```
+No docs search driver installed. Install marko/docs-fts to enable search_docs? [Y/n]
+```
+
+Answering yes runs `composer require --dev marko/docs-fts` and then builds the index automatically. In non-interactive mode, CI, or when `--no-interaction` is passed, the prompt is skipped and a hint is printed instead — the install never blocks.
+
+To install and build manually:
 
 ```bash
 composer require --dev marko/docs-fts
 marko docs-fts:build
 ```
 
-`marko devai:install` builds the index for you when a driver is installed. If no docs driver is installed, `search_docs` does not appear in the MCP tool list — the install still completes and logs how to add one.
+`marko devai:install` builds the index for you when a driver is already installed. If no docs driver is installed and the prompt is declined (or skipped), `search_docs` does not appear in the MCP tool list — the install still completes and logs how to add one.
 
 ## Fetching the most recent error
 

--- a/packages/docs-markdown/docs/packages/devai.md
+++ b/packages/docs-markdown/docs/packages/devai.md
@@ -13,7 +13,13 @@ It is the one point at which "AI tooling is available in this project" becomes t
 composer require --dev marko/devai
 ```
 
-To enable docs search (`search_docs`), also install a docs driver — `marko/docs-fts` is the recommended default:
+To enable docs search (`search_docs`), a docs driver is required — `marko/docs-fts` is the recommended default. When you run `devai:install` in an interactive terminal and no driver is found, it offers to install one for you:
+
+```
+No docs search driver installed. Install marko/docs-fts to enable search_docs? [Y/n]
+```
+
+Answering yes runs `composer require --dev marko/docs-fts` and builds the index. In non-interactive mode, CI, or when `--no-interaction` is passed, the prompt is skipped. To install manually:
 
 ```bash
 composer require --dev marko/docs-fts


### PR DESCRIPTION
## Why

Follows the docs-vec removal (#132): `marko/docs-fts` is the only first-party docs driver, but `devai` must keep depending on the `marko/docs` **contract** only (third parties can implement `DocsSearchInterface`). Previously, when no driver was installed, `marko devai:install` just printed a dead-end "run `composer require marko/docs-fts`" hint. This replaces that with an opt-in prompt — without hardcoding the driver as a dependency.

## What

- When `devai:install` runs **interactively** and no `DocsSearchInterface` driver is installed, it prompts: *"No docs search driver installed. Install marko/docs-fts to enable search_docs? [Y/n]"*. On **yes** → `composer require --dev marko/docs-fts` (guarded by `isOnPath('composer')`) → the index builds.
- **No**, `--no-interaction`, or a **non-TTY/CI** session → no prompt, no install; falls back to the printed hint and never blocks CI.
- An **already-installed** driver is detected and built with no prompt.
- `devai` still requires only `marko/docs` — the driver is installed at runtime, never added to devai's `composer.json` (asserted by a modularity-guard test).

## How

| Piece | Notes |
|---|---|
| `ConfirmationPrompterInterface` + `StdinPrompter` | Injectable stream resource + `--no-interaction` flag → parsing is unit-tested against `php://memory`; only the `stream_isatty()` line is untested. `FakePrompter` test double. |
| `DocsDriverResolver` | Reads the shared `marko/docs` `known-drivers.php` **as-is** (no shape change — it's a framework-wide convention with a shared validator + parity tests across ~20 packages). |
| `InstallationOrchestrator` | Builds whichever resolved driver is installed; no hardcoded `docs-fts`. |
| `InstallCommand` | Wires the opt-in prompt + guarded composer shell-out before delegating to the orchestrator. |

Built via the plan workflow (`.claude/plans/devai-docs-driver-prompt/`), TDD per task, reviewed by the devil's-advocate + standards-enforcer + doc-updater hooks. Docs updated: `ai-assisted-development/mcp.md` and `packages/devai.md`.

## Verification

`composer test` → **6798 passed, 0 failed** (+24 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)