### PR TITLE
docs: clarify discovery cache vs code index and when a reindex is needed

### DIFF
--- a/packages/docs-markdown/docs/concepts/modularity.md
+++ b/packages/docs-markdown/docs/concepts/modularity.md
@@ -41,6 +41,8 @@ vendor/     → Composer packages (base defaults)
 
 Discovery is automatic. Drop a module in `app/` or `modules/`, and Marko picks it up on the next request.
 
+No rebuild step is needed for the **application** to see a new module --- discovery runs live on every request. If your AI tooling (the [MCP](/docs/packages/mcp/) or [LSP](/docs/packages/lsp/) server) doesn't yet list the new module, that's the separate [code index](/docs/packages/codeindexer/), not the app: run `marko indexer:rebuild` and reload the tooling connection to refresh it.
+
 ## The `module.php` File
 
 Each module can optionally include a `module.php` at its root. This file declares the module's dependency injection wiring:

--- a/packages/docs-markdown/docs/guides/routing.md
+++ b/packages/docs-markdown/docs/guides/routing.md
@@ -5,6 +5,8 @@ description: Define routes with PHP attributes, middleware, and route groups.
 
 Marko uses PHP attributes to define routes directly on controller methods. No separate route files, no registration boilerplate.
 
+Routes are always discovered live at boot and are never cached --- adding or changing a route takes effect on the next request in every environment, with no rebuild. (This is unlike `#[Plugin]`, `#[Observer]`, `#[Preference]`, and `#[Command]`, which the [discovery cache](/docs/packages/core/#discovery-cache) can compile for production.)
+
 ## Defining Routes
 
 ```php title="app/blog/Controller/PostController.php"

--- a/packages/docs-markdown/docs/packages/codeindexer.md
+++ b/packages/docs-markdown/docs/packages/codeindexer.md
@@ -49,13 +49,17 @@ class MyTool
 
 ### Rebuilding the index
 
-The index rebuilds automatically when stale, but you can force a rebuild from the CLI:
+The index rebuilds automatically when a **fresh** read finds it stale --- `load()` compares every tracked source file's mtime against the cache and falls back to a full `build()` when anything is newer. You can also force a rebuild from the CLI:
 
 ```bash
 marko indexer:rebuild
 ```
 
 This writes the cache to `.marko/index.cache` and reports the number of modules, observers, plugins, commands, routes, config keys, templates, and translations indexed.
+
+:::caution[Long-running servers hold the index in memory]
+The staleness check runs only on the first load into a process. A long-running MCP or LSP server keeps the index in memory for its whole lifetime and won't re-check staleness afterward --- so code that changes *underneath* a running server stays invisible to the tooling until you run `marko indexer:rebuild` and reload the connection. This matters for **external** changes the server didn't make and can't know about: a `git pull`, a branch switch, a dependency install, or edits from another process or editor. It does **not** apply to code the current agent just wrote --- the agent already has that in context, and the running application discovers it live on the next request regardless.
+:::
 
 ## API Reference
 

--- a/packages/docs-markdown/docs/packages/core.md
+++ b/packages/docs-markdown/docs/packages/core.md
@@ -170,6 +170,8 @@ return [
 
 On every boot, Marko scans all module PHP files to discover `#[Preference]`, `#[Plugin]`, `#[Observer]`, and `#[Command]` attributes. In production this scan can be eliminated by compiling its results into a single PHP file --- the discovery cache.
 
+**Routes are deliberately not part of the discovery cache.** `Application::initialize()` always runs route discovery live on every boot, in every environment --- so adding or changing a `#[Get]`, `#[Post]`, or any other route attribute takes effect on the next request with no rebuild, ever. The cache covers only the four attribute types listed above.
+
 #### Compiling the cache
 
 ```bash
@@ -241,6 +243,17 @@ marko discovery:cache
 ```
 
 Serving stale discovery results in missing preferences, plugins, observers, or commands until the cache is recompiled.
+
+#### Not the same as the code index
+
+Marko has **two separate caches** that are easy to confuse --- different files, different commands, different consumers:
+
+| Cache | File | Built by | Consumed by | Rebuild when |
+|---|---|---|---|---|
+| **Discovery cache** | `storage/cache/discovery.php` | `marko discovery:cache` | the **running app** at boot | deploying to a non-`development` environment after plugins, observers, preferences, or commands changed |
+| **Code index** | `.marko/index.cache` | `marko indexer:rebuild` | **MCP / LSP tooling** ([`marko/codeindexer`](/docs/packages/codeindexer/)) | the AI tools show stale or missing symbols |
+
+The discovery cache makes the **app** boot faster in production. The code index lets **AI tooling** answer questions about your code. Rebuilding one has no effect on the other. Neither is required for routes or newly-added modules to work at runtime --- see [the routing note above](#discovery-cache) and the codeindexer page.
 
 ### Throwing Rich Exceptions
 


### PR DESCRIPTION
## Summary

Disambiguates Marko's **two** caches — the runtime *discovery cache* and the tooling *code index* — which were documented on separate pages that never referenced each other, and answers the recurring question "when do I actually need to rebuild?"

Prompted by a real session: an agent created a new module, then reflexively reindexed to "see" it. That's unnecessary — clarified below.

## Changes

- **`packages/core.md`** — added a discovery-cache vs code-index contrast table (file / command / consumer / when-to-rebuild), and a note that **routes are never cached**: route discovery runs live on every boot in every environment, so a new route needs no rebuild.
- **`guides/routing.md`** — mirrors the routes-are-always-live note.
- **`concepts/modularity.md`** — a new module needs no rebuild for the **app** (live discovery); only the tooling index may, and only conditionally.
- **`packages/codeindexer.md`** — reframed the long-running-server caveat to the case it actually applies to: **external** changes the server didn't make (a `git pull`, branch switch, dependency install, or edits from another process/editor), **never** code the current agent just wrote (already in its context).

## Verification

Claims checked against source, not assumed:
- `Application::initialize()` runs `discoverRoutes()` unconditionally, *outside* the `$useCache` fork that gates `#[Preference]`/`#[Plugin]`/`#[Observer]`/`#[Command]` — routes are genuinely never cached.
- `IndexCache::load()` runs the mtime staleness check and rebuilds on a fresh read; `ensureLoaded()`'s in-memory guard is why a long-running server won't re-detect external changes.

Docs-only; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)