### PR TITLE
fix: show devai:install prompt text and stream live progress

### DIFF
--- a/packages/devai/src/Commands/InstallCommand.php
+++ b/packages/devai/src/Commands/InstallCommand.php
@@ -60,7 +60,13 @@ readonly class InstallCommand implements CommandInterface
 
         $this->maybeInstallDocsDriver($input, $output, $projectRoot);
 
-        $result = $this->orchestrator->install($context, $projectRoot);
+        $result = $this->orchestrator->install(
+            $context,
+            $projectRoot,
+            static function (string $message) use ($output): void {
+                $output->writeLine($message);
+            },
+        );
 
         if ($result['status'] === 'skipped') {
             $output->writeLine($result['message'] ?? '');
@@ -115,6 +121,7 @@ readonly class InstallCommand implements CommandInterface
             return;
         }
 
+        $output->writeLine("Installing $pkg via composer (this may take a moment)…");
         $result = $this->commandRunner->run('composer', ['require', '--dev', $pkg]);
 
         if ($result['exitCode'] !== 0) {

--- a/packages/devai/src/Installation/InstallationOrchestrator.php
+++ b/packages/devai/src/Installation/InstallationOrchestrator.php
@@ -35,7 +35,9 @@ class InstallationOrchestrator
     public function install(
         InstallationContext $ctx,
         string $projectRoot,
+        ?callable $onProgress = null,
     ): array {
+        $progress = $onProgress ?? static function (string $message): void {};
         $marker = $projectRoot . '/.marko/devai.json';
         if (is_file($marker) && !$ctx->force) {
             return [
@@ -65,8 +67,9 @@ class InstallationOrchestrator
                 continue;
             }
 
+            $progress('Configuring agent: ' . $agentName . '…');
             $agents[$agentName]->install($installCtx, $projectRoot);
-            $this->log[] = "[$agentName] installed";
+            $this->log[] = "[$agentName] configured";
         }
 
         foreach (GuidelinesWriter::takeNotices() as $notice) {
@@ -87,8 +90,8 @@ class InstallationOrchestrator
             $this->updateGitignore($projectRoot);
         }
 
-        $this->warmFrameworkCaches($projectRoot, $markoBin);
-        $this->buildDocsIndex($projectRoot, $markoBin);
+        $this->warmFrameworkCaches($projectRoot, $markoBin, $progress);
+        $this->buildDocsIndex($projectRoot, $markoBin, $progress);
 
         return ['status' => 'installed', 'log' => $this->log];
     }
@@ -104,6 +107,7 @@ class InstallationOrchestrator
     private function warmFrameworkCaches(
         string $projectRoot,
         string $markoBin,
+        callable $progress,
     ): void {
         $commands = [
             'discovery:cache' => '[discovery] compiled discovery cache',
@@ -111,6 +115,7 @@ class InstallationOrchestrator
         ];
 
         foreach ($commands as $command => $successMessage) {
+            $progress('Running marko ' . $command . '…');
             $result = $this->runner->run($markoBin, [$command]);
 
             if (($result['exitCode'] ?? 1) === 0) {
@@ -136,6 +141,7 @@ class InstallationOrchestrator
     private function buildDocsIndex(
         string $projectRoot,
         string $markoBin,
+        callable $progress,
     ): void {
         $package = $this->docsDriverResolver->installedDriver($projectRoot);
 
@@ -149,6 +155,7 @@ class InstallationOrchestrator
         $command = $this->docsDriverResolver->buildCommand($package);
         $driver = substr($package, (int) strpos($package, '/') + 1);
 
+        $progress("Building docs search index ($driver)…");
         $result = $this->runner->run($markoBin, [$command]);
 
         if (($result['exitCode'] ?? 1) === 0) {

--- a/packages/devai/src/Process/StdinPrompter.php
+++ b/packages/devai/src/Process/StdinPrompter.php
@@ -8,10 +8,12 @@ class StdinPrompter implements ConfirmationPrompterInterface
 {
     /**
      * @param resource $stream
+     * @param resource $output
      */
     public function __construct(
         private $stream = STDIN,
         private readonly bool $noInteraction = false,
+        private $output = STDOUT,
     ) {}
 
     public function isInteractive(): bool
@@ -19,8 +21,13 @@ class StdinPrompter implements ConfirmationPrompterInterface
         return !$this->noInteraction && stream_isatty($this->stream);
     }
 
-    public function confirm(string $question, bool $default): bool
-    {
+    public function confirm(
+        string $question,
+        bool $default,
+    ): bool {
+        $hint = $default ? '[Y/n]' : '[y/N]';
+        fwrite($this->output, "$question $hint ");
+
         $line = fgets($this->stream);
         $answer = strtolower(trim($line !== false ? $line : ''));
 

--- a/packages/devai/tests/Unit/Commands/UpdateCommandTest.php
+++ b/packages/devai/tests/Unit/Commands/UpdateCommandTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Marko\CodeIndexer\Module\ModuleWalker;
+use Marko\CodeIndexer\ValueObject\ModuleInfo;
 use Marko\Core\Attributes\Command;
 use Marko\Core\Command\CommandInterface;
 use Marko\Core\Command\Input;
@@ -19,6 +20,7 @@ use Marko\DevAi\Skills\SkillsDistributor;
 class UpdateCommandTestStubOrchestrator extends InstallationOrchestrator
 {
     public ?InstallationContext $capturedContext = null;
+
     public bool $installCalled = false;
 
     /** @var array{status: string, log?: list<string>} */
@@ -27,6 +29,7 @@ class UpdateCommandTestStubOrchestrator extends InstallationOrchestrator
     public function install(
         InstallationContext $ctx,
         string $projectRoot,
+        ?callable $onProgress = null,
     ): array {
         $this->capturedContext = $ctx;
         $this->installCalled = true;
@@ -50,8 +53,7 @@ class UpdateCommandTestNullRunner implements CommandRunnerInterface
     public function run(
         string $command,
         array $args = [],
-    ): array
-    {
+    ): array {
         return ['exitCode' => 0, 'stdout' => '', 'stderr' => ''];
     }
 
@@ -190,10 +192,10 @@ it('detects and reports newly contributed guidelines from new packages', functio
 
         public function walk(): array
         {
-            return [new \Marko\CodeIndexer\ValueObject\ModuleInfo(
+            return [new ModuleInfo(
                 name: 'marko/authentication',
                 path: $this->authPath,
-                namespace: ''
+                namespace: '',
             )];
         }
     };

--- a/packages/devai/tests/Unit/Installation/InstallationOrchestratorTest.php
+++ b/packages/devai/tests/Unit/Installation/InstallationOrchestratorTest.php
@@ -256,7 +256,35 @@ it('prints a per-agent install summary', function (): void {
     expect($result['status'])->toBe('installed')
         ->and($result['log'])->toBeArray()
         ->and($result['log'])->not->toBeEmpty()
-        ->and(implode("\n", $result['log']))->toContain('[test-agent] installed');
+        ->and(implode("\n", $result['log']))->toContain('[test-agent] configured');
+});
+
+it('streams live progress messages to the supplied callback before each slow step runs', function (): void {
+    $agent = makeInstallSpyAgent(installed: true);
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry(['test-agent' => $agent]));
+
+    $messages = [];
+    $orchestrator->install(
+        new InstallationContext(selectedAgents: ['test-agent']),
+        $this->tempRoot,
+        function (string $message) use (&$messages): void {
+            $messages[] = $message;
+        },
+    );
+
+    $joined = implode("\n", $messages);
+    expect($joined)->toContain('Configuring agent: test-agent')
+        ->and($joined)->toContain('Running marko discovery:cache')
+        ->and($joined)->toContain('Running marko indexer:rebuild');
+});
+
+it('treats the progress callback as optional and installs without one', function (): void {
+    $agent = makeInstallSpyAgent(installed: true);
+    $orchestrator = makeInstallOrchestrator(makeInstallRegistry(['test-agent' => $agent]));
+
+    $result = $orchestrator->install(new InstallationContext(selectedAgents: ['test-agent']), $this->tempRoot);
+
+    expect($result['status'])->toBe('installed');
 });
 
 it('invokes install() once per selected agent', function (): void {

--- a/packages/devai/tests/Unit/Process/ConfirmationPrompterTest.php
+++ b/packages/devai/tests/Unit/Process/ConfirmationPrompterTest.php
@@ -28,8 +28,10 @@ function makeFakePrompter(bool $answer, bool $interactive = true): ConfirmationP
             return $this->interactive;
         }
 
-        public function confirm(string $question, bool $default): bool
-        {
+        public function confirm(
+            string $question,
+            bool $default,
+        ): bool {
             return $this->answer;
         }
     };
@@ -81,6 +83,26 @@ describe('StdinPrompter', function (): void {
         $prompter = new StdinPrompter($stream, noInteraction: true);
 
         expect($prompter->isInteractive())->toBeFalse();
+    });
+
+    it('writes the question and a Y/n hint to output before reading the answer', function (): void {
+        $output = fopen('php://memory', 'r+');
+        $prompter = new StdinPrompter(makeMemoryStream("y\n"), output: $output);
+
+        $prompter->confirm('Install the thing?', default: true);
+
+        rewind($output);
+        expect(stream_get_contents($output))->toBe('Install the thing? [Y/n] ');
+    });
+
+    it('reflects the default in the hint when the default is false', function (): void {
+        $output = fopen('php://memory', 'r+');
+        $prompter = new StdinPrompter(makeMemoryStream("\n"), output: $output);
+
+        $prompter->confirm('Proceed?', default: false);
+
+        rewind($output);
+        expect(stream_get_contents($output))->toBe('Proceed? [y/N] ');
     });
 });
 


### PR DESCRIPTION
## Problem

`marko devai:install` appeared to hang after detecting agents. Two issues:

1. **Invisible prompt** — `StdinPrompter::confirm()` blocked on `fgets()` without ever writing the question to the terminal, so the docs-driver confirmation looked like a hang (it was silently waiting for keyboard input).
2. **No progress feedback** — after answering, the slow steps (composer require, `discovery:cache`, `indexer:rebuild`, docs index build) ran silently until the final summary, again looking hung.

## Changes

- **`StdinPrompter`** — writes the question + a `[Y/n]`/`[y/N]` hint (reflecting the default) to an injectable output stream before reading stdin.
- **`InstallationOrchestrator::install()`** — accepts an optional `?callable $onProgress` and announces each slow step before it runs. Per-agent summary lines now read `configured` instead of `installed`.
- **`InstallCommand`** — prints `Installing … via composer …` before the composer step and wires a live progress callback to the orchestrator.

## Note on string formatting

Progress messages use string **concatenation** rather than `"$var…"` interpolation. The ellipsis glyph's UTF-8 bytes (`0x80-0xFF`) are valid PHP identifier characters, so `"$agentName…"` parses as one undefined variable. `{$var}` braces fix it, but the project's php-cs-fixer `remove_unnecessary_curly_braces` rule strips them — concatenation is the only formatter-safe form.

## Tests

- `ConfirmationPrompterTest` — asserts the question + hint are written, and that the hint reflects the default.
- `InstallationOrchestratorTest` — live-progress streaming, optional callback, `configured` wording.
- `UpdateCommandTest` — stub orchestrator signature updated to match.

All devai tests pass (252 passed, 596 assertions); phpcs + php-cs-fixer clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)