### PR TITLE
fix: support union-typed entity columns via explicit Column type

### DIFF
--- a/packages/database/src/Entity/EntityMetadataFactory.php
+++ b/packages/database/src/Entity/EntityMetadataFactory.php
@@ -18,6 +18,7 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionNamedType;
 use ReflectionProperty;
+use ReflectionUnionType;
 
 /**
  * Parses entity classes and extracts metadata from attributes.
@@ -95,13 +96,24 @@ class EntityMetadataFactory
             $columnName = $columnAttr->name ?? $this->camelToSnakeCase($propertyName);
             $type = $property->getType();
 
-            if (!$type instanceof ReflectionNamedType) {
+            if ($type instanceof ReflectionNamedType) {
+                $phpType = $type->getName();
+                $dbType = $columnAttr->type ?? $this->inferDatabaseType($phpType);
+                $nullable = $type->allowsNull();
+            } elseif ($type instanceof ReflectionUnionType) {
+                // A union type (e.g. a polymorphic foreign key declared as `int|string`)
+                // has no single reflection type to infer a database column type from, so
+                // an explicit #[Column(type: ...)] is required to resolve the ambiguity.
+                if ($columnAttr->type === null) {
+                    throw EntityException::unionTypeRequiresColumnType($entityClass, $propertyName);
+                }
+
+                $phpType = (string) $type;
+                $dbType = $columnAttr->type;
+                $nullable = $type->allowsNull();
+            } else {
                 throw EntityException::missingTypeDeclaration($entityClass, $propertyName);
             }
-
-            $phpType = $type->getName();
-            $dbType = $columnAttr->type ?? $this->inferDatabaseType($phpType);
-            $nullable = $type->allowsNull();
             $default = $property->hasDefaultValue() ? $property->getDefaultValue() : null;
 
             // Convert BackedEnum default values to their backing value for database storage

--- a/packages/database/src/Exceptions/EntityException.php
+++ b/packages/database/src/Exceptions/EntityException.php
@@ -81,6 +81,21 @@ class EntityException extends MarkoException
     /**
      * @param class-string $entityClass
      */
+    public static function unionTypeRequiresColumnType(
+        string $entityClass,
+        string $property,
+    ): self {
+        return new self(
+            message: "Property '$property' in entity '$entityClass' has a union type "
+                . 'and must declare an explicit column type',
+            context: "Parsing column '$property' in entity '$entityClass'",
+            suggestion: "Add an explicit type to the #[Column] attribute (e.g., #[Column(type: 'varchar')])",
+        );
+    }
+
+    /**
+     * @param class-string $entityClass
+     */
     public static function columnAndRelationshipConflict(
         string $entityClass,
         string $property,

--- a/packages/database/tests/Entity/EntityMetadataFactoryTest.php
+++ b/packages/database/tests/Entity/EntityMetadataFactoryTest.php
@@ -311,6 +311,38 @@ it('throws EntityException for property without type declaration', function (): 
     $this->factory->parse($className);
 })->throws(EntityException::class, 'must have a type declaration');
 
