### PR TITLE
fix: prevent devai:install composer hang on invisible prompt

### DIFF
--- a/packages/devai/src/Commands/InstallCommand.php
+++ b/packages/devai/src/Commands/InstallCommand.php
@@ -122,7 +122,10 @@ readonly class InstallCommand implements CommandInterface
         }
 
         $output->writeLine("Installing $pkg via composer (this may take a moment)…");
-        $result = $this->commandRunner->run('composer', ['require', '--dev', $pkg]);
+        $result = $this->commandRunner->run(
+            'composer',
+            ['require', '--dev', '--no-interaction', '--no-progress', $pkg]
+        );
 
         if ($result['exitCode'] !== 0) {
             $stderr = trim($result['stderr']);

--- a/packages/devai/src/Process/CommandRunner.php
+++ b/packages/devai/src/Process/CommandRunner.php
@@ -15,7 +15,15 @@ class CommandRunner implements CommandRunnerInterface
         array $args = [],
     ): array {
         $cmd = escapeshellcmd($command) . ' ' . implode(' ', array_map('escapeshellarg', $args));
-        $proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+        // Detach stdin (read from /dev/null) so a child can never block waiting on
+        // terminal input. Without this the child inherits the parent's TTY and any
+        // unexpected prompt — e.g. composer's allow-plugins trust question — deadlocks
+        // forever, with the prompt hidden because we buffer the child's output.
+        $proc = proc_open(
+            $cmd,
+            [0 => ['file', '/dev/null', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+        );
 
         if (!is_resource($proc)) {
             return ['exitCode' => -1, 'stdout' => '', 'stderr' => 'proc_open failed'];

--- a/packages/devai/tests/Unit/Commands/InstallCommandTest.php
+++ b/packages/devai/tests/Unit/Commands/InstallCommandTest.php
@@ -37,7 +37,10 @@ function makeInstallCmdFakePrompter(bool $answer, bool $interactive = true): Con
             return $this->interactive;
         }
 
-        public function confirm(string $question, bool $default): bool
+        public function confirm(
+            string $question,
+            bool $default,
+        ): bool
         {
             return $this->answer;
         }
@@ -60,7 +63,10 @@ function makeInstallCmdRunner(bool $composerOnPath = true, int $requireExitCode 
             private readonly int $requireExitCode,
         ) {}
 
-        public function run(string $command, array $args = []): array
+        public function run(
+            string $command,
+            array $args = [],
+        ): array
         {
             $this->calls[] = [$command, $args];
 
@@ -209,7 +215,9 @@ it('offers to install the recommended driver and runs composer require on yes', 
     ['stream' => $stream, 'output' => $output] = makeInstallCmdOutput();
     $cmd->execute(new Input(['marko', 'devai:install']), $output);
 
-    expect($runner->calls)->toContain(['composer', ['require', '--dev', 'marko/docs-fts']]);
+    expect($runner->calls)->toContain(
+        ['composer', ['require', '--dev', '--no-interaction', '--no-progress', 'marko/docs-fts']]
+    );
 });
 
 it('does not install anything when the user answers no', function (): void {

--- a/packages/devai/tests/Unit/Process/CommandRunnerTest.php
+++ b/packages/devai/tests/Unit/Process/CommandRunnerTest.php
@@ -33,6 +33,19 @@ describe('CommandRunner', function (): void {
             ->and(strlen($result['stderr']))->toBeGreaterThan(65536);
     })->group('integration');
 
+    it('does not block when the child reads stdin (stdin detached to /dev/null)', function (): void {
+        $runner = new CommandRunner();
+        // A child that reads stdin would deadlock forever if it inherited the parent's
+        // TTY. With stdin detached to /dev/null it gets immediate EOF and returns.
+        $started = microtime(true);
+        $result = $runner->run('sh', ['-c', 'read line; echo "done"']);
+        $elapsed = microtime(true) - $started;
+
+        expect($elapsed)->toBeLessThan(10.0)
+            ->and($result['stdout'])->toContain('done')
+            ->and($result['exitCode'])->toBe(0);
+    });
+
     it('returns the proc_open failure shape when the process cannot start', function (): void {
         $runner = new CommandRunner();
         // Pass a command that proc_open will fail on by using a completely invalid path


### PR DESCRIPTION
## Problem

`marko devai:install` could hang indefinitely at:

```
Installing marko/docs-fts via composer (this may take a moment)…
```

The docs-driver step shells out to `composer require --dev` via `CommandRunner`, which opened only stdout/stderr pipes and left the child **inheriting the parent's TTY stdin**. Composer thus detected an interactive terminal and could block on a prompt (most commonly the `allow-plugins` trust question). Because `CommandRunner` buffers all child output and never echoes it, that prompt was **invisible** — composer sat waiting for a keystroke the user couldn't see, an infinite hang.

It reproduced reliably with a cold cache + missing driver:

```bash
composer remove marko/docs-fts --no-interaction
rm -rf vendor/marko/docs-fts
composer clearcache
marko devai:install   # answer y → hangs
```

## Fix

- **`CommandRunner`** — detach the child's stdin to `/dev/null` (`0 => ['file', '/dev/null', 'r']`) so no shelled-out command can ever block on terminal input. Structural guard for every caller.
- **`InstallCommand`** — pass `--no-interaction --no-progress` to the composer require call so composer is contractually forbidden from prompting.

## Tests

- New `CommandRunnerTest` case: a child running `read line; echo done` now returns in <10s instead of deadlocking — the deterministic guarantee that stdin can't block.
- Updated `InstallCommandTest` assertion to expect the new composer args.

Full `packages/devai` suite green (253 passed); lint clean on all touched files.

## Out of scope

The buffered-silence UX (no live progress during a slow resolve) is unchanged — this PR stops the *hang*, not the quiet. A follow-up could stream runner output live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)