### PR TITLE
feat: add marko/testing as a skeleton dev dependency

### DIFF
--- a/packages/skeleton/composer.json
+++ b/packages/skeleton/composer.json
@@ -10,6 +10,7 @@
     },
     "require-dev": {
         "marko/devserver": "*",
+        "marko/testing": "*",
         "pestphp/pest": "^4.0"
     },
     "suggest": {

--- a/packages/skeleton/src/Prompts/PostCreateHook.php
+++ b/packages/skeleton/src/Prompts/PostCreateHook.php
@@ -6,9 +6,18 @@ namespace Marko\Skeleton\Prompts;
 
 class PostCreateHook
 {
+    /** @var resource */
+    private $errorStream;
+
+    /**
+     * @param resource|null $errorStream stream for error output (defaults to STDERR)
+     */
     public function __construct(
         private DevAiPrompt $prompt,
-    ) {}
+        $errorStream = null,
+    ) {
+        $this->errorStream = $errorStream ?? STDERR;
+    }
 
     /**
      * Run the post-create hook for $projectRoot.
@@ -19,8 +28,7 @@ class PostCreateHook
     public function run(
         string $projectRoot,
         bool $interactive = true,
-    ): int
-    {
+    ): int {
         if ($this->prompt->alreadyAnswered($projectRoot)) {
             return 0;
         }
@@ -37,8 +45,11 @@ class PostCreateHook
 
         $installResult = $this->prompt->install($projectRoot);
         if ($installResult !== 0) {
-            fwrite(STDERR, "Failed to install marko/devai (exit code: $installResult)\n");
-            fwrite(STDERR, "marko/devai package was added to composer; you may try `marko devai:install` manually\n");
+            fwrite($this->errorStream, "Failed to install marko/devai (exit code: $installResult)\n");
+            fwrite(
+                $this->errorStream,
+                "marko/devai package was added to composer; you may try `marko devai:install` manually\n"
+            );
 
             return $installResult;
         }
@@ -46,8 +57,8 @@ class PostCreateHook
         $exitCode = $this->runDevaiInstall($projectRoot, $interactive);
 
         if ($exitCode !== 0) {
-            fwrite(STDERR, "marko devai:install failed (exit code: $exitCode)\n");
-            fwrite(STDERR, "marko/devai is installed. You can re-run `marko devai:install` manually.\n");
+            fwrite($this->errorStream, "marko devai:install failed (exit code: $exitCode)\n");
+            fwrite($this->errorStream, "marko/devai is installed. You can re-run `marko devai:install` manually.\n");
 
             return $exitCode;
         }
@@ -62,8 +73,7 @@ class PostCreateHook
     protected function runDevaiInstall(
         string $projectRoot,
         bool $interactive,
-    ): int
-    {
+    ): int {
         $cmd = $interactive
             ? sprintf('cd %s && php marko devai:install 2>&1', escapeshellarg($projectRoot))
             : sprintf('cd %s && php marko devai:install --agents=claude-code 2>&1', escapeshellarg($projectRoot));

--- a/packages/skeleton/tests/PackageStructureTest.php
+++ b/packages/skeleton/tests/PackageStructureTest.php
@@ -31,6 +31,22 @@ it('requires marko/devserver as a dev dependency', function (): void {
     expect($composer['require-dev'])->toHaveKey('marko/devserver');
 });
 
+it('requires marko/testing as a dev dependency', function (): void {
+    // The testing package (fakes + Pest expectations) is dev-only tooling and
+    // must live in require-dev of the skeleton (the generated app's root), not
+    // in require — a dependency's require-dev is never installed transitively,
+    // so it cannot be delivered via marko/framework. See require check below.
+    $composer = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
+
+    expect($composer['require-dev'])->toHaveKey('marko/testing');
+});
+
+it('does not add marko/testing to require (dev-only, must not ship to production)', function (): void {
+    $composer = json_decode(file_get_contents(__DIR__ . '/../composer.json'), true);
+
+    expect($composer['require'])->not->toHaveKey('marko/testing');
+});
+
 it('has public/index.php using Application::boot() API', function (): void {
     $indexPath = __DIR__ . '/../public/index.php';
 

--- a/packages/skeleton/tests/Unit/Prompts/PostCreateHookTest.php
+++ b/packages/skeleton/tests/Unit/Prompts/PostCreateHookTest.php
@@ -41,7 +41,16 @@ it('runs marko devai:install after devai is added', function (): void {
         }
     };
 
-    $hook = new PostCreateHook($stubPrompt);
+    $hook = new class ($stubPrompt) extends PostCreateHook
+    {
+        protected function runDevaiInstall(
+            string $projectRoot,
+            bool $interactive,
+        ): int
+        {
+            return 0;
+        }
+    };
     ob_start();
     $hook->run($this->tempRoot, interactive: false);
     ob_end_clean();
@@ -55,27 +64,36 @@ it(
         $stubPrompt = new class () extends DevAiPrompt
         {
             public ?bool $askCalled = null;
-    
+
             public function ask(mixed $input = null): bool
             {
                 $this->askCalled = true;
-    
+
                 return true;
             }
-    
+
             public function install(string $projectRoot): int
             {
                 return 0;
             }
         };
-    
-        $hook = new PostCreateHook($stubPrompt);
+
+        $hook = new class ($stubPrompt) extends PostCreateHook
+        {
+            protected function runDevaiInstall(
+                string $projectRoot,
+                bool $interactive,
+            ): int
+            {
+                return 0;
+            }
+        };
         ob_start();
         $hook->run($this->tempRoot, interactive: false);
         ob_end_clean();
-    
+
         expect($stubPrompt->askCalled)->toBeNull();
-    }
+    },
 );
 
 it('aborts cleanly if devai:install fails without rolling back composer require', function (): void {
@@ -92,12 +110,18 @@ it('aborts cleanly if devai:install fails without rolling back composer require'
         }
     };
 
-    $hook = new PostCreateHook($stubPrompt);
+    $errorStream = fopen('php://memory', 'w+');
+    $hook = new PostCreateHook($stubPrompt, $errorStream);
     ob_start();
     $code = $hook->run($this->tempRoot, interactive: false);
     ob_end_clean();
 
-    expect($code)->not->toBe(0);
+    rewind($errorStream);
+    $errors = stream_get_contents($errorStream);
+    fclose($errorStream);
+
+    expect($code)->not->toBe(0)
+        ->and($errors)->toContain('Failed to install marko/devai (exit code: 1)');
 });
 
 it('prints a clear next-step message if the user skipped devai', function (): void {


### PR DESCRIPTION
## What

Adds `marko/testing` to the skeleton's `require-dev`, alongside `pestphp/pest` and `marko/devserver`:

```json
"require-dev": {
    "marko/devserver": "*",
    "marko/testing": "*",
    "pestphp/pest": "^4.0"
}
```

Generated apps now get the framework's fakes (`FakeMailer`, `FakeQueue`, `FakeEventDispatcher`, …) and the auto-loaded Pest expectations (`toHaveDispatched`, `toHaveSent`, …) out of the box, completing the testing story that already ships Pest.

## Why require-dev in the skeleton, not marko/framework

- **A dependency's `require-dev` is never installed transitively** — Composer only honors the *root* package's dev deps. The skeleton is the generated app's root; `marko/framework` is not. Putting it in framework's `require-dev` would be a dead entry.
- **It must not ship to production** — the only way to deliver it via framework would be framework's `require`, which is installed in prod for every app. Dev-only fakes don't belong there.
- **Same shape as `pest`/`devserver`** — universal, dev-only, no driver variants to choose between. That's the exact profile already in the skeleton's `require-dev`.

## Tests

Two new assertions in `PackageStructureTest` reaffirm the placement:

- `it('requires marko/testing as a dev dependency')` — present in `require-dev`
- `it('does not add marko/testing to require ...')` — absent from `require` (must not ship to prod)

## Incidental test-suite cleanup

While verifying, the skeleton suite was leaking `fwrite(STDERR, ...)` failure-path messages to the terminal (output buffering only captures STDOUT). Fixed by:

- Making `PostCreateHook`'s error stream injectable (constructor `$errorStream`, defaults to `STDERR`).
- The failure-path test now captures STDERR into a memory stream and asserts on the message instead of leaking it.
- Two other tests now stub the `devai:install` subprocess instead of spawning a real one — suite is silent and ~4x faster (0.32s → 0.07s).

All 37 skeleton tests pass; `phpcs` and `php-cs-fixer` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)