+it('parses a union-typed property when an explicit column type is declared', function (): void {
+    $entity = new #[Table('attachments')] class () extends Entity
+    {
+        #[Column(primaryKey: true, autoIncrement: true)]
+        public ?int $id = null;
+
+        #[Column(type: 'varchar', length: 255)]
+        public int|string $attachableId = 0;
+    };
+
+    $metadata = $this->factory->parse($entity::class);
+
+    expect($metadata->properties['attachableId']->type)->toContain('int')
+        ->and($metadata->properties['attachableId']->type)->toContain('string')
+        ->and($metadata->properties['attachableId']->columnType)->toBe('varchar')
+        ->and($metadata->columns[1]->type)->toBe('varchar')
+        ->and($metadata->columns[1]->nullable)->toBeFalse();
+});
+
+it('throws EntityException for a union-typed property without an explicit column type', function (): void {
+    $entity = new #[Table('attachments')] class () extends Entity
+    {
+        #[Column(primaryKey: true, autoIncrement: true)]
+        public ?int $id = null;
+
+        #[Column(length: 255)]
+        public int|string $attachableId = 0;
+    };
+
+    $this->factory->parse($entity::class);
+})->throws(EntityException::class, 'must declare an explicit column type');
+
 it('handles leading uppercase sequences correctly (HTMLParser becomes html_parser)', function (): void {
     $entity = new #[Table('records')] class () extends Entity
     {

--- a/packages/docs-markdown/docs/packages/database.md
+++ b/packages/docs-markdown/docs/packages/database.md
@@ -92,7 +92,21 @@ Marko infers database types from PHP types:
 | `DateTimeImmutable` | TIMESTAMP |
 | `BackedEnum` | ENUM with cases as values |
 | `array` or `?array` with `type: 'json'` | JSON (MySQL) / JSONB (PostgreSQL) |
+| Union type (e.g. `int\|string`) | No inference — requires an explicit `type:` |
 | Default values | From property initializers |
+
+### Union-Typed Columns
+
+A union type has no single PHP type to infer a column type from, so it must declare one explicitly. This is how polymorphic foreign keys are modeled — an attachment can point at entities whose primary keys are `int` or `string`:
+
+```php
+#[Column(type: 'varchar', length: 255)]
+public int|string $attachableId = 0;
+```
+
+Without an explicit `type:`, metadata parsing throws `EntityException` — Marko will not guess which side of the union wins.
+
+> A varchar-backed union always hydrates to a PHP `string`, even when the value was written as an `int`. Compare loosely or cast explicitly rather than strict-comparing against an integer primary key.
 
 ### String and UUID Primary Keys
 

--- a/packages/media/src/Entity/MediaAttachment.php
+++ b/packages/media/src/Entity/MediaAttachment.php
@@ -20,6 +20,6 @@ class MediaAttachment extends Entity
     #[Column(length: 255)]
     public string $attachableType = '';
 
-    #[Column(length: 255)]
+    #[Column(type: 'varchar', length: 255)]
     public int|string $attachableId = 0;
 }

--- a/packages/media/tests/Entity/MediaAttachmentTest.php
+++ b/packages/media/tests/Entity/MediaAttachmentTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marko\Media\Tests\Entity;
+
+use Marko\Database\Entity\EntityMetadataFactory;
+use Marko\Media\Entity\MediaAttachment;
+
+it('builds full entity metadata for MediaAttachment without throwing', function (): void {
+    $metadata = (new EntityMetadataFactory())->parse(MediaAttachment::class);
+
+    expect($metadata->tableName)->toBe('media_attachments');
+});
+
+it('maps the polymorphic attachableId union type to a varchar column', function (): void {
+    $metadata = (new EntityMetadataFactory())->parse(MediaAttachment::class);
+
+    expect($metadata->properties['attachableId']->type)->toContain('int')
+        ->and($metadata->properties['attachableId']->type)->toContain('string')
+        ->and($metadata->properties['attachableId']->columnType)->toBe('varchar');
+});


### PR DESCRIPTION
## Summary

`EntityMetadataFactory` threw `Property '...' must have a type declaration` for any entity property with a PHP union type (`ReflectionUnionType`), with no escape hatch. This broke `db:migrate`/`db:diff` outright for any project with `marko/media` installed, since `Marko\Media\Entity\MediaAttachment::$attachableId` is declared `int|string` (a polymorphic foreign key — an attachment can belong to entity types whose primary keys are int or string).

## Fix

`EntityMetadataFactory` now accepts a `ReflectionUnionType` property when it carries an explicit `#[Column(type: ...)]` attribute (already a supported mechanism for named-type columns, just not consulted before the union-type guard threw). `MediaAttachment::$attachableId` is now declared `#[Column(type: 'varchar', length: 255)]`, preserving its `int|string` PHP type while giving the factory an unambiguous DB column type. Union properties *without* an explicit `#[Column(type:...)]` still throw, now with a clearer `EntityException::unionTypeRequiresColumnType()` message instead of the previous misleading "must have a type declaration".

The `ReflectionNamedType` code path is unchanged — this is a strictly additive branch.

## Notes for reviewers

- Hydrated `attachableId` always comes back as a PHP string regardless of the original id's type (varchar columns hydrate to string, and `int|string` accepts that with no TypeError) — code comparing it against a real int PK should use loose comparison or cast explicitly. No existing usage in `packages/media` does a strict comparison.
- This escape hatch only casts safely end-to-end for unions that include `string` in their type list (a varchar column round-trips fine). A hypothetical future union like `int|bool` would still need casting support at hydration time — out of scope here since no such entity currently exists.
- `packages/media` ships no migration files — schema is derived entirely from entity metadata via `SchemaRegistry`, so this fix directly unblocks `db:diff`/`db:migrate` for any consumer.

## Test plan

- [x] `./vendor/bin/pest packages/database/tests` — 883 passed
- [x] `./vendor/bin/pest packages/media/tests` — 38 passed
- [x] Two new regression tests confirmed to fail on `develop` (pre-fix) with the original misleading error, and pass on this branch
- [x] `./vendor/bin/phpcs --standard=phpcs.xml` clean on all changed files
- [x] `./vendor/bin/phpstan` — zero new errors vs `develop` baseline

### Additional changes (maintainer)

- Documented the new rule in `packages/docs-markdown/docs/packages/database.md`: a union-type row in the **Type Inference Rules** table, a **Union-Typed Columns** section using the polymorphic-foreign-key case, and a note that a varchar-backed union always hydrates to `string` (so app code should not strict-compare it against an integer primary key).