### PR TITLE
feat: warm caches on install and add MCP handshake timeout

### DIFF
--- a/.claude/plans/mcp-cold-start-warmup/001-mcp-json-timeout.md
+++ b/.claude/plans/mcp-cold-start-warmup/001-mcp-json-timeout.md
@@ -1,0 +1,34 @@
+# Task 001: Add `timeout` to marko-mcp plugin `.mcp.json`
+
+**Status**: completed
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+Add a per-server `"timeout": 60000` (milliseconds) field to the marko-mcp plugin's `.mcp.json`
+so Claude Code gives the cold-boot `mcp:serve` initialize handshake 60s of headroom instead of
+dropping the server when it misses the default session-init probe window on a brand-new project.
+
+## Context
+- Related files:
+  - `packages/claude-plugins/plugins/marko-mcp/.mcp.json` (modify — add `timeout` to the `marko` server)
+  - `packages/claude-plugins/tests/Unit/MarkoMcpPluginTest.php` (modify — add timeout assertion; TDD)
+- Patterns to follow: the existing per-field assertions in `MarkoMcpPluginTest.php`
+  (e.g. the tests asserting `marko.command` and `marko.args`). Keep the server key `marko`
+  (not `marko-mcp`) and the empty `args` array unchanged.
+- Note: `timeout` is a sibling key to `command`/`args` inside `mcpServers.marko`, value in ms.
+
+## Requirements (Test Descriptions)
+- [ ] `it declares a numeric marko.timeout field in .mcp.json`
+- [ ] `it sets marko.timeout to 60000 milliseconds`
+- [ ] `it preserves the marko.command as ${CLAUDE_PLUGIN_ROOT}/bin/marko-mcp`
+- [ ] `it preserves marko.args as an empty array`
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Existing `.mcp.json` shape assertions in `MarkoMcpPluginTest.php` still pass
+- `.mcp.json` remains valid JSON
+- Code follows code standards
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/mcp-cold-start-warmup/002-devai-cache-warmup.md
+++ b/.claude/plans/mcp-cold-start-warmup/002-devai-cache-warmup.md
@@ -1,0 +1,69 @@
+# Task 002: Add framework cache warm-up step to `devai:install`
+
+**Status**: completed
+**Depends on**: none
+**Retry count**: 0
+
+## Description
+Add a `warmFrameworkCaches()` step to `InstallationOrchestrator::install()` that compiles the
+discovery cache and rebuilds the code index during install, so a project that has never booted
+has its caches warm before the first Claude session — making the first `mcp:serve` handshake
+hit the fast (~0.2s) path instead of compiling discovery + lazily building the index inside
+Claude Code's probe window. Follows the existing graceful, non-fatal `buildDocsIndex()` pattern.
+
+## Context
+- Related files:
+  - `packages/devai/src/Installation/InstallationOrchestrator.php` (modify — add private
+    `warmFrameworkCaches(string $projectRoot, string $markoBin): void`, call it in `install()`
+    immediately before `$this->buildDocsIndex(...)`)
+  - `packages/devai/tests/Unit/Installation/InstallationOrchestratorTest.php` (modify — add tests)
+- Patterns to follow:
+  - Mirror `buildDocsIndex()`: call `$this->runner->run($markoBin, [$command])`, branch on
+    `($result['exitCode'] ?? 1) === 0`, append a `[scope] ...` line to `$this->log`, never throw.
+  - IMPORTANT — use the test file's local `makeRecordingRunner()` helper, NOT `devaiRunner()`
+    from `tests/Helpers.php`. The existing `docs-fts:build` tests in
+    `InstallationOrchestratorTest.php` use `makeRecordingRunner()`, whose `calls` are positional
+    tuples `[$command, $args]` (so `$call[0]` is the binary, `$call[1]` is the args array).
+    `devaiRunner()` records ASSOCIATIVE arrays (`['command' => ..., 'args' => ...]`) and is used by
+    a different test file — `$call[1]` would be undefined there. Match the existing file's helper.
+  - Test pattern (success): assert recorded runner calls with
+    `fn ($call) => in_array('discovery:cache', $call[1], true)` (and `indexer:rebuild`), checking
+    `$buildCall[0]` is `$this->tempRoot . '/vendor/bin/marko'` — identical to the existing
+    `runs docs-fts:build during install` test.
+  - Test pattern (failure): inject an inline anonymous `CommandRunnerInterface` returning a
+    non-zero `exitCode` with a `stderr` message, then assert the install log contains a helpful
+    line and the returned `status` is still `installed` — exactly like the existing
+    `records a helpful log line when the docs index build fails` test.
+- Commands to run:
+  - `discovery:cache` — compiles preferences/plugins/observers/commands. Lives in `marko/core`,
+    so it is ALWAYS present in any project that has `vendor/bin/marko`.
+  - `indexer:rebuild` — rebuilds `.marko/index.cache`. Lives in `marko/codeindexer`, which is a
+    SEPARATE package and may be ABSENT in a minimal devai install. Run it unconditionally and rely
+    on the non-fatal exit-code handling: an absent command exits non-zero, which must be logged as
+    a helpful, non-fatal warning (same shape as `buildDocsIndex`'s failure branch) and must not
+    fail the install. Do NOT throw or abort if `indexer:rebuild` is unrecognized.
+- Order: run `discovery:cache` first, then `indexer:rebuild`, then (existing) `buildDocsIndex()`.
+  Each `marko` invocation is a fresh process; compiling the discovery cache first means the later
+  `indexer:rebuild` and `docs-fts:build` boots are already warm.
+
+## Requirements (Test Descriptions)
+- [ ] `it runs discovery:cache during install` (assert via `makeRecordingRunner()` recorded calls, `$call[1]`)
+- [ ] `it runs indexer:rebuild during install`
+- [ ] `it runs discovery:cache before indexer:rebuild` (and both before docs-fts:build)
+- [ ] `it targets the project vendor/bin/marko for warm-up commands` (assert `$call[0]` is `<tempRoot>/vendor/bin/marko`)
+- [ ] `it records a success log line when a warm-up command succeeds`
+- [ ] `it records a helpful log line when a warm-up command fails`
+- [ ] `it still returns installed status when a warm-up command fails`
+- [ ] `it still returns installed status when indexer:rebuild is unavailable` (codeindexer absent: runner returns non-zero exit; install must complete with a non-fatal log line and `status === 'installed'`)
+
+## Acceptance Criteria
+- All requirements have passing tests
+- Warm-up never throws and never changes the returned `status` from `installed`, even when
+  `indexer:rebuild` is unavailable (codeindexer not installed) or any warm-up command exits non-zero
+- Tests use the test file's local `makeRecordingRunner()` (positional-tuple calls), not `devaiRunner()`
+- Existing `InstallationOrchestrator` tests (including `docs-fts:build` and skip cases) still pass
+- No decrease in test coverage
+- Code follows code standards
+
+## Implementation Notes
+(Left blank - filled in by programmer during implementation)

--- a/.claude/plans/mcp-cold-start-warmup/_plan.md
+++ b/.claude/plans/mcp-cold-start-warmup/_plan.md
@@ -1,0 +1,91 @@
+# Plan: MCP Cold-Start Warm-Up
+
+## Created
+2026-06-24
+
+## Status
+completed
+
+## Objective
+Make the `marko-mcp` Claude Code plugin connect cleanly on a brand-new project's first
+session — eliminating the need to manually `/mcp` reconnect — by (1) giving the cold-boot
+MCP handshake timeout headroom and (2) warming the framework's discovery + code-index
+caches during `devai:install` so the first `mcp:serve` handshake hits the warm path.
+
+## Related Issues
+none (root cause references upstream anthropics/claude-code#60224 for context only)
+
+## Discovery Notes
+Root cause (already diagnosed this session): Claude Code starts plugin **stdio** MCP servers
+asynchronously and non-blocking; stdio servers do **not** auto-reconnect; if a server's
+`initialize` handshake misses Claude Code's session-init probe window it is silently dropped
+for that session (anthropics/claude-code#60224). On a brand-new project the first cold boot
+(module discovery + discovery-cache compile + lazy code-index build) is the slow part that
+misses the window. A warm project boots `mcp:serve` in ~0.2s.
+
+Codebase findings:
+- `packages/claude-plugins/plugins/marko-mcp/.mcp.json` — `{ mcpServers: { marko: { command, args:[] } } }`.
+  Claude Code honors an optional per-server `"timeout"` (ms) field here.
+- `packages/claude-plugins/tests/Unit/MarkoMcpPluginTest.php` — already asserts the `.mcp.json`
+  shape field-by-field; add a timeout assertion (TDD).
+- `packages/devai/src/Installation/InstallationOrchestrator.php` — `install()` already ends with
+  a graceful, non-fatal `buildDocsIndex()` that shells out via `CommandRunnerInterface` and appends
+  to `$this->log`. The framework warm-up is a direct sibling method following the same pattern.
+- Core commands available to warm caches: `discovery:cache` (compiles preferences/plugins/
+  observers/commands — `packages/core/src/Commands/DiscoveryCacheCommand.php`) and
+  `indexer:rebuild` (rebuilds `.marko/index.cache` — `packages/codeindexer/src/Commands/RebuildIndexCommand.php`).
+- `packages/devai/tests/Unit/Installation/InstallationOrchestratorTest.php` records every runner
+  call and asserts which commands ran (`in_array('docs-fts:build', $call[1], true)` pattern). NOTE:
+  those tests use the file-local `makeRecordingRunner()` helper whose `calls` are POSITIONAL tuples
+  `[$command, $args]` (`$call[0]` = binary, `$call[1]` = args). Do NOT use `devaiRunner()` from
+  `tests/Helpers.php` — it records ASSOCIATIVE arrays (`['command'=>,'args'=>]`) and is used by a
+  different test file. The warm-up tests reuse `makeRecordingRunner()`.
+
+Resolved assumptions: warm-up runs both commands, non-fatal/logged, placed before `buildDocsIndex()`.
+
+## Scope
+
+### In Scope
+- Add a `"timeout": 60000` field to the marko-mcp plugin `.mcp.json` (+ test assertion).
+- Add a `warmFrameworkCaches()` step to `InstallationOrchestrator::install()` that runs
+  `discovery:cache` and `indexer:rebuild` via the injected `CommandRunnerInterface`, logging
+  success/failure non-fatally, placed before `buildDocsIndex()` (+ tests).
+
+### Out of Scope
+- Changing how Claude Code itself probes/connects MCP servers (upstream behavior).
+- Adding a `timeout` to the per-agent `McpRegistration` written for non-Claude agents (Codex,
+  Cursor, etc.) — different config surfaces; not part of this ask.
+- Any change to `mcp:serve` boot internals or the `bin/marko-mcp` shim.
+- README/docs edits (handled by the doc-updater pipeline post-implementation).
+
+## Success Criteria
+- [ ] Plugin `.mcp.json` declares `marko.timeout = 60000`; existing shape assertions still pass.
+- [ ] `devai:install` runs `discovery:cache` and `indexer:rebuild` and logs the outcome.
+- [ ] Warm-up failures are non-fatal: install still returns `installed` with a helpful log line.
+- [ ] All tests passing.
+- [ ] Code follows project standards.
+
+## Task Overview
+| Task | Description | Depends On | Status |
+|------|-------------|------------|--------|
+| 001 | Add `timeout` to marko-mcp plugin `.mcp.json` | - | completed |
+| 002 | Add framework cache warm-up step to `devai:install` | - | completed |
+
+## Architecture Notes
+- Mirror the existing `buildDocsIndex()` pattern in `InstallationOrchestrator` exactly: resolve
+  `$markoBin`, call `$this->runner->run($markoBin, [$command])`, branch on `exitCode`, append a
+  `[scope] ...` line to `$this->log`. Never throw — a failed warm-up must not fail the install.
+- Each `marko` CLI invocation is a fresh process; running `discovery:cache` first means the
+  later `indexer:rebuild`, `docs-fts:build`, and the eventual `mcp:serve` all boot warm.
+- The `.mcp.json` `timeout` is in milliseconds (Claude Code convention); 60000 = 60s headroom.
+
+## Risks & Mitigations
+- Risk: warm-up commands not present in a minimal install (e.g. `marko/codeindexer` absent, so
+  `indexer:rebuild` is unrecognized) → mitigate by treating a non-zero exit as a logged, non-fatal
+  warning, identical to `buildDocsIndex`. `discovery:cache` ships in `marko/core` and is always
+  present; only `indexer:rebuild` can be missing. Task 002 includes an explicit test for the
+  codeindexer-absent path (install still returns `installed`).
+- Risk: warm-up slows `devai:install` noticeably → acceptable; it is a one-time install cost that
+  trades for a clean first session, and runs after the user-facing install work is done.
+- Risk: `MCP_TIMEOUT`/per-server timeout >60s ignored by some Claude Code versions → 60000 stays
+  within the honored range.

--- a/packages/claude-plugins/plugins/marko-mcp/.mcp.json
+++ b/packages/claude-plugins/plugins/marko-mcp/.mcp.json
@@ -2,7 +2,8 @@
   "mcpServers": {
     "marko": {
       "command": "${CLAUDE_PLUGIN_ROOT}/bin/marko-mcp",
-      "args": []
+      "args": [],
+      "timeout": 60000
     }
   }
 }

--- a/packages/claude-plugins/tests/Unit/MarkoMcpPluginTest.php
+++ b/packages/claude-plugins/tests/Unit/MarkoMcpPluginTest.php
@@ -12,11 +12,11 @@ describe('marko-mcp plugin', function (): void {
         'plugin.json declares name "marko-mcp" and a description matching the marketplace.json entry',
         function (): void {
             $manifest = json_decode(file_get_contents($this->pluginJsonPath), true);
-    
+
             expect(file_exists($this->pluginJsonPath))->toBeTrue()
                 ->and($manifest['name'])->toBe('marko-mcp')
                 ->and($manifest['description'])->toBe('Marko MCP server (codeindexer, docs-fts) for Claude Code.');
-        }
+        },
     );
 
     it('plugin.json includes author with name "Marko Framework"', function (): void {
@@ -38,14 +38,14 @@ describe('marko-mcp plugin', function (): void {
         function (): void {
             $mcpPath = $this->pluginRoot . '/.mcp.json';
             $mcp = json_decode(file_get_contents($mcpPath), true);
-    
+
             expect(file_exists($mcpPath))->toBeTrue()
                 ->and($mcp)->toHaveKey('mcpServers')
                 ->and($mcp['mcpServers'])->toBeArray()
                 ->and($mcp['mcpServers'])->toHaveKey('marko')
                 ->and($mcp['mcpServers'])->not->toHaveKey('marko-mcp')
                 ->and($mcp['mcpServers']['marko'])->toBeArray();
-        }
+        },
     );
 
     it('.mcp.json marko.command is "${CLAUDE_PLUGIN_ROOT}/bin/marko-mcp"', function (): void {
@@ -59,7 +59,33 @@ describe('marko-mcp plugin', function (): void {
 
         expect($mcp['mcpServers']['marko'])->toHaveKey('args')
             ->and($mcp['mcpServers']['marko']['args'])->toBeArray()
-            ->and($mcp['mcpServers']['marko']['args'])->toHaveCount(0);
+            ->and($mcp['mcpServers']['marko']['args'])->toBeEmpty();
+    });
+
+    it('declares a numeric marko.timeout field in .mcp.json', function (): void {
+        $mcp = json_decode(file_get_contents($this->pluginRoot . '/.mcp.json'), true);
+
+        expect($mcp['mcpServers']['marko'])->toHaveKey('timeout')
+            ->and($mcp['mcpServers']['marko']['timeout'])->toBeInt();
+    });
+
+    it('sets marko.timeout to 60000 milliseconds', function (): void {
+        $mcp = json_decode(file_get_contents($this->pluginRoot . '/.mcp.json'), true);
+
+        expect($mcp['mcpServers']['marko']['timeout'])->toBe(60000);
+    });
+
+    it('preserves the marko.command as ${CLAUDE_PLUGIN_ROOT}/bin/marko-mcp', function (): void {
+        $mcp = json_decode(file_get_contents($this->pluginRoot . '/.mcp.json'), true);
+
+        expect($mcp['mcpServers']['marko']['command'])->toBe('${CLAUDE_PLUGIN_ROOT}/bin/marko-mcp');
+    });
+
+    it('preserves marko.args as an empty array', function (): void {
+        $mcp = json_decode(file_get_contents($this->pluginRoot . '/.mcp.json'), true);
+
+        expect($mcp['mcpServers']['marko']['args'])->toBeArray()
+            ->and($mcp['mcpServers']['marko']['args'])->toBeEmpty();
     });
 
     it(
@@ -67,11 +93,11 @@ describe('marko-mcp plugin', function (): void {
         function (): void {
             $shimPath = $this->pluginRoot . '/bin/marko-mcp';
             $contents = file_exists($shimPath) ? file_get_contents($shimPath) : '';
-    
+
             expect(file_exists($shimPath))->toBeTrue()
                 ->and(str_starts_with($contents, '#!/bin/sh'))->toBeTrue()
                 ->and(is_executable($shimPath))->toBeTrue();
-        }
+        },
     );
 
     it('bin/marko-mcp searches for marko binary in order: ./vendor/bin/marko then marko on PATH', function (): void {
@@ -97,11 +123,11 @@ describe('marko-mcp plugin', function (): void {
         'bin/marko-mcp prints a loud error to stderr and exits 1 when no marko binary is found, suggesting "composer require marko/devai"',
         function (): void {
             $contents = file_get_contents($this->pluginRoot . '/bin/marko-mcp');
-    
+
             expect(str_contains($contents, '>&2'))->toBeTrue()
                 ->and(str_contains($contents, 'composer require marko/devai'))->toBeTrue()
                 ->and(str_contains($contents, 'exit 1'))->toBeTrue();
-        }
+        },
     );
 
     it(
@@ -109,7 +135,7 @@ describe('marko-mcp plugin', function (): void {
         function (): void {
             $readmePath = $this->pluginRoot . '/README.md';
             $contents = file_exists($readmePath) ? file_get_contents($readmePath) : '';
-    
+
             expect(file_exists($readmePath))->toBeTrue()
                 // What the plugin registers
             ->and(str_contains($contents, 'mcp:serve') || str_contains($contents, 'MCP server'))->toBeTrue()
@@ -117,6 +143,6 @@ describe('marko-mcp plugin', function (): void {
             ->and(str_contains($contents, '/plugin install marko-mcp@marko'))->toBeTrue()
                 // How to verify
             ->and(str_contains($contents, 'claude mcp list'))->toBeTrue();
-        }
+        },
     );
 });

--- a/packages/devai/src/Installation/InstallationOrchestrator.php
+++ b/packages/devai/src/Installation/InstallationOrchestrator.php
@@ -87,9 +87,40 @@ class InstallationOrchestrator
             $this->updateGitignore($projectRoot);
         }
 
+        $this->warmFrameworkCaches($projectRoot, $markoBin);
         $this->buildDocsIndex($projectRoot, $markoBin);
 
         return ['status' => 'installed', 'log' => $this->log];
+    }
+
+    /**
+     * Compile discovery cache and rebuild the code index so the first
+     * `mcp:serve` handshake hits the fast path instead of lazily compiling.
+     *
+     * Failures are non-fatal: a missing command (e.g. marko/codeindexer is not
+     * installed) exits non-zero, which is logged as a helpful warning and
+     * does not abort the install.
+     */
+    private function warmFrameworkCaches(
+        string $projectRoot,
+        string $markoBin,
+    ): void {
+        $commands = [
+            'discovery:cache' => '[discovery] compiled discovery cache',
+            'indexer:rebuild' => '[indexer] rebuilt code index',
+        ];
+
+        foreach ($commands as $command => $successMessage) {
+            $result = $this->runner->run($markoBin, [$command]);
+
+            if (($result['exitCode'] ?? 1) === 0) {
+                $this->log[] = $successMessage;
+            } else {
+                $stderr = trim((string) ($result['stderr'] ?? ''));
+                $hint = $stderr === '' ? '' : " ($stderr)";
+                $this->log[] = "[cache] $command failed$hint — re-run `marko $command` manually";
+            }
+        }
     }
 
     /**

--- a/packages/devai/tests/Unit/Installation/InstallationOrchestratorTest.php
+++ b/packages/devai/tests/Unit/Installation/InstallationOrchestratorTest.php
@@ -471,6 +471,168 @@ it('records a helpful log line when the docs index build fails for the resolved 
         ->and($log)->toContain('disk full');
 });
 
+it('runs discovery:cache during install', function (): void {
+    $runner = makeRecordingRunner();
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $cacheCall = array_find(
+        $runner->calls,
+        fn ($call) => in_array('discovery:cache', $call[1], true),
+    );
+
+    expect($cacheCall)->not->toBeNull()
+        ->and($cacheCall[0])->toBe($this->tempRoot . '/vendor/bin/marko');
+});
+
+it('still returns installed status when indexer:rebuild is unavailable', function (): void {
+    $runner = new class () implements CommandRunnerInterface
+    {
+        public function run(
+            string $command,
+            array $args = [],
+        ): array {
+            if (in_array('indexer:rebuild', $args, true)) {
+                return ['exitCode' => 1, 'stdout' => '', 'stderr' => 'Unknown command: indexer:rebuild'];
+            }
+
+            return ['exitCode' => 0, 'stdout' => '', 'stderr' => ''];
+        }
+
+        public function isOnPath(string $binary): bool
+        {
+            return false;
+        }
+    };
+
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $result = $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $log = implode("\n", $result['log'] ?? []);
+    expect($result['status'])->toBe('installed')
+        ->and($log)->toContain('indexer:rebuild')
+        ->and($log)->toContain('failed');
+});
+
+it('still returns installed status when a warm-up command fails', function (): void {
+    $runner = new class () implements CommandRunnerInterface
+    {
+        public function run(
+            string $command,
+            array $args = [],
+        ): array {
+            return ['exitCode' => 1, 'stdout' => '', 'stderr' => 'something went wrong'];
+        }
+
+        public function isOnPath(string $binary): bool
+        {
+            return false;
+        }
+    };
+
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $result = $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    expect($result['status'])->toBe('installed');
+});
+
+it('records a helpful log line when a warm-up command fails', function (): void {
+    $runner = new class () implements CommandRunnerInterface
+    {
+        public function run(
+            string $command,
+            array $args = [],
+        ): array {
+            return ['exitCode' => 1, 'stdout' => '', 'stderr' => 'command not found: discovery'];
+        }
+
+        public function isOnPath(string $binary): bool
+        {
+            return false;
+        }
+    };
+
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $result = $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $log = implode("\n", $result['log'] ?? []);
+    expect($log)->toContain('discovery:cache')
+        ->and($log)->toContain('failed')
+        ->and($log)->toContain('command not found: discovery');
+});
+
+it('records a success log line when a warm-up command succeeds', function (): void {
+    $runner = makeRecordingRunner();
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $result = $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $log = implode("\n", $result['log'] ?? []);
+    expect($log)->toContain('[discovery]')
+        ->and($log)->toContain('[indexer]');
+});
+
+it('targets the project vendor/bin/marko for warm-up commands', function (): void {
+    $runner = makeRecordingRunner();
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $warmUpCalls = array_filter(
+        $runner->calls,
+        fn ($call) => in_array($call[1][0] ?? null, ['discovery:cache', 'indexer:rebuild'], true),
+    );
+
+    expect($warmUpCalls)->not->toBeEmpty();
+    foreach ($warmUpCalls as $call) {
+        expect($call[0])->toBe($this->tempRoot . '/vendor/bin/marko');
+    }
+});
+
+it('runs discovery:cache before indexer:rebuild', function (): void {
+    mkdir($this->tempRoot . '/vendor/marko/docs-fts', 0755, true);
+    mkdir($this->tempRoot . '/vendor/marko/docs', 0755, true);
+    file_put_contents(
+        $this->tempRoot . '/vendor/marko/docs/known-drivers.php',
+        '<?php return [\'marko/docs-fts\' => \'FTS driver (recommended; fast full-text search)\'];',
+    );
+
+    $runner = makeRecordingRunner();
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $commandSequence = array_map(fn ($call) => $call[1][0] ?? null, $runner->calls);
+    $discoveryPos = array_search('discovery:cache', $commandSequence, true);
+    $indexerPos = array_search('indexer:rebuild', $commandSequence, true);
+    $docsPos = array_search('docs-fts:build', $commandSequence, true);
+
+    expect($discoveryPos)->not->toBeFalse()
+        ->and($indexerPos)->not->toBeFalse()
+        ->and($docsPos)->not->toBeFalse()
+        ->and($discoveryPos)->toBeLessThan($indexerPos)
+        ->and($indexerPos)->toBeLessThan($docsPos);
+});
+
+it('runs indexer:rebuild during install', function (): void {
+    $runner = makeRecordingRunner();
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry([]), runner: $runner);
+
+    $orchestrator->install(new InstallationContext(selectedAgents: []), $this->tempRoot);
+
+    $rebuildCall = array_find(
+        $runner->calls,
+        fn ($call) => in_array('indexer:rebuild', $call[1], true),
+    );
+
+    expect($rebuildCall)->not->toBeNull()
+        ->and($rebuildCall[0])->toBe($this->tempRoot . '/vendor/bin/marko');
+});
+
 it('does not hardcode the docs-fts package when resolving the driver to build', function (): void {
     mkdir($this->tempRoot . '/vendor/marko/docs-vec', 0755, true);
     mkdir($this->tempRoot . '/vendor/marko/docs', 0755, true);

--- a/packages/docs-markdown/docs/ai-assisted-development/installation.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/installation.md
@@ -34,10 +34,13 @@ The installer does the following in order:
 2. **Writes agent files** — For each detected agent, writes the appropriate configuration files (guidelines, MCP registration, skill files).
 3. **Merges package guidelines** — Reads every installed package's `resources/ai/guidelines.md` and merges the content into the agent guidelines files.
 4. **Distributes skills** — Writes skill bundles from `resources/ai/skills/` to the agent-specific skills directory for agents that support it.
+5. **Warms framework caches** — Runs `marko discovery:cache` then `marko indexer:rebuild` so the MCP server's first session does not incur a cold-compile delay. Failures are non-fatal and logged.
+6. **Builds the docs search index** — If a docs driver (e.g., `marko/docs-fts`) is installed, runs its index-build command so `search_docs` is queryable immediately.
 
-The `IndexCache` used by `marko/mcp` and `marko/lsp` builds automatically on first read if no cache file exists, so an explicit `indexer:rebuild` step is not required. You can run it manually if you want to pre-warm the cache:
+If you need to warm the caches manually at any time:
 
 ```bash
+marko discovery:cache
 marko indexer:rebuild
 ```
 

--- a/packages/docs-markdown/docs/ai-assisted-development/troubleshooting.md
+++ b/packages/docs-markdown/docs/ai-assisted-development/troubleshooting.md
@@ -42,6 +42,19 @@ If running inside a container or mounted volume, ensure the working directory is
 
 ## MCP server problems
 
+### MCP tools not available on the first session after install
+
+On a brand-new project, `mcp:serve` boots the framework for the first time during the agent's session-init handshake. If the discovery cache and code index have not been compiled yet, this cold-boot can exceed the agent's probe timeout and the MCP server appears unavailable.
+
+`devai:install` now pre-warms these caches automatically (runs `marko discovery:cache` and `marko indexer:rebuild`) so the first session starts on the fast path. If you still see missing tools on first launch, run the warm-up manually and restart the agent:
+
+```bash
+marko discovery:cache
+marko indexer:rebuild
+```
+
+Then reload the MCP connection (e.g., `/mcp` in Claude Code) or restart the agent session.
+
 ### Agent reports "MCP server failed to start"
 
 1. Confirm `marko mcp:serve` runs without error:


### PR DESCRIPTION
## Summary

Makes the `marko-mcp` Claude Code plugin connect cleanly on a brand-new project's **first** session, eliminating the need to manually `/mcp` reconnect.

**Root cause:** Claude Code starts plugin **stdio** MCP servers asynchronously and non-blocking; stdio servers do **not** auto-reconnect; if a server's `initialize` handshake misses Claude Code's session-init probe window it is silently dropped for that session. On a brand-new project the first cold boot (module discovery + discovery-cache compile + lazy code-index build) is the slow part that misses the window. A warm project boots `mcp:serve` in ~0.2s.

## What changed

- **MCP handshake timeout** — the marko-mcp plugin `.mcp.json` now sets a per-server `timeout` of `60000` ms so the cold-boot `mcp:serve` handshake isn't dropped by the session-init probe.
- **Install-time cache warm-up** — `InstallationOrchestrator::install()` now runs a non-fatal `warmFrameworkCaches()` step (`discovery:cache` then `indexer:rebuild`) before the docs-index build, so a never-booted project has warm caches before the first Claude session. Failures are logged and never fail the install.
- **Docs** — added cold-start guidance to the AI-assisted-development installation and troubleshooting pages.

## Testing

- New unit tests in `MarkoMcpPluginTest` (timeout field + preserved shape) and `InstallationOrchestratorTest` (warm-up command order, target binary, success/failure logging, non-fatal when `indexer:rebuild`/codeindexer is absent).
- Full fast suite green: **6812 passed, 0 failed**.

## Notes

- The `timeout` field only helps if Claude Code honors a per-server `timeout` in a plugin `.mcp.json`; it is harmless if not, and the install-time warm-up is the robust lever regardless. Real-world confirmation is a manual cold-start test on a fresh project after install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)